### PR TITLE
The first example application: a customised version of the `TestEm3` simplified sampling calorimeter test application. 

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -23,9 +23,9 @@ class G4HepEmGammaManager {
   
 public:
   // step length
-  void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {}
+  void   HowFar(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/) {}
   // interactions
-  void   Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {}
+  void   Perform(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/) {}
 };
 
 #endif // G4HepEmGammaManager_HH

--- a/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/src/G4HepEmProcess.cc
@@ -16,6 +16,7 @@
 #include "G4Threading.hh"
 #include "G4Track.hh"
 #include "G4Step.hh"
+#include "G4StepPoint.hh"
 #include "G4StepStatus.hh"
 #include "G4MaterialCutsCouple.hh"
 #include "G4ParticleChangeForLoss.hh"
@@ -44,14 +45,6 @@ void G4HepEmProcess::BuildPhysicsTable(const G4ParticleDefinition& partDef) {
   G4cout << " G4HepEmProcess::BuildPhysicsTable for Particle = " << partDef.GetParticleName() << G4endl;    
   StreamInfo(G4cout, partDef);
 
-  // Extracts EM and other configuration parameters, builds all the elememnt, 
-  // matrial and material-production-cuts related data structures shared by all 
-  // workers and all processes (read-only) at run time.
-  // Action is done only for the master runmanager and only if it was not done 
-  // yet: in case of re-init, first the G4HepEmRunManager::Clear() method needs 
-  // to be invoked.
-//  fTheG4HepEmRunManager->InitializeGlobal();  
-  
   // The ptr-s to global data structures created and filled in InitializeGlobal() 
   // will be copied to the workers and the TL-data structure will be created.
   //fTheG4HepEmRunManager->Initialize(G4Random::getTheEngine());
@@ -100,13 +93,15 @@ G4double G4HepEmProcess::AlongStepGetPhysicalInteractionLength (
                                         ? theTLData->GetPrimaryGammaTrack()->GetTrack()
                                         : theTLData->GetPrimaryElectronTrack()->GetTrack();
   thePrimaryTrack->SetCharge(partDef->GetPDGCharge());
-  thePrimaryTrack->SetEKin(track.GetDynamicParticle()->GetKineticEnergy());
-  thePrimaryTrack->SetLEKin(track.GetDynamicParticle()->GetLogKineticEnergy());
+  const G4DynamicParticle* theG4DPart = track.GetDynamicParticle();
+  thePrimaryTrack->SetEKin(theG4DPart->GetKineticEnergy());
+  thePrimaryTrack->SetLEKin(theG4DPart->GetLogKineticEnergy());
   const int    g4IMC = track.GetMaterialCutsCouple()->GetIndex();
   const int hepEmIMC = fTheG4HepEmRunManager->GetHepEmData()->fTheMatCutData->fG4MCIndexToHepEmMCIndex[g4IMC];
   thePrimaryTrack->SetMCIndex(hepEmIMC);
-  thePrimaryTrack->SetOnBoundary(track.GetStep()->GetPreStepPoint()->GetStepStatus()==G4StepStatus::fGeomBoundary);
-
+  const G4StepPoint* theG4PreStepPoint = track.GetStep()->GetPreStepPoint();
+  thePrimaryTrack->SetOnBoundary(theG4PreStepPoint->GetStepStatus()==G4StepStatus::fGeomBoundary);
+  //
   if (isGamma) {
     fTheG4HepEmRunManager->GetTheGammaManager()->HowFar(fTheG4HepEmRunManager->GetHepEmData(), fTheG4HepEmRunManager->GetHepEmParameters(), theTLData);
   } else {
@@ -135,7 +130,9 @@ G4VParticleChange* G4HepEmProcess::AlongStepDoIt( const G4Track& track, const G4
   const G4ThreeVector& primDir = track.GetDynamicParticle()->GetMomentumDirection();
   thePrimaryTrack->SetDirection(primDir[0], primDir[1], primDir[2]);
   thePrimaryTrack->SetGStepLength(track.GetStepLength());
-  thePrimaryTrack->SetOnBoundary(track.GetStep()->GetPostStepPoint()->GetStepStatus()==G4StepStatus::fGeomBoundary);
+  const G4StepPoint* theG4PostStepPoint = track.GetStep()->GetPostStepPoint();
+  thePrimaryTrack->SetOnBoundary(theG4PostStepPoint->GetStepStatus()==G4StepStatus::fGeomBoundary);
+  // invoke the physics interactions (all i.e. all along- and post-step as well as possible at rest)
   if (isGamma) {
     fTheG4HepEmRunManager->GetTheGammaManager()->Perform(fTheG4HepEmRunManager->GetHepEmData(), fTheG4HepEmRunManager->GetHepEmParameters(), theTLData);
   } else {
@@ -158,34 +155,33 @@ G4VParticleChange* G4HepEmProcess::AlongStepDoIt( const G4Track& track, const G4
   const int numSecondaries = numSecElectron+numSecGamma;
   if (numSecondaries>0) {
     fParticleChangeForLoss->SetNumberOfSecondaries(numSecondaries);    
-    double time = track.GetGlobalTime();
+    const G4ThreeVector& theG4PostStepPointPosition = theG4PostStepPoint->GetPosition();
+    const G4double          theG4PostStepGlobalTime = theG4PostStepPoint->GetGlobalTime();
+    const G4TouchableHandle&   theG4TouchableHandle = track.GetTouchableHandle();
     for (int is=0; is<numSecElectron; ++is) {
       G4HepEmTrack* secTrack = theTLData->GetSecondaryElectronTrack(is)->GetTrack();
-      const double* dir = secTrack->GetDirection();
+      const double*      dir = secTrack->GetDirection();
       // MUST BE CHANGED WHEN e+ is added 
-      G4DynamicParticle* dp = secTrack->GetCharge() < 0.0 
-                              ? new G4DynamicParticle(G4Electron::Definition(), G4ThreeVector(dir[0], dir[1], dir[2]), secTrack->GetEKin())
-                              : new G4DynamicParticle(G4Positron::Definition(), G4ThreeVector(dir[0], dir[1], dir[2]), secTrack->GetEKin());
-      G4Track* t = new G4Track(dp, time, track.GetPosition());
-      t->SetTouchableHandle(track.GetTouchableHandle());
-      fParticleChangeForLoss->AddSecondary(t);
+      G4DynamicParticle*  dp = secTrack->GetCharge() < 0.0 
+                               ? new G4DynamicParticle( G4Electron::Definition(), G4ThreeVector( dir[0], dir[1], dir[2] ), secTrack->GetEKin() )
+                               : new G4DynamicParticle( G4Positron::Definition(), G4ThreeVector( dir[0], dir[1], dir[2] ), secTrack->GetEKin() );
+      G4Track*     aG4Track  = new G4Track( dp, theG4PostStepGlobalTime, theG4PostStepPointPosition );
+      aG4Track->SetTouchableHandle( theG4TouchableHandle );
+      fParticleChangeForLoss->AddSecondary( aG4Track );
     }
     theTLData->ResetNumSecondaryElectronTrack();
 
     for (int is=0; is<numSecGamma; ++is) {
       G4HepEmTrack* secTrack = theTLData->GetSecondaryGammaTrack(is)->GetTrack();
-      const double* dir = secTrack->GetDirection();
-      G4DynamicParticle* dp = new G4DynamicParticle(G4Gamma::Definition(), G4ThreeVector(dir[0], dir[1], dir[2]), secTrack->GetEKin());
-      G4Track* t = new G4Track(dp, time, track.GetPosition());
-      t->SetTouchableHandle(track.GetTouchableHandle());
-      fParticleChangeForLoss->AddSecondary(t);
+      const double*      dir = secTrack->GetDirection();
+      G4DynamicParticle*  dp = new G4DynamicParticle( G4Gamma::Definition(), G4ThreeVector( dir[0], dir[1], dir[2] ), secTrack->GetEKin() );
+      G4Track*     aG4Track  = new G4Track(  dp, theG4PostStepGlobalTime, theG4PostStepPointPosition );
+      aG4Track->SetTouchableHandle( theG4TouchableHandle );
+      fParticleChangeForLoss->AddSecondary( aG4Track );
     }
-
     theTLData->ResetNumSecondaryGammaTrack();
- } 
-  
-  
-    
+  } 
+       
   return fParticleChangeForLoss;
 } 
 

--- a/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/src/G4HepEmProcess.cc
@@ -81,9 +81,9 @@ void     G4HepEmProcess::StartTracking(G4Track* track) {
 
 G4double G4HepEmProcess::AlongStepGetPhysicalInteractionLength ( 
                                                const G4Track& track,
-                                               G4double  previousStepSize,
-                                               G4double  currentMinimumStep,
-                                               G4double& proposedSafety,
+                                               G4double  /*previousStepSize*/,
+                                               G4double  /*currentMinimumStep*/,
+                                               G4double& /*proposedSafety*/,
                                                G4GPILSelection* selection) {
   *selection = CandidateForSelection;   
   G4HepEmTLData*            theTLData = fTheG4HepEmRunManager->GetTheTLData();  
@@ -130,7 +130,7 @@ G4VParticleChange* G4HepEmProcess::AlongStepDoIt( const G4Track& track, const G4
   const G4ThreeVector& primDir = track.GetDynamicParticle()->GetMomentumDirection();
   thePrimaryTrack->SetDirection(primDir[0], primDir[1], primDir[2]);
   thePrimaryTrack->SetGStepLength(track.GetStepLength());
-  const G4StepPoint* theG4PostStepPoint = track.GetStep()->GetPostStepPoint();
+  const G4StepPoint* theG4PostStepPoint = step.GetPostStepPoint();
   thePrimaryTrack->SetOnBoundary(theG4PostStepPoint->GetStepStatus()==G4StepStatus::fGeomBoundary);
   // invoke the physics interactions (all i.e. all along- and post-step as well as possible at rest)
   if (isGamma) {

--- a/apps/examples/TestEm3/ATLASbar.mac
+++ b/apps/examples/TestEm3/ATLASbar.mac
@@ -1,0 +1,42 @@
+## =============================================================================
+## Geant4 macro for modelling simplified sampling calorimeters
+## =============================================================================
+##
+/control/verbose 0
+/run/numberOfThreads 4
+/run/verbose 0
+##
+## -----------------------------------------------------------------------------
+## Setup the ATLASbar simplified sampling calorimeter: 
+##   = 50 Layers of:
+##     - Absorber 1 (gap) : 2.3 mm Lead 
+##     - Absorber 2 (abs.): 5.7 mm liquid-Argon
+## -----------------------------------------------------------------------------
+/testem/det/setSizeYZ 40 cm
+/testem/det/setNbOfLayers 50
+/testem/det/setNbOfAbsor 2
+/testem/det/setAbsor 1 G4_Pb 2.3 mm
+/testem/det/setAbsor 2 G4_lAr 5.7 mm
+##
+## -----------------------------------------------------------------------------
+## Set the physics list (more exactly, the EM physics constructor): 
+##  = 'HepEm'           : the G4HepEm EM physics c.t.r.
+##  =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
+##  = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
+## -----------------------------------------------------------------------------
+/testem/phys/addPhysics   HepEm
+##/testem/phys/addPhysics   G4Em
+##
+## -----------------------------------------------------------------------------
+## Set secondary production threshold, init. the run and set primary properties  
+## -----------------------------------------------------------------------------
+/run/setCut 0.7 mm
+/run/initialize
+/gun/particle e-
+/gun/energy 9999 MeV
+##
+## -----------------------------------------------------------------------------
+## Run the simulation with the given number of events and print list of processes
+## -----------------------------------------------------------------------------
+/run/beamOn 1000
+/process/list

--- a/apps/examples/TestEm3/CMakeLists.txt
+++ b/apps/examples/TestEm3/CMakeLists.txt
@@ -1,0 +1,44 @@
+#----------------------------------------------------------------------------
+# Setup the project
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
+project(TestEm3)
+
+#----------------------------------------------------------------------------
+# Find Geant4 package
+#
+find_package(Geant4 REQUIRED)
+
+
+#----------------------------------------------------------------------------
+# Find G4HepEm
+#
+find_package(G4HepEm REQUIRED)
+message (STATUS "====> ${G4HepEm_LIBRARIES}")
+
+
+#----------------------------------------------------------------------------
+# Setup Geant4 include directories and compile definitions
+#
+include(${Geant4_USE_FILE})
+
+#----------------------------------------------------------------------------
+# Locate sources and headers for this project
+#
+include_directories(${PROJECT_SOURCE_DIR}/include
+                    ${Geant4_INCLUDE_DIR}
+                    ${G4HepEm_INCLUDE_DIR}
+                    )
+file(GLOB sources ${PROJECT_SOURCE_DIR}/src/*.cc)
+file(GLOB headers ${PROJECT_SOURCE_DIR}/inc/*.hh)
+
+#----------------------------------------------------------------------------
+# Add the executable, and link it to the Geant4 libraries
+#
+add_executable(TestEm3 ${CMAKE_SOURCE_DIR}/TestEm3.cc ${sources} ${headers})
+target_link_libraries(TestEm3 ${Geant4_LIBRARIES} ${G4HepEm_LIBRARIES})
+
+#----------------------------------------------------------------------------
+# Install the executable to 'bin' directory under CMAKE_INSTALL_PREFIX
+#
+install(TARGETS TestEm3 DESTINATION bin)
+install(FILES ATLASbar.mac DESTINATION bin)

--- a/apps/examples/TestEm3/TestEm3.cc
+++ b/apps/examples/TestEm3/TestEm3.cc
@@ -1,0 +1,161 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/TestEm3.cc
+/// \brief Main program of the electromagnetic/TestEm3 example
+//
+// $Id: TestEm3.cc 92914 2015-09-21 15:00:48Z gcosmo $
+//
+
+
+//   M.Novak:
+//   ---------------------------------------------------------------------------
+// 
+//   This is an extended version of the TestEm3 standard Geant4 test used for 
+//   simplified calorimeter tests.
+//   The orginal Geant4 TestEm3 application was taken from:
+//   == Geant4 version Geant4.10.02.ref08
+//   == examples/extended/electromagnetic/TestEm3
+//
+
+#include "G4Types.hh"
+
+#ifdef G4MULTITHREADED
+#include "G4MTRunManager.hh"
+#else
+#include "G4RunManager.hh"
+#endif
+
+#include "G4UImanager.hh"
+#include "Randomize.hh"
+
+#include "DetectorConstruction.hh"
+#include "PhysicsList.hh"
+#include "ActionInitialization.hh"
+#include "SteppingVerbose.hh"
+
+
+#include <getopt.h>
+#include <err.h>
+#include <iostream>
+#include <iomanip>
+
+
+
+
+static bool isPerformance = false;
+static std::string  macrofile="";
+
+static struct option options[] = {
+   {"flag to run the application in performance mode (default FALSE)", no_argument, 0, 'p'},
+   {"standard Geant4 macro file", required_argument, 0, 'm'},
+   {0, 0, 0, 0}
+ };
+
+void help();
+
+
+// ============================================================================
+int main(int argc,char** argv) {
+ //
+ // process arguments
+  if (argc == 1) {
+    help();
+    exit(0);
+  }
+  while (true) {
+    int c, optidx = 0;
+    c = getopt_long(argc, argv, "pm:", options, &optidx);
+    if (c == -1)
+      break;
+    //
+    switch (c) {
+    case 0:
+      c = options[optidx].val;
+    /* fall through */
+    case 'p':
+      isPerformance = true;
+      break;
+    case 'm':
+      macrofile = optarg;
+      break;
+    default:
+      help();
+      errx(1, "unknown option %c", c);
+    }
+  }
+  //
+  // set the RNG seed and custom stepping verbose
+  G4Random::setTheSeed(12345678);
+  G4VSteppingVerbose::SetInstance(new SteppingVerbose);
+
+  // Construct the default run manager
+#ifdef G4MULTITHREADED
+  G4MTRunManager* runManager = new G4MTRunManager;
+  // Number of threads can be defined via from macro
+  G4int nThreads = 4;
+  runManager->SetNumberOfThreads(nThreads);
+#else
+  G4RunManager* runManager = new G4RunManager;
+#endif
+
+  // set mandatory initialization classes
+  DetectorConstruction* detector = new DetectorConstruction();
+  runManager->SetUserInitialization(detector);
+  runManager->SetUserInitialization(new PhysicsList);
+
+  // set user action classes
+  runManager->SetUserInitialization(new ActionInitialization(detector,isPerformance));
+
+  // get the pointer to the User Interface manager
+  G4UImanager* UI = G4UImanager::GetUIpointer();
+
+  G4String command = "/control/execute ";
+  G4String fileName = macrofile;
+  UI->ApplyCommand(command+fileName);
+
+  delete runManager;
+  return 0;
+}
+
+
+// =============================================================================
+void help() {
+  std::cout<<"\n "<<std::setw(100)<<std::setfill('=')<<""<<std::setfill(' ')<<std::endl;
+  std::cout<<"  Extended version of the standard Geant4 TestEm3 simplified calorimeter test.    \n"
+           << std::endl
+           <<"  **** Parameters: \n"
+           <<"      -p :   flag  ==> run the application in performance mode i.e. no scoring \n"
+           <<"         :   -     ==> run the application in NON performance mode i.e. with scoring (default) \n"
+           <<"      -m :   REQUIRED : the standard Geamt4 macro file\n"
+           << std::endl;
+
+  std::cout<<"\nUsage: TestEm3 [OPTIONS] INPUT_FILE\n\n"<<std::endl;
+
+  for (int i = 0; options[i].name != NULL; i++) {
+    printf("\t-%c  --%s\t%s\n", options[i].val, options[i].name, options[i].has_arg ? options[i].name : "");
+  }
+  std::cout<<"\n "<<std::setw(100)<<std::setfill('=')<<""<<std::setfill(' ')<<std::endl;
+}

--- a/apps/examples/TestEm3/include/ActionInitialization.hh
+++ b/apps/examples/TestEm3/include/ActionInitialization.hh
@@ -1,0 +1,61 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// $Id: ActionInitialization.hh 76346 2013-11-08 15:48:19Z maire $
+//
+/// \file ActionInitialization.hh
+/// \brief Definition of the ActionInitialization class
+
+#ifndef ActionInitialization_h
+#define ActionInitialization_h 1
+
+#include "G4VUserActionInitialization.hh"
+
+class DetectorConstruction;
+class G4VSteppingVerbose;
+
+/// Action initialization class.
+///
+
+class ActionInitialization : public G4VUserActionInitialization
+{
+  public:
+    ActionInitialization(DetectorConstruction*, bool isperformance=false);
+    virtual ~ActionInitialization();
+
+    virtual void BuildForMaster() const;
+    virtual void Build() const;
+
+    virtual G4VSteppingVerbose* InitializeSteppingVerbose() const;
+
+    void SetPerformanceModeFlag(bool val) { fIsPerformance = val; }
+
+  private:
+    DetectorConstruction *fDetector;
+    bool                  fIsPerformance;
+
+};
+
+#endif

--- a/apps/examples/TestEm3/include/DetectorConstruction.hh
+++ b/apps/examples/TestEm3/include/DetectorConstruction.hh
@@ -1,0 +1,143 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/DetectorConstruction.hh
+/// \brief Definition of the DetectorConstruction class
+//
+// $Id: DetectorConstruction.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef DetectorConstruction_h
+#define DetectorConstruction_h 1
+
+#include "G4VUserDetectorConstruction.hh"
+#include "G4ThreeVector.hh"
+#include "globals.hh"
+#include "G4Cache.hh"
+
+class G4Box;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class G4Material;
+class DetectorMessenger;
+
+class G4UniformMagField;
+class G4FieldManager;
+class PrimaryGeneratorAction;
+
+const G4int kMaxAbsor = 10; // 0 + 9
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class DetectorConstruction : public G4VUserDetectorConstruction {
+public:
+  DetectorConstruction();
+  ~DetectorConstruction();
+
+public:
+  virtual G4VPhysicalVolume *Construct();
+  virtual void ConstructSDandField();
+
+  void SetNbOfAbsor(G4int);
+  void SetAbsorMaterial(G4int, const G4String &);
+  void SetAbsorThickness(G4int, G4double);
+
+  void SetWorldMaterial(const G4String &);
+  void SetCalorSizeYZ(G4double);
+  void SetNbOfLayers(G4int);
+
+  void SetMagField(const G4ThreeVector &fv) { fMagFieldVector = fv; }
+
+  void SetPrimaryGenerator(PrimaryGeneratorAction *pg) { fPrimaryGenerator = pg; }
+
+public:
+  void PrintCalorParameters();
+
+  G4double GetWorldSizeX() { return fWorldSizeX; }
+  G4double GetWorldSizeYZ() { return fWorldSizeYZ; }
+
+  G4double GetCalorThickness() { return fCalorThickness; }
+  G4double GetCalorSizeYZ() { return fCalorSizeYZ; }
+
+  G4int GetNbOfLayers() { return fNbOfLayers; }
+
+  G4int GetNbOfAbsor() { return fNbOfAbsor; }
+  G4Material *GetAbsorMaterial(G4int i) { return fAbsorMaterial[i]; }
+  G4double GetAbsorThickness(G4int i) { return fAbsorThickness[i]; }
+
+  const G4VPhysicalVolume *GetphysiWorld() { return fPhysiWorld; }
+  const G4Material *GetWorldMaterial() { return fDefaultMaterial; }
+  const G4VPhysicalVolume *GetAbsorber(G4int i) { return fPhysiAbsor[i]; }
+
+private:
+  G4int fNbOfAbsor;
+  G4Material *fAbsorMaterial[kMaxAbsor];
+  G4double fAbsorThickness[kMaxAbsor];
+
+  G4int fNbOfLayers;
+  G4double fLayerThickness;
+
+  G4double fCalorSizeYZ;
+  G4double fCalorThickness;
+
+  G4Material *fDefaultMaterial;
+  G4double fWorldSizeYZ;
+  G4double fWorldSizeX;
+
+  G4Box *fSolidWorld;
+  G4LogicalVolume *fLogicWorld;
+  G4VPhysicalVolume *fPhysiWorld;
+
+  G4Box *fSolidCalor;
+  G4LogicalVolume *fLogicCalor;
+  G4VPhysicalVolume *fPhysiCalor;
+
+  G4Box *fSolidLayer;
+  G4LogicalVolume *fLogicLayer;
+  G4VPhysicalVolume *fPhysiLayer;
+
+  G4Box *fSolidAbsor[kMaxAbsor];
+  G4LogicalVolume *fLogicAbsor[kMaxAbsor];
+  G4VPhysicalVolume *fPhysiAbsor[kMaxAbsor];
+
+  // field related members
+  G4ThreeVector fMagFieldVector;
+
+  PrimaryGeneratorAction *fPrimaryGenerator;
+
+  DetectorMessenger *fDetectorMessenger;
+
+private:
+  void DefineMaterials();
+  void ComputeCalorParameters();
+  void SetConstantField();
+  G4VPhysicalVolume *ConstructCalorimeter();
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/DetectorMessenger.hh
+++ b/apps/examples/TestEm3/include/DetectorMessenger.hh
@@ -1,0 +1,76 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/DetectorMessenger.hh
+/// \brief Definition of the DetectorMessenger class
+//
+// $Id: DetectorMessenger.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef DetectorMessenger_h
+#define DetectorMessenger_h 1
+
+#include "globals.hh"
+#include "G4UImessenger.hh"
+
+class DetectorConstruction;
+class G4UIdirectory;
+class G4UIcommand;
+class G4UIcmdWithAnInteger;
+class G4UIcmdWithADoubleAndUnit;
+class G4UIcmdWithoutParameter;
+class G4UIcmdWith3VectorAndUnit;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class DetectorMessenger: public G4UImessenger
+{
+  public:
+    DetectorMessenger(DetectorConstruction* );
+   ~DetectorMessenger();
+
+    virtual void SetNewValue(G4UIcommand*, G4String);
+
+  private:
+    DetectorConstruction*      fDetector;
+
+    G4UIdirectory*             fTestemDir;
+    G4UIdirectory*             fDetDir;
+    
+    G4UIcmdWithADoubleAndUnit* fSizeYZCmd;
+    G4UIcmdWithAnInteger*      fNbLayersCmd;
+    G4UIcmdWithAnInteger*      fNbAbsorCmd;
+    G4UIcommand*               fAbsorCmd;
+    //
+    G4UIcmdWith3VectorAndUnit* fFieldCmd;
+
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif
+

--- a/apps/examples/TestEm3/include/EmAcceptance.hh
+++ b/apps/examples/TestEm3/include/EmAcceptance.hh
@@ -1,0 +1,62 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/EmAcceptance.hh
+/// \brief Definition of the EmAcceptance class
+//
+// $Id: EmAcceptance.hh 66241 2012-12-13 18:34:42Z gunter $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef EmAcceptance_h
+#define EmAcceptance_h 1
+
+#include "globals.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class EmAcceptance
+{
+public:
+
+  EmAcceptance();
+ ~EmAcceptance();
+
+  void BeginOfAcceptance(const G4String& title, G4int stat);
+  void EndOfAcceptance();
+
+  void EmAcceptanceGauss(const G4String& title, G4int stat, 
+                               G4double avr, G4double avr0, 
+                               G4double rms, G4double limit);
+
+private:
+
+  G4bool fIsAccepted;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/EventAction.hh
+++ b/apps/examples/TestEm3/include/EventAction.hh
@@ -1,0 +1,65 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/EventAction.hh
+/// \brief Definition of the EventAction class
+//
+// $Id: EventAction.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef EventAction_h
+#define EventAction_h 1
+
+#include "G4UserEventAction.hh"
+#include "globals.hh"
+#include "DetectorConstruction.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class EventAction : public G4UserEventAction
+{
+  public:
+    EventAction(DetectorConstruction*);
+   ~EventAction();
+
+    virtual void BeginOfEventAction(const G4Event*);
+    virtual void   EndOfEventAction(const G4Event*);
+
+    void SumEnergy(G4int k, G4double de, G4double dl) {
+      fEnergyDeposit[k] += de; fTrackLengthCh[k] += dl;
+    }
+
+  private:
+    DetectorConstruction* fDetector;
+
+    G4double              fEnergyDeposit[kMaxAbsor];
+    G4double              fTrackLengthCh[kMaxAbsor];
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/HistoManager.hh
+++ b/apps/examples/TestEm3/include/HistoManager.hh
@@ -1,0 +1,60 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: HistoManager.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef HistoManager_h
+#define HistoManager_h 1
+
+#include "globals.hh"
+
+#include "g4root.hh"
+////#include "g4xml.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "DetectorConstruction.hh"
+const G4int kMaxHisto = 2*kMaxAbsor + 3;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class HistoManager
+{
+  public:
+    HistoManager();
+   ~HistoManager();
+
+  private:
+    void Book();
+    G4String fFileName;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/PhysListEmStandard.hh
+++ b/apps/examples/TestEm3/include/PhysListEmStandard.hh
@@ -1,0 +1,61 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/PhysListEmStandard.hh
+/// \brief Definition of the PhysListEmStandard class
+//
+// $Id: PhysListEmStandard.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef PhysListEmStandard_h
+#define PhysListEmStandard_h 1
+
+#include "G4VPhysicsConstructor.hh"
+#include "globals.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class PhysListEmStandard : public G4VPhysicsConstructor
+{
+  public: 
+     PhysListEmStandard(const G4String& name = "standard");
+    ~PhysListEmStandard();
+
+  public: 
+    // This method is dummy for physics
+    virtual void ConstructParticle() {};
+ 
+    // This method will be invoked in the Construct() method.
+    // each physics process will be instantiated and
+    // registered to the process manager of each particle type 
+    virtual void ConstructProcess();
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif
+

--- a/apps/examples/TestEm3/include/PhysListG4Em.hh
+++ b/apps/examples/TestEm3/include/PhysListG4Em.hh
@@ -1,0 +1,26 @@
+
+#ifndef PhysListG4Em_h
+#define PhysListG4Em_h 1
+
+#include "G4VPhysicsConstructor.hh"
+#include "globals.hh"
+
+
+class PhysListG4Em : public G4VPhysicsConstructor {
+  public:
+     PhysListG4Em (const G4String& name = "G4EM-physics-list (like G4HepEm)");
+    ~PhysListG4Em();
+
+  public:
+    // This method is dummy for physics: particles are constructed in PhysicsList
+    void ConstructParticle() override {};
+
+    // This method will be invoked in the Construct() method.
+    // each physics process will be instantiated and
+    // registered to the process manager of each particle type
+    void ConstructProcess() override;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/PhysListHepEm.hh
+++ b/apps/examples/TestEm3/include/PhysListHepEm.hh
@@ -1,0 +1,26 @@
+
+#ifndef PhysListHepEm_h
+#define PhysListHepEm_h 1
+
+#include "G4VPhysicsConstructor.hh"
+#include "globals.hh"
+
+
+class PhysListHepEm : public G4VPhysicsConstructor {
+  public:
+     PhysListHepEm (const G4String& name = "G4HepEm-physics-list");
+    ~PhysListHepEm();
+
+  public:
+    // This method is dummy for physics: particles are constructed in PhysicsList
+    void ConstructParticle() override {};
+
+    // This method will be invoked in the Construct() method.
+    // each physics process will be instantiated and
+    // registered to the process manager of each particle type
+    void ConstructProcess() override;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/PhysicsList.hh
+++ b/apps/examples/TestEm3/include/PhysicsList.hh
@@ -1,0 +1,74 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/PhysicsList.hh
+/// \brief Definition of the PhysicsList class
+//
+// $Id: PhysicsList.hh 95227 2016-02-01 09:19:15Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef PhysicsList_h
+#define PhysicsList_h 1
+
+#include "G4VModularPhysicsList.hh"
+#include "globals.hh"
+
+class StepMax;
+class PhysicsListMessenger;
+class G4VPhysicsConstructor;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class PhysicsList: public G4VModularPhysicsList
+{
+public:
+
+    PhysicsList();
+   ~PhysicsList();
+
+    virtual void ConstructParticle();
+    virtual void ConstructProcess();
+    
+    void AddPhysicsList(const G4String& name);
+    void AddDecay();
+    void AddRadioactiveDecay();
+    void AddStepMax();
+
+private:
+    
+    G4VPhysicsConstructor*  fEmPhysicsList;
+    G4String fEmName;
+    
+    StepMax* fStepMaxProcess;
+    
+    PhysicsListMessenger* fMessenger;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif
+

--- a/apps/examples/TestEm3/include/PhysicsListMessenger.hh
+++ b/apps/examples/TestEm3/include/PhysicsListMessenger.hh
@@ -1,0 +1,68 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/PhysicsListMessenger.hh
+/// \brief Definition of the PhysicsListMessenger class
+//
+// $Id: PhysicsListMessenger.hh 82038 2014-06-10 07:58:08Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef PhysicsListMessenger_h
+#define PhysicsListMessenger_h 1
+
+#include "globals.hh"
+#include "G4UImessenger.hh"
+
+class PhysicsList;
+class G4UIdirectory;
+class G4UIcmdWithADoubleAndUnit;
+class G4UIcmdWithAString;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class PhysicsListMessenger: public G4UImessenger
+{
+  public:
+  
+    PhysicsListMessenger(PhysicsList* );
+   ~PhysicsListMessenger();
+    
+    virtual void SetNewValue(G4UIcommand*, G4String);
+    
+  private:
+  
+    PhysicsList*               fPhysicsList;
+    
+    G4UIdirectory*             fPhysDir;    
+    G4UIcmdWithAString*        fListCmd;
+    
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif
+

--- a/apps/examples/TestEm3/include/PrimaryGeneratorAction.hh
+++ b/apps/examples/TestEm3/include/PrimaryGeneratorAction.hh
@@ -1,0 +1,71 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/PrimaryGeneratorAction.hh
+/// \brief Definition of the PrimaryGeneratorAction class
+//
+// $Id: PrimaryGeneratorAction.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef PrimaryGeneratorAction_h
+#define PrimaryGeneratorAction_h 1
+
+#include "G4VUserPrimaryGeneratorAction.hh"
+#include "G4ParticleGun.hh"
+#include "globals.hh"
+
+class G4Event;
+class DetectorConstruction;
+class PrimaryGeneratorMessenger;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class PrimaryGeneratorAction : public G4VUserPrimaryGeneratorAction
+{
+  public:
+    PrimaryGeneratorAction(DetectorConstruction*);
+   ~PrimaryGeneratorAction();
+
+  public:
+    void SetDefaultKinematic();
+    void SetRndmBeam(G4double val) { fRndmBeam = val;}
+    virtual
+    void GeneratePrimaries(G4Event*);
+
+    G4ParticleGun* GetParticleGun() {return fParticleGun;};
+
+  private:
+    G4ParticleGun*         fParticleGun;
+    DetectorConstruction*  fDetector;
+    G4double fRndmBeam;   //lateral random beam extension in fraction sizeYZ/2
+
+    PrimaryGeneratorMessenger* fGunMessenger;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/PrimaryGeneratorMessenger.hh
+++ b/apps/examples/TestEm3/include/PrimaryGeneratorMessenger.hh
@@ -1,0 +1,66 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/PrimaryGeneratorMessenger.hh
+/// \brief Definition of the PrimaryGeneratorMessenger class
+//
+// $Id: PrimaryGeneratorMessenger.hh 66241 2012-12-13 18:34:42Z gunter $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef PrimaryGeneratorMessenger_h
+#define PrimaryGeneratorMessenger_h 1
+
+#include "G4UImessenger.hh"
+#include "globals.hh"
+
+class PrimaryGeneratorAction;
+class G4UIdirectory;
+class G4UIcmdWithoutParameter;
+class G4UIcmdWithADouble;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class PrimaryGeneratorMessenger: public G4UImessenger
+{
+  public:
+    PrimaryGeneratorMessenger(PrimaryGeneratorAction*);
+   ~PrimaryGeneratorMessenger();
+    
+    virtual void SetNewValue(G4UIcommand*, G4String);
+    
+  private:
+    PrimaryGeneratorAction*    fAction;
+    
+    G4UIdirectory*             fGunDir;      
+    G4UIcmdWithoutParameter*   fDefaultCmd;
+    G4UIcmdWithADouble*        fRndmCmd;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif
+

--- a/apps/examples/TestEm3/include/Run.hh
+++ b/apps/examples/TestEm3/include/Run.hh
@@ -1,0 +1,105 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/Run.hh
+/// \brief Definition of the Run class
+//
+// $Id: Run.hh 71375 2013-06-14 07:39:33Z maire $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef Run_h
+#define Run_h 1
+
+#include "DetectorConstruction.hh"
+
+#include "G4Run.hh"
+#include "globals.hh"
+#include <map>
+
+class DetectorConstruction;
+class G4ParticleDefinition;
+class G4Track;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class Run : public G4Run
+{
+  public:
+    Run(DetectorConstruction*);
+   ~Run();
+
+  public:
+    void SetPrimary(G4ParticleDefinition* particle, G4double energy);
+
+    void FillPerEvent(G4int,G4double,G4double);
+
+    void SumEnergyFlow (G4int plane, G4double Eflow);
+    void SumLateralEleak(G4int cell, G4double Eflow);
+    void AddChargedStep();
+    void AddNeutralStep();
+    void AddSecondaryTrack(const G4Track*);
+    
+    void AddCHStepInLayer(double stepl, int layerindx) { fCHTrackLPerLayer[layerindx] += stepl; }
+    void AddEDepInLayer(double edep, int layerindx)    { fEDepPerLayer[layerindx]     += edep;  }
+
+    void SetEdepAndRMS(G4int, G4double, G4double, G4double);
+    void SetApplyLimit(G4bool);
+
+    virtual void Merge(const G4Run*);
+    void EndOfRun();
+
+  private:
+    DetectorConstruction*  fDetector;
+    G4ParticleDefinition*  fParticle;
+    G4double  fEkin;
+
+    G4double fSumEAbs [kMaxAbsor], fSum2EAbs [kMaxAbsor];
+    G4double fSumLAbs [kMaxAbsor], fSum2LAbs [kMaxAbsor];
+
+    std::vector<G4double> fEnergyFlow;
+    std::vector<G4double> fLateralEleak;
+    std::vector<G4double> fEnergyDeposit[kMaxAbsor];
+    //
+    std::vector<G4double> fCHTrackLPerLayer;
+    std::vector<G4double> fEDepPerLayer;
+
+    G4double fChargedStep;
+    G4double fNeutralStep;
+
+    G4double  fN_gamma;
+    G4double  fN_elec;
+    G4double  fN_pos;
+
+    G4double fEdeptrue [kMaxAbsor];
+    G4double fRmstrue  [kMaxAbsor];
+    G4double fLimittrue[kMaxAbsor];
+    G4bool fApplyLimit;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/RunAction.hh
+++ b/apps/examples/TestEm3/include/RunAction.hh
@@ -1,0 +1,80 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/RunAction.hh
+/// \brief Definition of the RunAction class
+//
+// $Id: RunAction.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef RunAction_h
+#define RunAction_h 1
+
+#include "G4UserRunAction.hh"
+#include "globals.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class Run;
+class DetectorConstruction;
+class PrimaryGeneratorAction;
+class RunActionMessenger;
+class HistoManager;
+class G4Timer;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class RunAction : public G4UserRunAction
+{
+public:
+
+  RunAction(DetectorConstruction*, PrimaryGeneratorAction* prim=0);
+ ~RunAction();
+
+  virtual G4Run* GenerateRun();
+  virtual void   BeginOfRunAction(const G4Run*);
+  virtual void   EndOfRunAction(const G4Run*);
+
+  // Acceptance parameters
+  void SetEdepAndRMS(G4int, G4double, G4double, G4double);
+  void SetApplyLimit(G4bool val);
+
+  void SetPerformanceFlag(G4bool val)  { fIsPerformance = val; }
+
+private:
+  G4bool                  fIsPerformance;
+  DetectorConstruction*   fDetector;
+  PrimaryGeneratorAction* fPrimary;
+  Run*                    fRun;
+  RunActionMessenger*     fRunMessenger;
+  HistoManager*           fHistoManager;
+  G4Timer*                fTimer;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/RunActionMessenger.hh
+++ b/apps/examples/TestEm3/include/RunActionMessenger.hh
@@ -1,0 +1,65 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/RunActionMessenger.hh
+/// \brief Definition of the RunActionMessenger class
+//
+// $Id: RunActionMessenger.hh 66241 2012-12-13 18:34:42Z gunter $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef RunActionMessenger_h
+#define RunActionMessenger_h 1
+
+#include "globals.hh"
+#include "G4UImessenger.hh"
+
+class RunAction;
+class G4UIdirectory;
+class G4UIcommand;
+class G4UIcmdWithABool;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class RunActionMessenger: public G4UImessenger
+{
+public:
+  RunActionMessenger(RunAction*);
+  virtual ~RunActionMessenger();
+    
+  void SetNewValue(G4UIcommand*, G4String);
+    
+private:
+  RunAction*          fRunAction;
+    
+  G4UIdirectory*      fRunDir;
+  G4UIcommand*        fAccCmd;
+  G4UIcmdWithABool*   fLimCmd;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/StepMax.hh
+++ b/apps/examples/TestEm3/include/StepMax.hh
@@ -1,0 +1,105 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/StepMax.hh
+/// \brief Definition of the StepMax class
+//
+// $Id: StepMax.hh 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef StepMax_h
+#define StepMax_h 1
+
+#include "globals.hh"
+#include "G4VDiscreteProcess.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4Step.hh"
+
+#include "DetectorConstruction.hh"
+
+class StepMaxMessenger;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class StepMax : public G4VDiscreteProcess
+{
+public:
+
+  StepMax(const G4String& processName = "UserStepMax");
+ ~StepMax();
+
+  G4bool   IsApplicable(const G4ParticleDefinition&);
+
+  void     SetStepMax(G4int, G4double);
+
+  G4double GetStepMax(G4int k) { return fStepMax[k];};
+
+  G4double PostStepGetPhysicalInteractionLength( const G4Track& track,
+                                               G4double previousStepSize,
+                                               G4ForceCondition* condition);
+
+  G4VParticleChange* PostStepDoIt(const G4Track&, const G4Step&);
+
+  G4double GetMeanFreePath(const G4Track&, G4double,G4ForceCondition*)
+     {return DBL_MAX;};    
+
+private:
+
+  G4double fStepMax[kMaxAbsor];
+     
+  StepMaxMessenger* fMess;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+inline 
+G4double StepMax::PostStepGetPhysicalInteractionLength( const G4Track& aTrack,
+                                    G4double, G4ForceCondition* condition)
+{
+  // condition is set to "Not Forced"
+  *condition = NotForced;
+  
+  G4double limit = DBL_MAX; 
+  G4int n = aTrack.GetVolume()->GetCopyNo();
+  if (n < kMaxAbsor) limit = fStepMax[n];
+  return limit;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+inline 
+G4VParticleChange* StepMax::PostStepDoIt(const G4Track& aTrack, const G4Step&)
+{
+   // do nothing
+   aParticleChange.Initialize(aTrack);
+   return &aParticleChange;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif
+

--- a/apps/examples/TestEm3/include/StepMaxMessenger.hh
+++ b/apps/examples/TestEm3/include/StepMaxMessenger.hh
@@ -1,0 +1,63 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/StepMaxMessenger.hh
+/// \brief Definition of the StepMaxMessenger class
+//
+// $Id: StepMaxMessenger.hh 66241 2012-12-13 18:34:42Z gunter $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef StepMaxMessenger_h
+#define StepMaxMessenger_h 1
+
+#include "globals.hh"
+#include "G4UImessenger.hh"
+
+class StepMax;
+class G4UIdirectory;
+class G4UIcommand;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class StepMaxMessenger: public G4UImessenger
+{
+  public:
+    StepMaxMessenger(StepMax*);
+   ~StepMaxMessenger();
+    
+    void SetNewValue(G4UIcommand*, G4String);
+    
+  private:
+    StepMax*       fStepMax;
+    
+    G4UIdirectory* fStepMaxDir;    
+    G4UIcommand*   fStepMaxCmd;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/SteppingAction.hh
+++ b/apps/examples/TestEm3/include/SteppingAction.hh
@@ -1,0 +1,62 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/SteppingAction.hh
+/// \brief Definition of the SteppingAction class
+//
+// $Id: SteppingAction.hh 78655 2014-01-14 11:13:41Z gcosmo $
+// 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef SteppingAction_h
+#define SteppingAction_h 1
+
+#include "G4UserSteppingAction.hh"
+#include "globals.hh"
+
+class DetectorConstruction;
+class EventAction;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class SteppingAction : public G4UserSteppingAction
+{
+  public:
+    SteppingAction(DetectorConstruction*, EventAction*);
+   ~SteppingAction();
+
+    virtual void UserSteppingAction(const G4Step*);
+    
+    G4double BirksAttenuation(const G4Step*);
+    
+  private:
+    DetectorConstruction* fDetector;
+    EventAction*          fEventAct;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/SteppingVerbose.hh
+++ b/apps/examples/TestEm3/include/SteppingVerbose.hh
@@ -1,0 +1,55 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/SteppingVerbose.hh
+/// \brief Definition of the SteppingVerbose class
+//
+//
+// $Id: SteppingVerbose.hh 98762 2016-08-09 14:08:07Z gcosmo $
+// 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef SteppingVerbose_h
+#define SteppingVerbose_h 1
+
+#include "G4SteppingVerbose.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class SteppingVerbose : public G4SteppingVerbose {
+
+public:   
+
+  SteppingVerbose();
+ ~SteppingVerbose();
+ 
+  virtual void TrackingStarted();
+  virtual void StepInfo();
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/include/TrackingAction.hh
+++ b/apps/examples/TestEm3/include/TrackingAction.hh
@@ -1,0 +1,59 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/include/TrackingAction.hh
+/// \brief Definition of the TrackingAction class
+//
+// $Id: TrackingAction.hh 78655 2014-01-14 11:13:41Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#ifndef TrackingAction_h
+#define TrackingAction_h 1
+
+#include "G4UserTrackingAction.hh"
+#include "globals.hh"
+
+class DetectorConstruction;
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+class TrackingAction : public G4UserTrackingAction {
+
+  public:  
+    TrackingAction(DetectorConstruction*);
+   ~TrackingAction() {};
+   
+    virtual void  PreUserTrackingAction(const G4Track*);   
+    virtual void PostUserTrackingAction(const G4Track*);
+    
+  private:
+    DetectorConstruction* fDetector;
+};
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#endif

--- a/apps/examples/TestEm3/src/ActionInitialization.cc
+++ b/apps/examples/TestEm3/src/ActionInitialization.cc
@@ -1,0 +1,85 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// $Id: ActionInitialization.cc 76346 2013-11-08 15:48:19Z maire $
+//
+/// \file ActionInitialization.cc
+/// \brief Implementation of the ActionInitialization class
+
+#include "ActionInitialization.hh"
+#include "DetectorConstruction.hh"
+#include "PrimaryGeneratorAction.hh"
+#include "RunAction.hh"
+#include "EventAction.hh"
+#include "TrackingAction.hh"
+#include "SteppingAction.hh"
+#include "SteppingVerbose.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+ActionInitialization::ActionInitialization(DetectorConstruction* det, bool isperformance)
+ : G4VUserActionInitialization(),fDetector(det),fIsPerformance(isperformance)
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+ActionInitialization::~ActionInitialization()
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void ActionInitialization::BuildForMaster() const
+{
+  RunAction* masterRunAct = new RunAction(fDetector);
+  masterRunAct->SetPerformanceFlag(fIsPerformance);
+  SetUserAction(masterRunAct);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void ActionInitialization::Build() const
+{
+
+  PrimaryGeneratorAction* prim = new PrimaryGeneratorAction(fDetector);
+  fDetector->SetPrimaryGenerator(prim);
+  SetUserAction(prim);
+  if (!fIsPerformance) {
+    RunAction* run = new RunAction(fDetector,prim);
+    SetUserAction(run);
+    EventAction* event = new EventAction(fDetector);
+    SetUserAction(event);
+    SetUserAction(new TrackingAction(fDetector));
+    SetUserAction(new SteppingAction(fDetector,event));
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4VSteppingVerbose* ActionInitialization::InitializeSteppingVerbose() const
+{
+  return new SteppingVerbose();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/DetectorConstruction.cc
+++ b/apps/examples/TestEm3/src/DetectorConstruction.cc
@@ -1,0 +1,505 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/DetectorConstruction.cc
+/// \brief Implementation of the DetectorConstruction class
+//
+// $Id: DetectorConstruction.cc 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "DetectorConstruction.hh"
+#include "DetectorMessenger.hh"
+
+#include "G4NistManager.hh"
+#include "G4Material.hh"
+#include "G4Box.hh"
+#include "G4LogicalVolume.hh"
+#include "G4PVPlacement.hh"
+#include "G4PVReplica.hh"
+
+#include "G4GeometryManager.hh"
+#include "G4PhysicalVolumeStore.hh"
+#include "G4LogicalVolumeStore.hh"
+#include "G4SolidStore.hh"
+
+#include "G4RunManager.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4UnitsTable.hh"
+#include "G4PhysicalConstants.hh"
+
+#include "G4TransportationManager.hh"
+#include "G4UniformMagField.hh"
+#include "G4FieldManager.hh"
+
+#include "PrimaryGeneratorAction.hh"
+
+#include <iomanip>
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+DetectorConstruction::DetectorConstruction()
+    : G4VUserDetectorConstruction(), fDefaultMaterial(0), fSolidWorld(0), fLogicWorld(0), fPhysiWorld(0),
+      fSolidCalor(0), fLogicCalor(0), fPhysiCalor(0), fSolidLayer(0), fLogicLayer(0), fPhysiLayer(0),
+      fPrimaryGenerator(0), fDetectorMessenger(0)
+{
+  // default parameter values of the calorimeter
+  fNbOfAbsor         = 2;
+  fAbsorThickness[1] = 2.3 * mm;
+  fAbsorThickness[2] = 5.7 * mm;
+  fNbOfLayers        = 50;
+  fCalorSizeYZ       = 40. * cm;
+  ComputeCalorParameters();
+
+  // materials
+  DefineMaterials();
+  SetWorldMaterial("Galactic");
+  SetAbsorMaterial(1, "Lead");
+  SetAbsorMaterial(2, "liquidArgon");
+
+  // create commands for interactive definition of the calorimeter
+  fDetectorMessenger = new DetectorMessenger(this);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+DetectorConstruction::~DetectorConstruction()
+{
+  delete fDetectorMessenger;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4VPhysicalVolume *DetectorConstruction::Construct()
+{
+  return ConstructCalorimeter();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::DefineMaterials()
+{
+  // This function illustrates the possible ways to define materials using
+  // G4 database on G4Elements
+  G4NistManager *manager = G4NistManager::Instance();
+  manager->SetVerbose(0);
+  //
+  // define Elements
+  //
+  G4double z, a;
+
+  G4Element *H  = manager->FindOrBuildElement(1);
+  G4Element *C  = manager->FindOrBuildElement(6);
+  G4Element *N  = manager->FindOrBuildElement(7);
+  G4Element *O  = manager->FindOrBuildElement(8);
+  G4Element *Si = manager->FindOrBuildElement(14);
+  G4Element *Ge = manager->FindOrBuildElement(32);
+  G4Element *Sb = manager->FindOrBuildElement(51);
+  G4Element *I  = manager->FindOrBuildElement(53);
+  G4Element *Cs = manager->FindOrBuildElement(55);
+  G4Element *Pb = manager->FindOrBuildElement(82);
+  G4Element *Bi = manager->FindOrBuildElement(83);
+
+  //
+  // define an Element from isotopes, by relative abundance
+  //
+  G4int iz, n; // iz=number of protons  in an isotope;
+               // n=number of nucleons in an isotope;
+  G4int ncomponents;
+  G4double abundance;
+
+  G4Isotope *U5 = new G4Isotope("U235", iz = 92, n = 235, a = 235.01 * g / mole);
+  G4Isotope *U8 = new G4Isotope("U238", iz = 92, n = 238, a = 238.03 * g / mole);
+
+  G4Element *U = new G4Element("enriched Uranium", "U", ncomponents = 2);
+  U->AddIsotope(U5, abundance = 90. * perCent);
+  U->AddIsotope(U8, abundance = 10. * perCent);
+
+  //
+  // define simple materials
+  //
+  G4double density;
+
+  new G4Material("liquidH2", z = 1., a = 1.008 * g / mole, density = 70.8 * mg / cm3);
+  new G4Material("Aluminium", z = 13., a = 26.98 * g / mole, density = 2.700 * g / cm3);
+  new G4Material("Titanium", z = 22., a = 47.867 * g / mole, density = 4.54 * g / cm3);
+  new G4Material("Iron", z = 26., a = 55.85 * g / mole, density = 7.870 * g / cm3);
+  new G4Material("Copper", z = 29., a = 63.55 * g / mole, density = 8.960 * g / cm3);
+  new G4Material("Tungsten", z = 74., a = 183.85 * g / mole, density = 19.30 * g / cm3);
+  new G4Material("Gold", z = 79., a = 196.97 * g / mole, density = 19.32 * g / cm3);
+  new G4Material("Uranium", z = 92., a = 238.03 * g / mole, density = 18.95 * g / cm3);
+
+  //
+  // define a material from elements.   case 1: chemical molecule
+  //
+  G4int natoms;
+
+  G4Material *H2O = new G4Material("Water", density = 1.000 * g / cm3, ncomponents = 2);
+  H2O->AddElement(H, natoms = 2);
+  H2O->AddElement(O, natoms = 1);
+  H2O->GetIonisation()->SetMeanExcitationEnergy(78.0 * eV);
+  H2O->SetChemicalFormula("H_2O");
+
+  G4Material *CH = new G4Material("Polystyrene", density = 1.032 * g / cm3, ncomponents = 2);
+  CH->AddElement(C, natoms = 1);
+  CH->AddElement(H, natoms = 1);
+
+  G4Material *Sci = new G4Material("Scintillator", density = 1.032 * g / cm3, ncomponents = 2);
+  Sci->AddElement(C, natoms = 9);
+  Sci->AddElement(H, natoms = 10);
+
+  Sci->GetIonisation()->SetBirksConstant(0.126 * mm / MeV);
+
+  G4Material *Lct = new G4Material("Lucite", density = 1.185 * g / cm3, ncomponents = 3);
+  Lct->AddElement(C, 59.97 * perCent);
+  Lct->AddElement(H, 8.07 * perCent);
+  Lct->AddElement(O, 31.96 * perCent);
+
+  G4Material *Sili = new G4Material("Silicon", density = 2.330 * g / cm3, ncomponents = 1);
+  Sili->AddElement(Si, natoms = 1);
+
+  G4Material *SiO2 = new G4Material("quartz", density = 2.200 * g / cm3, ncomponents = 2);
+  SiO2->AddElement(Si, natoms = 1);
+  SiO2->AddElement(O, natoms = 2);
+
+  G4Material *G10 = new G4Material("NemaG10", density = 1.700 * g / cm3, ncomponents = 4);
+  G10->AddElement(Si, natoms = 1);
+  G10->AddElement(O, natoms = 2);
+  G10->AddElement(C, natoms = 3);
+  G10->AddElement(H, natoms = 3);
+
+  G4Material *CsI = new G4Material("CsI", density = 4.534 * g / cm3, ncomponents = 2);
+  CsI->AddElement(Cs, natoms = 1);
+  CsI->AddElement(I, natoms = 1);
+  CsI->GetIonisation()->SetMeanExcitationEnergy(553.1 * eV);
+
+  G4Material *BGO = new G4Material("BGO", density = 7.10 * g / cm3, ncomponents = 3);
+  BGO->AddElement(O, natoms = 12);
+  BGO->AddElement(Ge, natoms = 3);
+  BGO->AddElement(Bi, natoms = 4);
+
+  // SiNx
+  density          = 3.1 * g / cm3;
+  G4Material *SiNx = new G4Material("SiNx", density, ncomponents = 3);
+  SiNx->AddElement(Si, 300);
+  SiNx->AddElement(N, 310);
+  SiNx->AddElement(H, 6);
+
+  //
+  // define gaseous materials using G4 NIST database
+  //
+  G4double fractionmass;
+
+  G4Material *Air = manager->FindOrBuildMaterial("G4_AIR");
+  manager->ConstructNewGasMaterial("Air20", "G4_AIR", 293. * kelvin, 1. * atmosphere);
+
+  G4Material *lAr    = manager->FindOrBuildMaterial("G4_lAr");
+  G4Material *lArEm3 = new G4Material("liquidArgon", density = 1.390 * g / cm3, ncomponents = 1);
+  lArEm3->AddMaterial(lAr, fractionmass = 1.0);
+
+  //
+  // define a material from elements and others materials (mixture of mixtures)
+  //
+
+  G4Material *Lead = new G4Material("Lead", density = 11.35 * g / cm3, ncomponents = 1);
+  Lead->AddElement(Pb, fractionmass = 1.0);
+
+  G4Material *LeadSb = new G4Material("LeadSb", density = 11.35 * g / cm3, ncomponents = 2);
+  LeadSb->AddElement(Sb, fractionmass = 4. * perCent);
+  LeadSb->AddElement(Pb, fractionmass = 96. * perCent);
+
+  G4Material *Aerog = new G4Material("Aerogel", density = 0.200 * g / cm3, ncomponents = 3);
+  Aerog->AddMaterial(SiO2, fractionmass = 62.5 * perCent);
+  Aerog->AddMaterial(H2O, fractionmass = 37.4 * perCent);
+  Aerog->AddElement(C, fractionmass = 0.1 * perCent);
+
+  //
+  // examples of gas in non STP conditions
+  //
+  G4double temperature, pressure;
+
+  G4Material *CO2 = new G4Material("CarbonicGas", density = 27. * mg / cm3, ncomponents = 2, kStateGas,
+                                   temperature = 325. * kelvin, pressure = 50. * atmosphere);
+  CO2->AddElement(C, natoms = 1);
+  CO2->AddElement(O, natoms = 2);
+
+  G4Material *steam = new G4Material("WaterSteam", density = 1.0 * mg / cm3, ncomponents = 1, kStateGas,
+                                     temperature = 273 * kelvin, pressure = 1 * atmosphere);
+  steam->AddMaterial(H2O, fractionmass = 1.);
+
+  new G4Material("ArgonGas", z = 18, a = 39.948 * g / mole, density = 1.782 * mg / cm3, kStateGas, 273.15 * kelvin,
+                 1 * atmosphere);
+  //
+  // examples of vacuum
+  //
+
+  density     = universe_mean_density; // from PhysicalConstants.h
+  pressure    = 3.e-18 * pascal;
+  temperature = 2.73 * kelvin;
+  new G4Material("Galactic", z = 1., a = 1.008 * g / mole, density, kStateGas, temperature, pressure);
+
+  density          = 1.e-5 * g / cm3;
+  pressure         = 2.e-2 * bar;
+  temperature      = STP_Temperature; // from PhysicalConstants.h
+  G4Material *beam = new G4Material("Beam", density, ncomponents = 1, kStateGas, temperature, pressure);
+  beam->AddMaterial(Air, fractionmass = 1.);
+
+  //  G4cout << *(G4Material::GetMaterialTable()) << G4endl;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::ComputeCalorParameters()
+{
+  // Compute derived parameters of the calorimeter
+  fLayerThickness = 0.;
+  for (G4int iAbs = 1; iAbs <= fNbOfAbsor; iAbs++) {
+    fLayerThickness += fAbsorThickness[iAbs];
+  }
+  fCalorThickness = fNbOfLayers * fLayerThickness;
+  fWorldSizeX     = 1.2 * fCalorThickness;
+  fWorldSizeYZ    = 1.2 * fCalorSizeYZ;
+  // update the primary generator
+  if (fPrimaryGenerator) {
+    fPrimaryGenerator->SetDefaultKinematic();
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4VPhysicalVolume *DetectorConstruction::ConstructCalorimeter()
+{
+  // complete the Calor parameters definition
+  ComputeCalorParameters();
+
+  // Cleanup old geometry
+  G4GeometryManager::GetInstance()->OpenGeometry();
+  G4PhysicalVolumeStore::GetInstance()->Clean();
+  G4LogicalVolumeStore::GetInstance()->Clean();
+  G4SolidStore::GetInstance()->Clean();
+
+  //
+  // World
+  //
+
+  fSolidWorld = new G4Box("World",                                                 // its name
+                          fWorldSizeX / 2., fWorldSizeYZ / 2., fWorldSizeYZ / 2.); // its size
+
+  fLogicWorld = new G4LogicalVolume(fSolidWorld,      // its solid
+                                    fDefaultMaterial, // its material
+                                    "World");         // its name
+
+  fPhysiWorld = new G4PVPlacement(0,               // no rotation
+                                  G4ThreeVector(), // at (0,0,0)
+                                  fLogicWorld,     // its fLogical volume
+                                  "World",         // its name
+                                  0,               // its mother  volume
+                                  false,           // no boolean operation
+                                  0);              // copy number
+  //
+  // Calorimeter
+  //
+
+  fSolidCalor = new G4Box("Calorimeter", fCalorThickness / 2., fCalorSizeYZ / 2., fCalorSizeYZ / 2.);
+
+  fLogicCalor = new G4LogicalVolume(fSolidCalor, fDefaultMaterial, "Calorimeter");
+
+  fPhysiCalor = new G4PVPlacement(0,               // no rotation
+                                  G4ThreeVector(), // at (0,0,0)
+                                  fLogicCalor,     // its fLogical volume
+                                  "Calorimeter",   // its name
+                                  fLogicWorld,     // its mother  volume
+                                  false,           // no boolean operation
+                                  0);              // copy number
+
+  //
+  // Layers
+  //
+
+  fSolidLayer = new G4Box("Layer", fLayerThickness / 2, fCalorSizeYZ / 2, fCalorSizeYZ / 2);
+
+  fLogicLayer = new G4LogicalVolume(fSolidLayer, fDefaultMaterial, "Layer");
+  if (fNbOfLayers > 1)
+    fPhysiLayer = new G4PVReplica("Layer", fLogicLayer, fLogicCalor, kXAxis, fNbOfLayers, fLayerThickness);
+  else
+    fPhysiLayer = new G4PVPlacement(0, G4ThreeVector(), fLogicLayer, "Layer", fLogicCalor, false, 0);
+
+  //
+  // Absorbers
+  //
+
+  G4double xfront = -0.5 * fLayerThickness;
+  for (G4int k = 1; k <= fNbOfAbsor; k++) {
+    fSolidAbsor[k] = new G4Box("Absorber", // its name
+                               fAbsorThickness[k] / 2, fCalorSizeYZ / 2, fCalorSizeYZ / 2);
+
+    fLogicAbsor[k] = new G4LogicalVolume(fSolidAbsor[k],    // its solid
+                                         fAbsorMaterial[k], // its material
+                                         fAbsorMaterial[k]->GetName());
+
+    G4double xcenter = xfront + 0.5 * fAbsorThickness[k];
+    xfront += fAbsorThickness[k];
+    fPhysiAbsor[k] = new G4PVPlacement(0, G4ThreeVector(xcenter, 0., 0.), fLogicAbsor[k], fAbsorMaterial[k]->GetName(),
+                                       fLogicLayer, false,
+                                       k); // copy number
+  }
+  //
+  PrintCalorParameters();
+
+  // always return the fPhysical World
+  //
+  return fPhysiWorld;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::PrintCalorParameters()
+{
+  G4cout << "\n-------------------------------------------------------------"
+         << "\n ---> The calorimeter is " << fNbOfLayers << " layers of:";
+  for (G4int i = 1; i <= fNbOfAbsor; i++) {
+    G4cout << "\n \t" << std::setw(12) << fAbsorMaterial[i]->GetName() << ": " << std::setw(6)
+           << G4BestUnit(fAbsorThickness[i], "Length");
+  }
+  G4cout << "\n-------------------------------------------------------------\n";
+
+  G4cout << "\n" << fDefaultMaterial << G4endl;
+  for (G4int j = 1; j <= fNbOfAbsor; j++)
+    G4cout << "\n" << fAbsorMaterial[j] << G4endl;
+
+  G4cout << "\n-------------------------------------------------------------\n";
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::SetWorldMaterial(const G4String &material)
+{
+  // search the material by its name
+  G4Material *pttoMaterial = G4NistManager::Instance()->FindOrBuildMaterial(material);
+  if (pttoMaterial) fDefaultMaterial = pttoMaterial;
+  G4RunManager::GetRunManager()->PhysicsHasBeenModified();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::SetNbOfLayers(G4int ival)
+{
+  // set the number of Layers
+  //
+  if (ival < 1) {
+    G4cout << "\n --->warning from SetfNbOfLayers: " << ival << " must be at least 1. Command refused" << G4endl;
+    return;
+  }
+  fNbOfLayers = ival;
+  G4RunManager::GetRunManager()->ReinitializeGeometry();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::SetNbOfAbsor(G4int ival)
+{
+  // set the number of Absorbers
+  //
+  if (ival < 1 || ival > (kMaxAbsor - 1)) {
+    G4cout << "\n ---> warning from SetfNbOfAbsor: " << ival << " must be at least 1 and and most " << kMaxAbsor - 1
+           << ". Command refused" << G4endl;
+    return;
+  }
+  fNbOfAbsor = ival;
+  G4RunManager::GetRunManager()->ReinitializeGeometry();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::SetAbsorMaterial(G4int ival, const G4String &material)
+{
+  // search the material by its name
+  //
+  if (ival > fNbOfAbsor || ival <= 0) {
+    G4cout << "\n --->warning from SetAbsorMaterial: absor number " << ival << " out of range. Command refused"
+           << G4endl;
+    return;
+  }
+
+  G4Material *pttoMaterial = G4NistManager::Instance()->FindOrBuildMaterial(material);
+  if (pttoMaterial) fAbsorMaterial[ival] = pttoMaterial;
+  G4RunManager::GetRunManager()->PhysicsHasBeenModified();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::SetAbsorThickness(G4int ival, G4double val)
+{
+  // change Absorber thickness
+  //
+  if (ival > fNbOfAbsor || ival <= 0) {
+    G4cout << "\n --->warning from SetAbsorThickness: absor number " << ival << " out of range. Command refused"
+           << G4endl;
+    return;
+  }
+  if (val <= DBL_MIN) {
+    G4cout << "\n --->warning from SetAbsorThickness: thickness " << val << " out of range. Command refused" << G4endl;
+    return;
+  }
+  fAbsorThickness[ival] = val;
+  G4RunManager::GetRunManager()->ReinitializeGeometry();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::SetCalorSizeYZ(G4double val)
+{
+  // change the transverse size
+  //
+  if (val <= DBL_MIN) {
+    G4cout << "\n --->warning from SetfCalorSizeYZ: thickness " << val << " out of range. Command refused" << G4endl;
+    return;
+  }
+  fCalorSizeYZ = val;
+  G4RunManager::GetRunManager()->ReinitializeGeometry();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorConstruction::ConstructSDandField()
+{
+  if (fMagFieldVector.mag() > 0.0 && 0) {
+    // Apply a global uniform magnetic field along the Z axis.
+    // Notice that only if the magnetic field is not zero, the Geant4
+    // transportion in field gets activated.
+    auto uniformMagField     = new G4UniformMagField(fMagFieldVector);
+    G4FieldManager *fieldMgr = G4TransportationManager::GetTransportationManager()->GetFieldManager();
+    fieldMgr->SetDetectorField(uniformMagField);
+    fieldMgr->CreateChordFinder(uniformMagField);
+    G4cout << G4endl << " *** SETTING MAGNETIC FIELD : fieldValue = " << fMagFieldVector / kilogauss
+           << " [kilogauss] *** " << G4endl << G4endl;
+
+  } else {
+    G4cout << G4endl << " *** NO MAGNETIC FIELD SET  *** " << G4endl << G4endl;
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/DetectorMessenger.cc
+++ b/apps/examples/TestEm3/src/DetectorMessenger.cc
@@ -1,0 +1,165 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/DetectorMessenger.cc
+/// \brief Implementation of the DetectorMessenger class
+//
+// $Id: DetectorMessenger.cc 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "DetectorMessenger.hh"
+
+#include <sstream>
+
+#include "DetectorConstruction.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcommand.hh"
+#include "G4UIparameter.hh"
+#include "G4UIcmdWithAnInteger.hh"
+#include "G4UIcmdWithADoubleAndUnit.hh"
+#include "G4UIcmdWithoutParameter.hh"
+#include "G4UIcmdWith3VectorAndUnit.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+DetectorMessenger::DetectorMessenger(DetectorConstruction * Det)
+:G4UImessenger(),fDetector(Det),
+ fTestemDir(0),
+ fDetDir(0),
+ fSizeYZCmd(0),
+ fNbLayersCmd(0),
+ fNbAbsorCmd(0),
+ fAbsorCmd(0),
+ fFieldCmd(0)
+{ 
+  fTestemDir = new G4UIdirectory("/testem/");
+  fTestemDir->SetGuidance("UI commands specific to this example");
+  //
+  fDetDir = new G4UIdirectory("/testem/det/");
+  fDetDir->SetGuidance("detector construction commands");
+  //
+  fSizeYZCmd = new G4UIcmdWithADoubleAndUnit("/testem/det/setSizeYZ",this);
+  fSizeYZCmd->SetGuidance("Set tranverse size of the calorimeter");
+  fSizeYZCmd->SetParameterName("Size",false);
+  fSizeYZCmd->SetRange("Size>0.");
+  fSizeYZCmd->SetUnitCategory("Length");
+  fSizeYZCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  fSizeYZCmd->SetToBeBroadcasted(false);
+  //  
+  fNbLayersCmd = new G4UIcmdWithAnInteger("/testem/det/setNbOfLayers",this);
+  fNbLayersCmd->SetGuidance("Set number of layers.");
+  fNbLayersCmd->SetParameterName("NbLayers",false);
+  fNbLayersCmd->SetRange("NbLayers>0");
+  fNbLayersCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  fNbLayersCmd->SetToBeBroadcasted(false);
+  // 
+  fNbAbsorCmd = new G4UIcmdWithAnInteger("/testem/det/setNbOfAbsor",this);
+  fNbAbsorCmd->SetGuidance("Set number of Absorbers.");
+  fNbAbsorCmd->SetParameterName("NbAbsor",false);
+  fNbAbsorCmd->SetRange("NbAbsor>0");
+  fNbAbsorCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  fNbAbsorCmd->SetToBeBroadcasted(false);
+  //
+  fFieldCmd = new G4UIcmdWith3VectorAndUnit("/testem/det/setField",this);
+  fFieldCmd->SetGuidance("Set the constant magenetic field vector.");
+  fFieldCmd->SetUnitCategory("Magnetic flux density");
+  fFieldCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  fFieldCmd->SetToBeBroadcasted(false);
+  // 
+  fAbsorCmd = new G4UIcommand("/testem/det/setAbsor",this);
+  fAbsorCmd->SetGuidance("Set the absor nb, the material, the thickness.");
+  fAbsorCmd->SetGuidance("  absor number : from 1 to NbOfAbsor");
+  fAbsorCmd->SetGuidance("  material name");
+  fAbsorCmd->SetGuidance("  thickness (with unit) : t>0."); 
+  //
+  G4UIparameter* AbsNbPrm = new G4UIparameter("AbsorNb",'i',false);
+  AbsNbPrm->SetGuidance("absor number : from 1 to NbOfAbsor");
+  AbsNbPrm->SetParameterRange("AbsorNb>0");
+  fAbsorCmd->SetParameter(AbsNbPrm);
+  //
+  G4UIparameter* MatPrm = new G4UIparameter("material",'s',false);
+  MatPrm->SetGuidance("material name");
+  fAbsorCmd->SetParameter(MatPrm);
+  //    
+  G4UIparameter* ThickPrm = new G4UIparameter("thickness",'d',false);
+  ThickPrm->SetGuidance("thickness of absorber");
+  ThickPrm->SetParameterRange("thickness>0.");
+  fAbsorCmd->SetParameter(ThickPrm);
+  //
+  G4UIparameter* unitPrm = new G4UIparameter("unit",'s',false);
+  unitPrm->SetGuidance("unit of thickness");
+  G4String unitList = G4UIcommand::UnitsList(G4UIcommand::CategoryOf("mm"));
+  unitPrm->SetParameterCandidates(unitList);
+  fAbsorCmd->SetParameter(unitPrm);
+  //
+  fAbsorCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  fAbsorCmd->SetToBeBroadcasted(false);  
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+DetectorMessenger::~DetectorMessenger()
+{
+  delete fSizeYZCmd;
+  delete fNbLayersCmd;
+  delete fNbAbsorCmd;
+  delete fAbsorCmd;
+  delete fFieldCmd;
+  delete fDetDir;  
+  delete fTestemDir;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
+{
+  if( command == fSizeYZCmd )
+   { fDetector->SetCalorSizeYZ(fSizeYZCmd->GetNewDoubleValue(newValue));}
+
+  if( command == fNbLayersCmd )
+   { fDetector->SetNbOfLayers(fNbLayersCmd->GetNewIntValue(newValue));}
+
+  if( command == fNbAbsorCmd )
+   { fDetector->SetNbOfAbsor(fNbAbsorCmd->GetNewIntValue(newValue));}
+
+  if( command == fFieldCmd )
+   { fDetector->SetMagField(fFieldCmd->GetNew3VectorValue(newValue));}
+   
+  if (command == fAbsorCmd)
+   {
+     G4int num; G4double tick;
+     G4String unt, mat;
+     std::istringstream is(newValue);
+     is >> num >> mat >> tick >> unt;
+     G4String material=mat;
+     tick *= G4UIcommand::ValueOf(unt);
+     fDetector->SetAbsorMaterial (num,material);
+     fDetector->SetAbsorThickness(num,tick);
+   }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/EmAcceptance.cc
+++ b/apps/examples/TestEm3/src/EmAcceptance.cc
@@ -1,0 +1,82 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/EmAcceptance.cc
+/// \brief Implementation of the Emeptance class
+//
+// $Id: EmAcceptance.cc 67268 2013-02-13 11:38:40Z ihrivnac $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "EmAcceptance.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+EmAcceptance::EmAcceptance()
+ : fIsAccepted(false)
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+EmAcceptance::~EmAcceptance()
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void EmAcceptance::BeginOfAcceptance(const G4String& title, G4int stat)
+{
+  G4cout << "\n<<<<<ACCEPTANCE>>>>> " << stat << " events for " << title 
+         << G4endl;
+  fIsAccepted = true;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void EmAcceptance::EndOfAcceptance()
+{
+  G4String resume = "IS ACCEPTED";
+  if (!fIsAccepted) resume = "IS NOT ACCEPTED";
+  G4cout << "<<<<<END>>>>>   " << resume << G4endl;
+  G4cout << G4endl;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void EmAcceptance::EmAcceptanceGauss(const G4String& title, G4int stat,
+                                           G4double avr, G4double avr0,
+                                           G4double rms, G4double limit)
+{
+  G4double x = std::sqrt((G4double)stat);
+  G4double dde = avr - avr0;
+  G4double de = dde*x/rms;
+
+  G4cout << title << ": " << avr << "  del"<< title << "= " << dde
+         << " nrms= " << de << G4endl;
+
+  if (std::fabs(de) > limit) fIsAccepted = false;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/EventAction.cc
+++ b/apps/examples/TestEm3/src/EventAction.cc
@@ -1,0 +1,80 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/EventAction.cc
+/// \brief Implementation of the EventAction class
+//
+// $Id: EventAction.cc 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "EventAction.hh"
+
+#include "Run.hh"
+#include "HistoManager.hh"
+
+#include "G4RunManager.hh"
+#include "G4Event.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+EventAction::EventAction(DetectorConstruction* det)
+:G4UserEventAction(),fDetector(det)
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+EventAction::~EventAction()
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void EventAction::BeginOfEventAction(const G4Event*)
+{       
+  //initialize EnergyDeposit per event
+  //
+  for (G4int k=0; k<kMaxAbsor; k++) {
+    fEnergyDeposit[k] = fTrackLengthCh[k] = 0.0;   
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void EventAction::EndOfEventAction(const G4Event*)
+{
+  //get Run
+  Run* run = static_cast<Run*>(
+             G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+             
+  for (G4int k=1; k<=fDetector->GetNbOfAbsor(); k++) {
+     run->FillPerEvent(k,fEnergyDeposit[k],fTrackLengthCh[k]);
+     if (fEnergyDeposit[k] > 0.)
+             G4AnalysisManager::Instance()->FillH1(k, fEnergyDeposit[k]);
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+

--- a/apps/examples/TestEm3/src/HistoManager.cc
+++ b/apps/examples/TestEm3/src/HistoManager.cc
@@ -1,0 +1,86 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+//
+// $Id: HistoManager.cc 98762 2016-08-09 14:08:07Z gcosmo $
+// 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "HistoManager.hh"
+#include "G4UnitsTable.hh"
+#include "DetectorConstruction.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+HistoManager::HistoManager()
+  : fFileName("testem3")
+{
+  Book();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+HistoManager::~HistoManager()
+{
+  delete G4AnalysisManager::Instance();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void HistoManager::Book()
+{
+  // Create or get analysis manager
+  // The choice of analysis technology is done via selection of a namespace
+  // in HistoManager.hh
+  G4AnalysisManager* analysisManager = G4AnalysisManager::Instance();
+  analysisManager->SetFileName(fFileName);
+  analysisManager->SetVerboseLevel(1);
+  analysisManager->SetActivation(true);   // enable inactivation of histograms
+
+  // Define histograms start values
+  
+  const G4String id[] = { "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+                         "10","11","12","13","14","15","16","17","18","19",
+                         "20","21","22"};
+  G4String title;
+
+  // Default values (to be reset via /analysis/h1/set command)
+  G4int nbins = 100;
+  G4double vmin = 0.;
+  G4double vmax = 100.;
+  
+  // Create all histograms as inactivated 
+  // as we have not yet set nbins, vmin, vmax
+  for (G4int k=0; k<kMaxHisto; k++) {
+    if (k < kMaxAbsor) title = "Edep in absorber " + id[k];
+    if (k > kMaxAbsor) title = "Edep longit. profile (MeV/event) in absorber "
+                               + id[k-kMaxAbsor];
+    if (k == 2*kMaxAbsor+1) title = "energy flow (MeV/event)";
+    if (k == 2*kMaxAbsor+2) title = "lateral energy leak (MeV/event)";
+    G4int ih = analysisManager->CreateH1(id[k], title, nbins, vmin, vmax);
+    analysisManager->SetH1Activation(ih, false);
+  }
+}

--- a/apps/examples/TestEm3/src/PhysListEmStandard.cc
+++ b/apps/examples/TestEm3/src/PhysListEmStandard.cc
@@ -1,0 +1,194 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+// $Id: PhysListEmStandard.cc 92914 2015-09-21 15:00:48Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "PhysListEmStandard.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4ProcessManager.hh"
+#include "G4PhysicsListHelper.hh"
+
+#include "G4ComptonScattering.hh"
+#include "G4GammaConversion.hh"
+#include "G4PhotoElectricEffect.hh"
+#include "G4RayleighScattering.hh"
+#include "G4KleinNishinaModel.hh"
+
+#include "G4eMultipleScattering.hh"
+#include "G4eIonisation.hh"
+#include "G4eBremsstrahlung.hh"
+#include "G4eplusAnnihilation.hh"
+
+#include "G4MuMultipleScattering.hh"
+#include "G4MuIonisation.hh"
+#include "G4MuBremsstrahlung.hh"
+#include "G4MuPairProduction.hh"
+
+#include "G4hMultipleScattering.hh"
+#include "G4hIonisation.hh"
+#include "G4hBremsstrahlung.hh"
+#include "G4hPairProduction.hh"
+
+#include "G4ionIonisation.hh"
+#include "G4IonParametrisedLossModel.hh"
+#include "G4NuclearStopping.hh"
+
+#include "G4EmParameters.hh"
+#include "G4MscStepLimitType.hh"
+
+#include "G4BuilderType.hh"
+#include "G4LossTableManager.hh"
+#include "G4UAtomicDeexcitation.hh"
+
+#include "G4SystemOfUnits.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PhysListEmStandard::PhysListEmStandard(const G4String& name)
+   :  G4VPhysicsConstructor(name)
+{
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(1);
+  param->SetMinEnergy(10*eV);
+  param->SetMaxEnergy(10*TeV);
+  param->SetLowestElectronEnergy(100*eV);
+  param->SetNumberOfBinsPerDecade(20);
+  param->SetMscStepLimitType(fUseSafetyPlus);
+  param->SetFluo(true);
+  param->SetAuger(false);
+  param->SetPixe(false);
+  SetPhysicsType(bElectromagnetic);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PhysListEmStandard::~PhysListEmStandard()
+{}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PhysListEmStandard::ConstructProcess()
+{
+  G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // Add standard EM Processes
+  //
+  auto aParticleIterator = GetParticleIterator();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
+    G4String particleName = particle->GetParticleName();
+
+    if (particleName == "gamma") {
+
+      ////ph->RegisterProcess(new G4RayleighScattering, particle);
+      ph->RegisterProcess(new G4PhotoElectricEffect, particle);
+      G4ComptonScattering* cs   = new G4ComptonScattering;
+      cs->SetEmModel(new G4KleinNishinaModel());
+      ph->RegisterProcess(cs, particle);
+      ph->RegisterProcess(new G4GammaConversion, particle);
+
+    } else if (particleName == "e-") {
+
+      ph->RegisterProcess(new G4eMultipleScattering(), particle);
+      //
+      G4eIonisation* eIoni = new G4eIonisation();
+      eIoni->SetStepFunction(0.1, 100*um);
+      ph->RegisterProcess(eIoni, particle);
+      //
+      ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+
+    } else if (particleName == "e+") {
+
+      ph->RegisterProcess(new G4eMultipleScattering(), particle);
+      //
+      G4eIonisation* eIoni = new G4eIonisation();
+      eIoni->SetStepFunction(0.1, 100*um);
+      ph->RegisterProcess(eIoni, particle);
+      //
+      ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+      //
+      ph->RegisterProcess(new G4eplusAnnihilation(), particle);
+
+    } else if (particleName == "mu+" ||
+               particleName == "mu-"    ) {
+
+      ph->RegisterProcess(new G4MuMultipleScattering(), particle);
+      G4MuIonisation* muIoni = new G4MuIonisation();
+      muIoni->SetStepFunction(0.1, 50*um);
+      ph->RegisterProcess(muIoni, particle);
+      ph->RegisterProcess(new G4MuBremsstrahlung(), particle);
+      ph->RegisterProcess(new G4MuPairProduction(), particle);
+
+    } else if( particleName == "proton" ||
+               particleName == "pi-" ||
+               particleName == "pi+"    ) {
+
+      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      G4hIonisation* hIoni = new G4hIonisation();
+      hIoni->SetStepFunction(0.1, 20*um);
+      ph->RegisterProcess(hIoni, particle);
+      ph->RegisterProcess(new G4hBremsstrahlung(), particle);
+      ph->RegisterProcess(new G4hPairProduction(), particle);
+
+    } else if( particleName == "alpha" ||
+               particleName == "He3"    ) {
+
+      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      G4ionIonisation* ionIoni = new G4ionIonisation();
+      ionIoni->SetStepFunction(0.1, 1*um);
+      ph->RegisterProcess(ionIoni, particle);
+      ph->RegisterProcess(new G4NuclearStopping(), particle);
+
+    } else if( particleName == "GenericIon" ) {
+
+      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      G4ionIonisation* ionIoni = new G4ionIonisation();
+      ionIoni->SetEmModel(new G4IonParametrisedLossModel());
+      ionIoni->SetStepFunction(0.1, 1*um);
+      ph->RegisterProcess(ionIoni, particle);
+      ph->RegisterProcess(new G4NuclearStopping(), particle);
+
+    } else if ((!particle->IsShortLived()) &&
+               (particle->GetPDGCharge() != 0.0) &&
+               (particle->GetParticleName() != "chargedgeantino")) {
+
+      //all others charged particles except geantino
+      ph->RegisterProcess(new G4hMultipleScattering(), particle);
+      ph->RegisterProcess(new G4hIonisation(), particle);
+    }
+  }
+
+  // Deexcitation
+  //
+  G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
+  G4LossTableManager::Instance()->SetAtomDeexcitation(de);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/PhysListG4Em.cc
+++ b/apps/examples/TestEm3/src/PhysListG4Em.cc
@@ -1,0 +1,136 @@
+
+#include "PhysListG4Em.hh"
+
+#include "G4ParticleDefinition.hh"
+#include "G4ProcessManager.hh"
+#include "G4PhysicsListHelper.hh"
+
+#include "G4ComptonScattering.hh"
+//#include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
+
+#include "G4GammaConversion.hh"
+#include "G4PhotoElectricEffect.hh"
+#include "G4LivermorePhotoElectricModel.hh"
+//#include "G4RayleighScattering.hh"
+
+#include "G4eMultipleScattering.hh"
+#include "G4GoudsmitSaundersonMscModel.hh"
+#include "G4eIonisation.hh"
+#include "G4eBremsstrahlung.hh"
+#include "G4eplusAnnihilation.hh"
+
+#include "G4EmParameters.hh"
+#include "G4MscStepLimitType.hh"
+
+#include "G4BuilderType.hh"
+#include "G4LossTableManager.hh"
+//#include "G4UAtomicDeexcitation.hh"
+
+#include "G4SystemOfUnits.hh"
+
+
+PhysListG4Em::PhysListG4Em(const G4String& name) : G4VPhysicsConstructor(name) {
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(1);
+  // inactivate energy loss fluctuations
+  param->SetLossFluctuations(false);
+//  param->SetEnableSamplingTable(true);
+  // set min/max energy for tables: 100 eV - 100 TeV by default
+  //param->SetMinEnergy(100*eV);
+  //param->SetMaxEnergy(100*TeV);
+  // set lowest kinetic energy i.e. tracking cut for charged particles having energy loss process: 1 keV by default
+  // param->SetLowestElectronEnergy(1.*keV);
+  // activate/inactivate integral approach: true by default
+  // param->SetIntegral(true);
+  // inactivate to use cuts as final range
+  param->SetUseCutAsFinalRange(false);
+
+  //
+  // MSC options and parameters: 3 different stepping algorithms (can be set from the G4 macro)
+  // 1. fUseSafety: opt0 step limit [corresponds to G4-Urban fUseSafety]
+  param->SetMscStepLimitType(fUseSafety);
+  // 2. fUseDistanceToBoundary: opt3 step limit [corresponds to G4-Urban fUseDistanceToBoundary]
+  // param->SetMscStepLimitType(fUseDistanceToBoundary);
+  // 3. fUseSafetyPlus: error free G4-GS stepping [there is no corresponding G4-Urban]
+  // param->SetMscStepLimitType(fUseSafetyPlus);
+  // Skin depth: times elastic mean free path skin near boundaries (can be set from the G4 macro)
+  // - used by the G4-GS model when fUseDistanceToBoundary and fUseSafety stepping is set)
+  param->SetMscSkin(3);
+  // Range factor: (can be set from the G4 macro)
+  param->SetMscRangeFactor(0.06);
+  //
+  SetPhysicsType(bElectromagnetic);
+}
+
+
+PhysListG4Em::~PhysListG4Em() {}
+
+
+void PhysListG4Em::ConstructProcess() {
+  G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // Add standard EM Processes
+  //
+  auto aParticleIterator = GetParticleIterator();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
+    G4String particleName = particle->GetParticleName();
+
+    if (particleName == "gamma") {
+      ph->RegisterProcess(new G4ComptonScattering(), particle);
+      ph->RegisterProcess(new G4GammaConversion, particle);
+      G4double LivermoreLowEnergyLimit = 1*eV;
+      G4double LivermoreHighEnergyLimit = 1*TeV;
+      G4PhotoElectricEffect* thePhotoElectricEffect = new G4PhotoElectricEffect();
+      G4LivermorePhotoElectricModel* theLivermorePhotoElectricModel = new G4LivermorePhotoElectricModel();
+      theLivermorePhotoElectricModel->SetLowEnergyLimit(LivermoreLowEnergyLimit);
+      theLivermorePhotoElectricModel->SetHighEnergyLimit(LivermoreHighEnergyLimit);
+      thePhotoElectricEffect->AddEmModel(0, theLivermorePhotoElectricModel);
+      ph->RegisterProcess(thePhotoElectricEffect, particle);
+    } else if (particleName == "e-") {
+
+// //     ph->RegisterProcess(new G4eMultipleScattering(), particle);
+
+/*
+      G4eMultipleScattering* msc = new G4eMultipleScattering;
+      G4GoudsmitSaundersonMscModel* msc1 = new G4GoudsmitSaundersonMscModel();
+      msc->AddEmModel(0, msc1);
+      ph->RegisterProcess(msc,particle);
+
+*/
+
+
+
+      //
+      G4eIonisation* eIoni = new G4eIonisation();
+      ph->RegisterProcess(eIoni, particle);
+      
+      ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+    } else if (particleName == "e+") {
+//      ph->RegisterProcess(new G4eMultipleScattering(), particle);
+
+/*
+      G4eMultipleScattering* msc = new G4eMultipleScattering;
+      G4GoudsmitSaundersonMscModel* msc1 = new G4GoudsmitSaundersonMscModel();
+      msc->AddEmModel(0, msc1);
+      ph->RegisterProcess(msc,particle);
+*/      
+     
+
+//      G4eIonisation* eIoni = new G4eIonisation();
+//      ph->RegisterProcess(eIoni, particle);
+//      ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+      //
+//      ph->RegisterProcess(new G4eplusAnnihilation(), particle);
+    }
+  }
+
+  
+  // Deexcitation
+  //
+//  G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
+//  G4LossTableManager::Instance()->SetAtomDeexcitation(de);
+}
+

--- a/apps/examples/TestEm3/src/PhysListHepEm.cc
+++ b/apps/examples/TestEm3/src/PhysListHepEm.cc
@@ -1,0 +1,118 @@
+
+#include "PhysListHepEm.hh"
+
+// include the G4HepEmProcess from the G4HepEm lib.
+#include "G4HepEmProcess.hh"
+
+#include "G4ParticleDefinition.hh"
+#include "G4ProcessManager.hh"
+#include "G4PhysicsListHelper.hh"
+
+#include "G4ComptonScattering.hh"
+//#include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
+
+#include "G4GammaConversion.hh"
+#include "G4PhotoElectricEffect.hh"
+#include "G4LivermorePhotoElectricModel.hh"
+//#include "G4RayleighScattering.hh"
+
+#include "G4eMultipleScattering.hh"
+#include "G4GoudsmitSaundersonMscModel.hh"
+#include "G4eIonisation.hh"
+#include "G4eBremsstrahlung.hh"
+#include "G4eplusAnnihilation.hh"
+
+#include "G4EmParameters.hh"
+#include "G4MscStepLimitType.hh"
+
+#include "G4BuilderType.hh"
+#include "G4LossTableManager.hh"
+//#include "G4UAtomicDeexcitation.hh"
+
+#include "G4SystemOfUnits.hh"
+
+
+PhysListHepEm::PhysListHepEm(const G4String& name) : G4VPhysicsConstructor(name) {
+  G4EmParameters* param = G4EmParameters::Instance();
+  param->SetDefaults();
+  param->SetVerbose(1);
+  // inactivate energy loss fluctuations
+  param->SetLossFluctuations(false);
+//  param->SetEnableSamplingTable(true);
+  // set min/max energy for tables: 100 eV - 100 TeV by default
+  //param->SetMinEnergy(100*eV);
+  //param->SetMaxEnergy(100*TeV);
+  // set lowest kinetic energy i.e. tracking cut for charged particles having energy loss process: 1 keV by default
+  // param->SetLowestElectronEnergy(1.*keV);
+  // activate/inactivate integral approach: true by default
+  // param->SetIntegral(true);
+  // inactivate to use cuts as final range
+  param->SetUseCutAsFinalRange(false);
+
+  //
+  // MSC options and parameters: 3 different stepping algorithms (can be set from the G4 macro)
+  // 1. fUseSafety: opt0 step limit [corresponds to G4-Urban fUseSafety]
+  param->SetMscStepLimitType(fUseSafety);
+  // 2. fUseDistanceToBoundary: opt3 step limit [corresponds to G4-Urban fUseDistanceToBoundary]
+  // param->SetMscStepLimitType(fUseDistanceToBoundary);
+  // 3. fUseSafetyPlus: error free G4-GS stepping [there is no corresponding G4-Urban]
+  // param->SetMscStepLimitType(fUseSafetyPlus);
+  // Skin depth: times elastic mean free path skin near boundaries (can be set from the G4 macro)
+  // - used by the G4-GS model when fUseDistanceToBoundary and fUseSafety stepping is set)
+  param->SetMscSkin(3);
+  // Range factor: (can be set from the G4 macro)
+  param->SetMscRangeFactor(0.06);
+  //
+  SetPhysicsType(bElectromagnetic);
+}
+
+
+PhysListHepEm::~PhysListHepEm() {}
+
+
+void PhysListHepEm::ConstructProcess() {
+  G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
+  G4HepEmProcess* hepEmProcess = new G4HepEmProcess();
+
+  // Add standard EM Processes
+  //
+  auto aParticleIterator = GetParticleIterator();
+  aParticleIterator->reset();
+  while( (*aParticleIterator)() ){
+    G4ParticleDefinition* particle = aParticleIterator->value();
+    G4String particleName = particle->GetParticleName();
+
+    if (particleName == "gamma") {
+      ph->RegisterProcess(new G4ComptonScattering(), particle);
+      ph->RegisterProcess(new G4GammaConversion, particle);
+      G4double LivermoreLowEnergyLimit = 1*eV;
+      G4double LivermoreHighEnergyLimit = 1*TeV;
+      G4PhotoElectricEffect* thePhotoElectricEffect = new G4PhotoElectricEffect();
+      G4LivermorePhotoElectricModel* theLivermorePhotoElectricModel = new G4LivermorePhotoElectricModel();
+      theLivermorePhotoElectricModel->SetLowEnergyLimit(LivermoreLowEnergyLimit);
+      theLivermorePhotoElectricModel->SetHighEnergyLimit(LivermoreHighEnergyLimit);
+      thePhotoElectricEffect->AddEmModel(0, theLivermorePhotoElectricModel);
+      ph->RegisterProcess(thePhotoElectricEffect, particle);
+    } else if (particleName == "e-") {
+
+      // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
+      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, 0, -1);
+
+    } else if (particleName == "e+") {
+
+      // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e- 
+      // annihilation into 2 gamma interactions for e+
+//      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, 0, -1);
+
+    }
+  }
+
+  
+  // Deexcitation
+  //
+//  G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
+//  G4LossTableManager::Instance()->SetAtomDeexcitation(de);
+}
+

--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -1,0 +1,308 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/PhysicsList.cc
+/// \brief Implementation of the PhysicsList class
+//
+// $Id: PhysicsList.cc 95227 2016-02-01 09:19:15Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "PhysicsList.hh"
+#include "PhysicsListMessenger.hh"
+
+#include "PhysListEmStandard.hh"
+#include "PhysListHepEm.hh"
+#include "PhysListG4Em.hh"
+
+#include "G4EmStandardPhysics.hh"
+#include "G4EmStandardPhysics_option1.hh"
+#include "G4EmStandardPhysics_option2.hh"
+#include "G4EmStandardPhysics_option3.hh"
+#include "G4EmStandardPhysics_option4.hh"
+#include "G4EmStandardPhysicsWVI.hh"
+#include "G4EmStandardPhysicsGS.hh"
+#include "G4EmStandardPhysicsSS.hh"
+
+#include "G4EmLivermorePhysics.hh"
+#include "G4EmPenelopePhysics.hh"
+#include "G4EmLowEPPhysics.hh"
+
+#include "G4LossTableManager.hh"
+#include "G4UnitsTable.hh"
+#include "G4SystemOfUnits.hh"
+
+// particles
+
+#include "G4BosonConstructor.hh"
+#include "G4LeptonConstructor.hh"
+#include "G4MesonConstructor.hh"
+#include "G4BosonConstructor.hh"
+#include "G4BaryonConstructor.hh"
+#include "G4IonConstructor.hh"
+#include "G4ShortLivedConstructor.hh"
+
+
+// HepEm: the G4HepEm EM phyics constructor is (see PhysListHepEm)
+// G4Em : the G4 EM phyics constructor, that is equivalent to the G4HepEm, is (see PhysListG4Em)
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PhysicsList::PhysicsList() : G4VModularPhysicsList(),
+ fEmPhysicsList(0), fStepMaxProcess(0), fMessenger(0)
+{
+  G4LossTableManager::Instance();
+  SetDefaultCutValue(1*mm);
+
+  fMessenger = new PhysicsListMessenger(this);
+  SetVerboseLevel(1);
+
+  // EM physics: set to HepEm by def.
+  fEmName        = G4String("HepEm");
+  fEmPhysicsList = new PhysListHepEm(fEmName);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PhysicsList::~PhysicsList()
+{
+  delete fMessenger;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PhysicsList::ConstructParticle()
+{
+    G4BosonConstructor  pBosonConstructor;
+    pBosonConstructor.ConstructParticle();
+
+    G4LeptonConstructor pLeptonConstructor;
+    pLeptonConstructor.ConstructParticle();
+
+    G4MesonConstructor pMesonConstructor;
+    pMesonConstructor.ConstructParticle();
+
+    G4BaryonConstructor pBaryonConstructor;
+    pBaryonConstructor.ConstructParticle();
+
+    G4IonConstructor pIonConstructor;
+    pIonConstructor.ConstructParticle();
+
+    G4ShortLivedConstructor pShortLivedConstructor;
+    pShortLivedConstructor.ConstructParticle();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "G4ProcessManager.hh"
+
+void PhysicsList::ConstructProcess()
+{
+  // Transportation
+  //
+  AddTransportation();
+
+  // electromagnetic Physics List
+  //
+  fEmPhysicsList->ConstructProcess();
+  // add other processes if not HepEm physics list is used
+  if (fEmName!="HepEm" && fEmName!="G4Em" ) {
+    // decay Process
+    AddDecay();
+    // radioactive decay Process
+    AddRadioactiveDecay();
+    // stepLimitation (as a full process)
+    AddStepMax();
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PhysicsList::AddPhysicsList(const G4String& name)
+{
+  if (verboseLevel>1) {
+    G4cout << "PhysicsList::AddPhysicsList: <" << name << ">" << G4endl;
+  }
+
+  if (name == fEmName) return;
+
+  if (name == "local") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new PhysListEmStandard(name);
+
+  } else if (name == "HepEm") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new PhysListHepEm();
+
+  } else if (name == "G4Em") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new PhysListG4Em();
+
+  } else if (name == "emstandard_opt0") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysics();
+
+  } else if (name == "emstandard_opt1") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysics_option1();
+
+  } else if (name == "emstandard_opt2") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysics_option2();
+
+  } else if (name == "emstandard_opt3") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysics_option3();
+
+  } else if (name == "emstandard_opt4") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysics_option4();
+
+  } else if (name == "emstandardWVI") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysicsWVI();
+
+  } else if (name == "emstandardGS") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysicsGS();
+
+  } else if (name == "emstandardSS") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmStandardPhysicsSS();
+
+  } else if (name == "emlivermore") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmLivermorePhysics();
+
+  } else if (name == "empenelope") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmPenelopePhysics();
+
+  } else if (name == "emlowenergy") {
+
+    fEmName = name;
+    delete fEmPhysicsList;
+    fEmPhysicsList = new G4EmLowEPPhysics();
+
+  } else {
+
+    G4cout << "PhysicsList::AddPhysicsList: <" << name << ">"
+           << " is not defined"
+           << G4endl;
+  }
+}
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "G4PhysicsListHelper.hh"
+#include "G4Decay.hh"
+
+void PhysicsList::AddDecay()
+{
+  G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+
+  // Decay Process
+  //
+  G4Decay* fDecayProcess = new G4Decay();
+
+  auto theParticleIterator = GetParticleIterator();
+  theParticleIterator->reset();
+  while( (*theParticleIterator)() ){
+    G4ParticleDefinition* particle = theParticleIterator->value();
+    if (fDecayProcess->IsApplicable(*particle))
+      ph->RegisterProcess(fDecayProcess, particle);
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "G4PhysicsListHelper.hh"
+#include "G4RadioactiveDecay.hh"
+#include "G4GenericIon.hh"
+#include "G4NuclideTable.hh"
+
+void PhysicsList::AddRadioactiveDecay()
+{
+  G4RadioactiveDecay* radioactiveDecay = new G4RadioactiveDecay();
+
+  radioactiveDecay->SetARM(true);                //Atomic Rearangement
+
+  G4PhysicsListHelper* ph = G4PhysicsListHelper::GetPhysicsListHelper();
+  ph->RegisterProcess(radioactiveDecay, G4GenericIon::GenericIon());
+
+  // mandatory for G4NuclideTable
+  //
+  G4NuclideTable::GetInstance()->SetThresholdOfHalfLife(0.1*picosecond);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "StepMax.hh"
+
+void PhysicsList::AddStepMax()
+{
+  // Step limitation seen as a process
+  fStepMaxProcess = new StepMax();
+
+  auto theParticleIterator = GetParticleIterator();
+  theParticleIterator->reset();
+  while ((*theParticleIterator)()){
+      G4ParticleDefinition* particle = theParticleIterator->value();
+      G4ProcessManager* pmanager = particle->GetProcessManager();
+
+      if (fStepMaxProcess->IsApplicable(*particle))
+        {
+          pmanager ->AddDiscreteProcess(fStepMaxProcess);
+        }
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/PhysicsListMessenger.cc
+++ b/apps/examples/TestEm3/src/PhysicsListMessenger.cc
@@ -1,0 +1,74 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/PhysicsListMessenger.cc
+/// \brief Implementation of the PhysicsListMessenger class
+//
+// $Id: PhysicsListMessenger.cc 82038 2014-06-10 07:58:08Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "PhysicsListMessenger.hh"
+
+#include "PhysicsList.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcmdWithADoubleAndUnit.hh"
+#include "G4UIcmdWithAString.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PhysicsListMessenger::PhysicsListMessenger(PhysicsList* pPhys)
+:G4UImessenger(),fPhysicsList(pPhys),
+ fPhysDir(0),
+ fListCmd(0)
+{
+  fPhysDir = new G4UIdirectory("/testem/phys/");
+  fPhysDir->SetGuidance("physics list commands");
+
+  fListCmd = new G4UIcmdWithAString("/testem/phys/addPhysics",this);
+  fListCmd->SetGuidance("Add modular physics list.");
+  fListCmd->SetParameterName("PList",false);
+  fListCmd->AvailableForStates(G4State_PreInit);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PhysicsListMessenger::~PhysicsListMessenger()
+{
+  delete fListCmd;
+  delete fPhysDir;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PhysicsListMessenger::SetNewValue(G4UIcommand* command,
+                                          G4String newValue)
+{
+  if( command == fListCmd )
+   { fPhysicsList->AddPhysicsList(newValue);}
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/PrimaryGeneratorAction.cc
+++ b/apps/examples/TestEm3/src/PrimaryGeneratorAction.cc
@@ -1,0 +1,109 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/PrimaryGeneratorAction.cc
+/// \brief Implementation of the PrimaryGeneratorAction class
+//
+// $Id: PrimaryGeneratorAction.cc 67268 2013-02-13 11:38:40Z ihrivnac $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "PrimaryGeneratorAction.hh"
+
+#include "PrimaryGeneratorMessenger.hh"
+#include "DetectorConstruction.hh"
+#include "HistoManager.hh"
+
+#include "G4Event.hh"
+#include "G4ParticleGun.hh"
+#include "G4ParticleTable.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4SystemOfUnits.hh"
+#include "Randomize.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PrimaryGeneratorAction::PrimaryGeneratorAction(DetectorConstruction* det)
+:G4VUserPrimaryGeneratorAction(),
+ fParticleGun(0),
+ fDetector(det),   
+ fRndmBeam(0.),  
+ fGunMessenger(0)
+{
+  G4int n_particle = 1;
+  fParticleGun  = new G4ParticleGun(n_particle);
+  SetDefaultKinematic();
+  
+  //create a messenger for this class
+  fGunMessenger = new PrimaryGeneratorMessenger(this);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PrimaryGeneratorAction::~PrimaryGeneratorAction()
+{
+  delete fParticleGun;
+  delete fGunMessenger;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PrimaryGeneratorAction::SetDefaultKinematic()
+{
+  G4ParticleTable* particleTable = G4ParticleTable::GetParticleTable();
+  G4String particleName;
+  G4ParticleDefinition* particle
+                    = particleTable->FindParticle(particleName="e-");
+  fParticleGun->SetParticleDefinition(particle);
+  fParticleGun->SetParticleMomentumDirection(G4ThreeVector(1.,0.,0.));
+  fParticleGun->SetParticleEnergy(1.*GeV);
+  G4double position = -0.25 * (fDetector->GetWorldSizeX() + fDetector->GetCalorThickness());
+  fParticleGun->SetParticlePosition(G4ThreeVector(position,0.*cm,0.*cm));
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PrimaryGeneratorAction::GeneratePrimaries(G4Event* anEvent)
+{
+  //this function is called at the begining of event
+  //
+  //randomize the beam, if requested.
+  if (fRndmBeam > 0.) 
+    {
+      G4ThreeVector oldPosition = fParticleGun->GetParticlePosition();    
+      G4double rbeam = 0.5*(fDetector->GetCalorSizeYZ())*fRndmBeam;
+      G4double x0 = oldPosition.x();
+      G4double y0 = oldPosition.y() + (2*G4UniformRand()-1.)*rbeam;
+      G4double z0 = oldPosition.z() + (2*G4UniformRand()-1.)*rbeam;
+      fParticleGun->SetParticlePosition(G4ThreeVector(x0,y0,z0));
+      fParticleGun->GeneratePrimaryVertex(anEvent);
+      fParticleGun->SetParticlePosition(oldPosition);      
+    }
+  else  fParticleGun->GeneratePrimaryVertex(anEvent);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+

--- a/apps/examples/TestEm3/src/PrimaryGeneratorMessenger.cc
+++ b/apps/examples/TestEm3/src/PrimaryGeneratorMessenger.cc
@@ -1,0 +1,87 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/PrimaryGeneratorMessenger.cc
+/// \brief Implementation of the PrimaryGeneratorMessenger class
+//
+// $Id: PrimaryGeneratorMessenger.cc 67268 2013-02-13 11:38:40Z ihrivnac $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "PrimaryGeneratorMessenger.hh"
+
+#include "PrimaryGeneratorAction.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcmdWithoutParameter.hh"
+#include "G4UIcmdWithADouble.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PrimaryGeneratorMessenger::PrimaryGeneratorMessenger(
+                                             PrimaryGeneratorAction* Gun)
+:G4UImessenger(),fAction(Gun),
+ fGunDir(0),      
+ fDefaultCmd(0),
+ fRndmCmd(0)
+{
+  fGunDir = new G4UIdirectory("/testem/gun/");
+  fGunDir->SetGuidance("gun control");
+   
+  fDefaultCmd = new G4UIcmdWithoutParameter("/testem/gun/setDefault",this);
+  fDefaultCmd->SetGuidance("set/reset kinematic defined in PrimaryGenerator");
+  fDefaultCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
+  
+  fRndmCmd = new G4UIcmdWithADouble("/testem/gun/rndm",this);
+  fRndmCmd->SetGuidance("random lateral extension on the beam");
+  fRndmCmd->SetGuidance("in fraction of 0.5*sizeYZ");
+  fRndmCmd->SetParameterName("rBeam",false);
+  fRndmCmd->SetRange("rBeam>=0.&&rBeam<=1.");
+  fRndmCmd->AvailableForStates(G4State_Idle);  
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+PrimaryGeneratorMessenger::~PrimaryGeneratorMessenger()
+{
+  delete fDefaultCmd;
+  delete fRndmCmd;
+  delete fGunDir;  
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void PrimaryGeneratorMessenger::SetNewValue(G4UIcommand* command,
+                                               G4String newValue)
+{ 
+  if( command == fDefaultCmd )
+   { fAction->SetDefaultKinematic();}
+   
+  if( command == fRndmCmd )
+   { fAction->SetRndmBeam(fRndmCmd->GetNewDoubleValue(newValue));}   
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+

--- a/apps/examples/TestEm3/src/Run.cc
+++ b/apps/examples/TestEm3/src/Run.cc
@@ -1,0 +1,392 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/Run.cc
+/// \brief Implementation of the Run class
+//
+// $Id: Run.cc 71376 2013-06-14 07:44:50Z maire $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "Run.hh"
+#include "DetectorConstruction.hh"
+#include "PrimaryGeneratorAction.hh"
+#include "HistoManager.hh"
+#include "EmAcceptance.hh"
+
+#include "G4ParticleTable.hh"
+#include "G4ParticleDefinition.hh"
+#include "G4Track.hh"
+#include "G4Gamma.hh"
+#include "G4Electron.hh"
+#include "G4Positron.hh"
+
+#include "G4UnitsTable.hh"
+#include "G4SystemOfUnits.hh"
+
+#include <iomanip>
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+Run::Run(DetectorConstruction* det)
+: G4Run(),
+  fDetector(det),
+  fParticle(0), fEkin(0.),
+  fChargedStep(0), fNeutralStep(0),
+  fN_gamma(0), fN_elec(0), fN_pos(0),
+  fApplyLimit(false)
+{
+  //initialize cumulative quantities
+  //
+  for (G4int k=0; k<kMaxAbsor; k++) {
+    fSumEAbs[k] = fSum2EAbs[k]  = fSumLAbs[k] = fSum2LAbs[k] = 0.;
+    fEnergyDeposit[k].clear();
+    fEdeptrue[k] = fRmstrue[k] = 1.;
+    fLimittrue[k] = DBL_MAX;
+  }
+  // set size of the containers for layer by layer data
+  // 
+  fCHTrackLPerLayer.resize(fDetector->GetNbOfLayers(),0.0);
+  fEDepPerLayer.resize(fDetector->GetNbOfLayers(),0.0);
+  //initialize Eflow
+  //
+  G4int nbPlanes = (fDetector->GetNbOfLayers())*(fDetector->GetNbOfAbsor()) + 2;
+  fEnergyFlow.resize(nbPlanes);
+  fLateralEleak.resize(nbPlanes);
+  for (G4int k=0; k<nbPlanes; k++) {fEnergyFlow[k] = fLateralEleak[k] = 0.; }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+Run::~Run()
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::SetPrimary(G4ParticleDefinition* particle, G4double energy)
+{
+  fParticle = particle;
+  fEkin     = energy;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::FillPerEvent(G4int kAbs, G4double EAbs, G4double LAbs)
+{
+  //accumulate statistic with restriction
+  //
+  if(fApplyLimit) fEnergyDeposit[kAbs].push_back(EAbs);
+  fSumEAbs[kAbs]  += EAbs;  fSum2EAbs[kAbs]  += EAbs*EAbs;
+  fSumLAbs[kAbs]  += LAbs;  fSum2LAbs[kAbs]  += LAbs*LAbs;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::SumEnergyFlow(G4int plane, G4double Eflow)
+{
+  fEnergyFlow[plane] += Eflow;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::SumLateralEleak(G4int cell, G4double Eflow)
+{
+  fLateralEleak[cell] += Eflow;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::AddChargedStep()
+{
+  fChargedStep += 1.0;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::AddNeutralStep()
+{
+  fNeutralStep += 1.0;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::AddSecondaryTrack(const G4Track* track)
+{
+  const G4ParticleDefinition* d = track->GetDefinition();
+  if(d == G4Gamma::Gamma()) { fN_gamma += 1.; }
+  else if (d == G4Electron::Electron()) { fN_elec += 1.; }
+  else if (d == G4Positron::Positron()) { fN_pos += 1.; }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::Merge(const G4Run* run)
+{
+  const Run* localRun = static_cast<const Run*>(run);
+
+  // pass information about primary particle
+  fParticle = localRun->fParticle;
+  fEkin     = localRun->fEkin;
+
+  // accumulate sums
+  //
+  for (G4int k=0; k<kMaxAbsor; k++) {
+    fSumEAbs[k]  += localRun->fSumEAbs[k];
+    fSum2EAbs[k] += localRun->fSum2EAbs[k];
+    fSumLAbs[k]  += localRun->fSumLAbs[k];
+    fSum2LAbs[k] += localRun->fSum2LAbs[k];
+  }
+
+  G4int nbPlanes = (fDetector->GetNbOfLayers())*(fDetector->GetNbOfAbsor()) + 2;
+  for (G4int k=0; k<nbPlanes; k++) {
+    fEnergyFlow[k]   += localRun->fEnergyFlow[k];
+    fLateralEleak[k] += localRun->fLateralEleak[k];
+  }
+
+  G4int nbLayers = fDetector->GetNbOfLayers();
+  for (G4int il=0; il<nbLayers; ++il) {
+    fCHTrackLPerLayer[il] += localRun->fCHTrackLPerLayer[il];
+    fEDepPerLayer[il]     += localRun->fEDepPerLayer[il];
+  }
+
+  fChargedStep += localRun->fChargedStep;
+  fNeutralStep += localRun->fNeutralStep;
+
+  fN_gamma += localRun->fN_gamma;
+  fN_elec  += localRun->fN_elec;
+  fN_pos   += localRun->fN_pos;
+
+  fApplyLimit = localRun->fApplyLimit;
+
+  for (G4int k=0; k<kMaxAbsor; k++) {
+    fEdeptrue[k]  = localRun->fEdeptrue[k];
+    fRmstrue[k]   = localRun->fRmstrue[k];
+    fLimittrue[k] = localRun->fLimittrue[k];
+  }
+
+  G4Run::Merge(run);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::EndOfRun()
+{
+  G4int nEvt = numberOfEvent;
+  G4double  norm = G4double(nEvt);
+  if(norm > 0) norm = 1./norm;
+  G4double qnorm = std::sqrt(norm);
+
+  fChargedStep *= norm;
+  fNeutralStep *= norm;
+
+  //compute and print statistic
+  //
+  G4double beamEnergy = fEkin;
+  G4double sqbeam = std::sqrt(beamEnergy/GeV);
+
+  G4double MeanEAbs,MeanEAbs2,rmsEAbs,resolution,rmsres;
+  G4double MeanLAbs,MeanLAbs2,rmsLAbs;
+
+  std::ios::fmtflags mode = G4cout.flags();
+  G4int  prec = G4cout.precision(2);
+  G4cout << "\n------------------------------------------------------------\n";
+  G4cout << std::setw(14) << "material"
+         << std::setw(17) << "Edep       RMS"
+         << std::setw(33) << "sqrt(E0(GeV))*rmsE/Emean"
+         << std::setw(23) << "total tracklen \n \n";
+
+  for (G4int k=1; k<=fDetector->GetNbOfAbsor(); k++)
+    {
+      MeanEAbs  = fSumEAbs[k]*norm;
+      MeanEAbs2 = fSum2EAbs[k]*norm;
+      rmsEAbs  = std::sqrt(std::abs(MeanEAbs2 - MeanEAbs*MeanEAbs));
+      //G4cout << "k= " << k << "  RMS= " <<  rmsEAbs
+      //     << "  fApplyLimit: " << fApplyLimit << G4endl;
+      if(fApplyLimit) {
+        G4int    nn    = 0;
+        G4double sume  = 0.0;
+        G4double sume2 = 0.0;
+        // compute trancated means
+        G4double lim   = rmsEAbs * 2.5;
+        for(G4int i=0; i<nEvt; i++) {
+          G4double e = (fEnergyDeposit[k])[i];
+          if(std::abs(e - MeanEAbs) < lim) {
+            sume  += e;
+            sume2 += e*e;
+            nn++;
+          }
+        }
+        G4double norm1 = G4double(nn);
+        if(norm1 > 0.0) norm1 = 1.0/norm1;
+        MeanEAbs  = sume*norm1;
+        MeanEAbs2 = sume2*norm1;
+        rmsEAbs  = std::sqrt(std::abs(MeanEAbs2 - MeanEAbs*MeanEAbs));
+      }
+
+      resolution= 100.*sqbeam*rmsEAbs/MeanEAbs;
+      rmsres    = resolution*qnorm;
+
+      // Save mean and RMS
+      fSumEAbs[k] = MeanEAbs;
+      fSum2EAbs[k] = rmsEAbs;
+
+      MeanLAbs  = fSumLAbs[k]*norm;
+      MeanLAbs2 = fSum2LAbs[k]*norm;
+      rmsLAbs  = std::sqrt(std::abs(MeanLAbs2 - MeanLAbs*MeanLAbs));
+
+      //print
+      //
+      G4cout
+       << std::setw(14) << fDetector->GetAbsorMaterial(k)->GetName() << ": "
+       << std::setprecision(6)
+       << std::setw(6) << G4BestUnit(MeanEAbs,"Energy") << " :  "
+       << std::setprecision(6)
+       << std::setw(5) << G4BestUnit( rmsEAbs,"Energy")
+       << std::setw(10) << resolution  << " +- "
+       << std::setw(5) << rmsres << " %"
+       << std::setprecision(6)
+       << std::setw(10) << G4BestUnit(MeanLAbs,"Length")  << " +- "
+       << std::setw(4) << G4BestUnit( rmsLAbs,"Length")
+       << G4endl;
+    }
+  G4cout << "\n------------------------------------------------------------\n";
+
+  G4cout << std::setprecision(14);
+  G4cout << " Beam particle "
+         << fParticle->GetParticleName()
+         << "  E = " << G4BestUnit(beamEnergy,"Energy") << G4endl;
+  G4cout << " Mean number of gamma       " << fN_gamma*norm << G4endl;
+  G4cout << " Mean number of e-          " << fN_elec*norm << G4endl;
+  G4cout << " Mean number of e+          " << fN_pos*norm << G4endl;
+  G4cout << std::setprecision(6)
+         << " Mean number of charged steps  " << fChargedStep << G4endl;
+  G4cout << " Mean number of neutral steps  " << fNeutralStep << G4endl;
+  G4cout << "------------------------------------------------------------\n";
+
+  //Energy flow
+  //
+  G4AnalysisManager* analysis = G4AnalysisManager::Instance();
+  G4int Idmax = (fDetector->GetNbOfLayers())*(fDetector->GetNbOfAbsor());
+  for (G4int Id=1; Id<=Idmax+1; Id++) {
+    analysis->FillH1(2*kMaxAbsor+1, (G4double)Id, fEnergyFlow[Id]);
+    analysis->FillH1(2*kMaxAbsor+2, (G4double)Id, fLateralEleak[Id]);
+  }
+
+  //Energy deposit from energy flow balance
+  //
+  G4double EdepTot[kMaxAbsor];
+  for (G4int k=0; k<kMaxAbsor; k++) EdepTot[k] = 0.;
+
+  G4int nbOfAbsor = fDetector->GetNbOfAbsor();
+  for (G4int Id=1; Id<=Idmax; Id++) {
+   G4int iAbsor = Id%nbOfAbsor; if (iAbsor==0) iAbsor = nbOfAbsor;
+   EdepTot[iAbsor] += (fEnergyFlow[Id] - fEnergyFlow[Id+1] - fLateralEleak[Id]);
+  }
+
+  G4cout << std::setprecision(3)
+         << "\n Energy deposition from Energy flow balance : \n"
+         << std::setw(10) << "  material \t Total Edep \n \n";
+  G4cout.precision(6);
+
+  for (G4int k=1; k<=nbOfAbsor; k++) {
+    EdepTot [k] *= norm;
+    G4cout << std::setw(10) << fDetector->GetAbsorMaterial(k)->GetName() << ":"
+           << "\t " << G4BestUnit(EdepTot [k],"Energy") << "\n";
+  }
+
+  G4cout << "\n------------------------------------------------------------\n"
+         << G4endl;
+
+  // Acceptance
+  EmAcceptance acc;
+  G4bool isStarted = false;
+  for (G4int j=1; j<=fDetector->GetNbOfAbsor(); j++) {
+    if (fLimittrue[j] < DBL_MAX) {
+      if (!isStarted) {
+        acc.BeginOfAcceptance("Sampling Calorimeter",nEvt);
+        isStarted = true;
+      }
+      MeanEAbs = fSumEAbs[j];
+      rmsEAbs  = fSum2EAbs[j];
+      G4String mat = fDetector->GetAbsorMaterial(j)->GetName();
+      acc.EmAcceptanceGauss("Edep"+mat, nEvt, MeanEAbs,
+                             fEdeptrue[j], fRmstrue[j], fLimittrue[j]);
+      acc.EmAcceptanceGauss("Erms"+mat, nEvt, rmsEAbs,
+                             fRmstrue[j], fRmstrue[j], 2.0*fLimittrue[j]);
+    }
+  }
+  if(isStarted) acc.EndOfAcceptance();
+
+  //normalize histograms
+  //
+  for (G4int ih = kMaxAbsor+1; ih < kMaxHisto; ih++) {
+    analysis->ScaleH1(ih,norm/MeV);
+  }
+
+  // print layer by layer data
+  //
+  G4int nLayers = fCHTrackLPerLayer.size();
+  G4cout << " \n ----------------------------------------------------------- \n"
+         << " ----------------   Layer by layer mean data  -------------- \n"
+         << " ----------------------------------------------------------- \n";
+  G4cout << "  #Layers   Charged-TrakL [mm]   Energy-Dep [MeV]  " << G4endl << G4endl;
+  G4cout.setf(std::ios::scientific);
+  G4cout.precision(6);
+  for (G4int il = 0; il < nLayers; ++il)  {
+      G4cout << "  " 
+             << std::setw(5)  << il 
+             << std::setw(20) << fCHTrackLPerLayer[il]*norm/mm 
+             << std::setw(20) << fEDepPerLayer[il]*norm/MeV
+             << G4endl;
+  }
+  G4cout << G4endl;
+  G4cout << " \n ================================================================== \n"
+         << G4endl;  
+
+
+  G4cout.setf(mode,std::ios::floatfield);
+  G4cout.precision(prec);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::SetEdepAndRMS(G4int i, G4double edep, G4double rms, G4double lim)
+{
+  if (i>=0 && i<kMaxAbsor) {
+    fEdeptrue [i] = edep;
+    fRmstrue  [i] = rms;
+    fLimittrue[i] = lim;
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void Run::SetApplyLimit(G4bool val)
+{
+  fApplyLimit = val;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/RunAction.cc
+++ b/apps/examples/TestEm3/src/RunAction.cc
@@ -1,0 +1,149 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/RunAction.cc
+/// \brief Implementation of the RunAction class
+//
+// $Id: RunAction.cc 90969 2015-06-12 08:12:57Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "RunAction.hh"
+
+#include "DetectorConstruction.hh"
+#include "PrimaryGeneratorAction.hh"
+#include "RunActionMessenger.hh"
+#include "HistoManager.hh"
+#include "Run.hh"
+#include "G4Timer.hh"
+#include "G4RunManager.hh"
+#include "Randomize.hh"
+
+#include "G4ProductionCutsTable.hh"
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+RunAction::RunAction(DetectorConstruction* det, PrimaryGeneratorAction* prim)
+:G4UserRunAction(), fIsPerformance(false), fDetector(det), fPrimary(prim), fRun(0), fRunMessenger(0),
+ fHistoManager(0), fTimer(0)
+{
+  fRunMessenger = new RunActionMessenger(this);
+  fHistoManager = new HistoManager();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+RunAction::~RunAction()
+{
+  delete fRunMessenger;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4Run* RunAction::GenerateRun()
+{
+  if (!fIsPerformance) {
+    fRun = new Run(fDetector);
+    return fRun;
+  }
+  return nullptr;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void RunAction::BeginOfRunAction(const G4Run*)
+{
+  if (isMaster) {
+    //    G4Random::showEngineStatus();
+    G4ProductionCutsTable::GetProductionCutsTable()->DumpCouples();
+
+    fTimer = new G4Timer();
+    fTimer->Start();
+  }
+
+  if (fIsPerformance) {
+    return;
+  }
+
+  // keep run condition
+  if (fPrimary) {
+    G4ParticleDefinition* particle
+      = fPrimary->GetParticleGun()->GetParticleDefinition();
+    G4double energy = fPrimary->GetParticleGun()->GetParticleEnergy();
+    fRun->SetPrimary(particle, energy);
+  }
+
+  //histograms
+  //
+  G4AnalysisManager* analysis = G4AnalysisManager::Instance();
+  if (analysis->IsActive()) analysis->OpenFile();
+
+  // save Rndm status and open the timer
+
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void RunAction::EndOfRunAction(const G4Run*)
+{
+  // compute and print statistic
+  if (isMaster) {
+    fTimer->Stop();
+    G4cout << "  ======================================================" << G4endl;
+    G4cout << "   Time:  "  << *fTimer << G4endl;
+    G4cout << "  ======================================================" << G4endl;
+    delete fTimer;
+    if (!fIsPerformance) {
+      fRun->EndOfRun();
+    } else {
+      return;
+    }
+  }
+  //save histograms
+  G4AnalysisManager* analysis = G4AnalysisManager::Instance();
+  if (analysis->IsActive()) {
+    analysis->Write();
+    analysis->CloseFile();
+  }
+
+  // show Rndm status
+  //  if (isMaster)  G4Random::showEngineStatus();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void RunAction::SetEdepAndRMS(G4int i,G4double edep,G4double rms,G4double lim)
+{
+  if (fRun) fRun->SetEdepAndRMS(i, edep, rms, lim);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void RunAction::SetApplyLimit(G4bool val)
+{
+  if (fRun) fRun->SetApplyLimit(val);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/RunActionMessenger.cc
+++ b/apps/examples/TestEm3/src/RunActionMessenger.cc
@@ -1,0 +1,109 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/RunActionMessenger.cc
+/// \brief Implementation of the RunActionMessenger class
+//
+// $Id: RunActionMessenger.cc 67268 2013-02-13 11:38:40Z ihrivnac $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "RunActionMessenger.hh"
+
+#include "RunAction.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcommand.hh"
+#include "G4UIparameter.hh"
+#include "G4UIcmdWithABool.hh"
+
+#include <sstream>
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+RunActionMessenger::RunActionMessenger(RunAction* run)
+:G4UImessenger(),fRunAction(run),
+ fRunDir(0),
+ fAccCmd(0),
+ fLimCmd(0)
+{
+  fRunDir = new G4UIdirectory("/testem/run/");
+  fRunDir->SetGuidance("run commands");
+    
+  fAccCmd = new G4UIcommand("/testem/run/acceptance",this);
+  fAccCmd->SetGuidance("Check Edep and RMS of energy deposition for given absorber");
+  //
+  G4UIparameter* AbsNbPrm = new G4UIparameter("AbsorNb",'i',false);
+  AbsNbPrm->SetGuidance("absorber number : from 1 to NbOfAbsor");
+  AbsNbPrm->SetParameterRange("AbsorNb>0");
+  fAccCmd->SetParameter(AbsNbPrm);
+  //    
+  G4UIparameter* edep = new G4UIparameter("Edep",'d',false);
+  edep->SetGuidance("mean energy deposition (MeV)");
+  edep->SetParameterRange("Edep>=0.");
+  fAccCmd->SetParameter(edep);
+  //    
+  G4UIparameter* rms = new G4UIparameter("RMS",'d',false);
+  rms->SetGuidance("RMS of energy deposition (MeV)");
+  rms->SetParameterRange("RMS>=0.");
+  fAccCmd->SetParameter(rms);
+  //    
+  G4UIparameter* lim = new G4UIparameter("nRMS",'d',false);
+  lim->SetGuidance("Limit in number of RMS of energy deposition");
+  lim->SetParameterRange("Limit>=0.");
+  fAccCmd->SetParameter(lim);
+  //
+  fLimCmd = new G4UIcmdWithABool("/testem/run/limitEdep",this);
+  fLimCmd->SetGuidance("remove energy outside acceptance limit");
+  fLimCmd->AvailableForStates(G4State_PreInit,G4State_Idle);      
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+RunActionMessenger::~RunActionMessenger()
+{
+  delete fAccCmd;
+  delete fRunDir;    
+  delete fLimCmd;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void RunActionMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
+{      
+  if( command == fAccCmd )
+   { 
+     G4int num; 
+     G4double edep, rms, lim;
+     std::istringstream is(newValue);
+     is >> num >> edep >> rms >> lim;
+     fRunAction->SetEdepAndRMS(num,edep,rms,lim);
+   }
+
+  if( command == fLimCmd )
+   { fRunAction->SetApplyLimit(fLimCmd->GetNewBoolValue(newValue));}
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/StepMax.cc
+++ b/apps/examples/TestEm3/src/StepMax.cc
@@ -1,0 +1,62 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/StepMax.cc
+/// \brief Implementation of the StepMax class
+//
+// $Id: StepMax.cc 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "StepMax.hh"
+#include "StepMaxMessenger.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+StepMax::StepMax(const G4String& processName)
+ : G4VDiscreteProcess(processName),fMess(0) 
+{
+  for (G4int k=0; k<kMaxAbsor; k++) fStepMax[k] = DBL_MAX;
+  fMess = new StepMaxMessenger(this);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+StepMax::~StepMax() { delete fMess; }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4bool StepMax::IsApplicable(const G4ParticleDefinition& particle)
+{
+  return (particle.GetPDGCharge() != 0. && !particle.IsShortLived());
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void StepMax::SetStepMax(G4int k,G4double step) {fStepMax[k] = step;}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+

--- a/apps/examples/TestEm3/src/StepMaxMessenger.cc
+++ b/apps/examples/TestEm3/src/StepMaxMessenger.cc
@@ -1,0 +1,90 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/StepMaxMessenger.cc
+/// \brief Implementation of the StepMaxMessenger class
+//
+// $Id: fStepMaxMessenger.cc,v 1.3 2006-06-29 16:53:21 gunter Exp $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "StepMaxMessenger.hh"
+
+#include "StepMax.hh"
+#include "G4UIdirectory.hh"
+#include "G4UIcommand.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+StepMaxMessenger::StepMaxMessenger(StepMax* stepM)
+:G4UImessenger(),fStepMax(stepM),
+ fStepMaxDir(0),    
+ fStepMaxCmd(0)
+{
+  fStepMaxDir = new G4UIdirectory("/testem/stepMax/");
+  fStepMaxDir->SetGuidance("histograms control");
+   
+  fStepMaxCmd = new G4UIcommand("/testem/stepMax/absorber",this);
+  fStepMaxCmd->SetGuidance("Set max allowed step length in absorber k");
+  //
+  G4UIparameter* k = new G4UIparameter("k",'i',false);
+  k->SetGuidance("absorber number : from 1 to MaxHisto-1");
+  k->SetParameterRange("k>0");
+  fStepMaxCmd->SetParameter(k);
+  //    
+  G4UIparameter* sMax = new G4UIparameter("sMax",'d',false);
+  sMax->SetGuidance("stepMax, expressed in choosen unit");
+  sMax->SetParameterRange("sMax>0.");
+  fStepMaxCmd->SetParameter(sMax);
+  //    
+  G4UIparameter* unit = new G4UIparameter("unit",'s',false);
+  fStepMaxCmd->SetParameter(unit);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+StepMaxMessenger::~StepMaxMessenger()
+{
+  delete fStepMaxCmd;
+  delete fStepMaxDir;  
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void StepMaxMessenger::SetNewValue(G4UIcommand* command, G4String newValues)
+{ 
+  if (command == fStepMaxCmd)
+   { G4int k; G4double sMax; 
+     G4String unts;
+     std::istringstream is(newValues);
+     is >> k >> sMax >> unts;
+     G4String unit = unts;
+     G4double vUnit = G4UIcommand::ValueOf(unit);  
+     fStepMax->SetStepMax(k,sMax*vUnit);
+   }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/SteppingAction.cc
+++ b/apps/examples/TestEm3/src/SteppingAction.cc
@@ -1,0 +1,151 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/SteppingAction.cc
+/// \brief Implementation of the SteppingAction class
+//
+// $Id: SteppingAction.cc 98762 2016-08-09 14:08:07Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "SteppingAction.hh"
+
+#include "DetectorConstruction.hh"
+#include "Run.hh"
+#include "EventAction.hh"
+#include "HistoManager.hh"
+
+#include "G4Positron.hh"
+#include "G4RunManager.hh"
+#include "G4PhysicalConstants.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+SteppingAction::SteppingAction(DetectorConstruction* det, EventAction* evt)
+:G4UserSteppingAction(),fDetector(det),fEventAct(evt) 
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+SteppingAction::~SteppingAction()
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void SteppingAction::UserSteppingAction(const G4Step* aStep)
+{
+  //track informations
+  const G4StepPoint* prePoint = aStep->GetPreStepPoint();   
+  const G4StepPoint* endPoint = aStep->GetPostStepPoint();
+  const G4ParticleDefinition* particle = aStep->GetTrack()->GetDefinition(); 
+    
+  //if World, return
+  //
+  G4VPhysicalVolume* volume = prePoint->GetTouchableHandle()->GetVolume();    
+  //if sum of absorbers do not fill exactly a layer: check material, not volume.
+  G4Material* mat = volume->GetLogicalVolume()->GetMaterial();
+  if (mat == fDetector->GetWorldMaterial()) return; 
+ 
+  //here we are in an absorber. Locate it
+  //
+  G4int absorNum  = prePoint->GetTouchableHandle()->GetCopyNumber(0);
+  G4int layerNum  = prePoint->GetTouchableHandle()->GetCopyNumber(1);
+  
+  //get Run
+  Run* run = static_cast<Run*>(
+             G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+                       
+  // collect energy deposit taking into account track weight
+  G4double edep = aStep->GetTotalEnergyDeposit()*aStep->GetTrack()->GetWeight();
+  run->AddEDepInLayer(edep, layerNum);
+  
+  // collect step length of charged particles
+  G4double stepl = 0.;
+  if (particle->GetPDGCharge() != 0.) {
+    stepl = aStep->GetStepLength();
+    run->AddChargedStep();
+    run->AddCHStepInLayer(stepl, layerNum);    
+  } else { run->AddNeutralStep(); }
+  
+  //  G4cout << "Nabs= " << absorNum << "   edep(keV)= " << edep << G4endl;
+  
+  // sum up per event
+  fEventAct->SumEnergy(absorNum,edep,stepl);
+  
+  //longitudinal profile of edep per absorber
+  if (edep>0.) {
+    G4AnalysisManager::Instance()->FillH1(kMaxAbsor+absorNum, 
+                                          G4double(layerNum+1), edep);
+  }
+  //energy flow
+  //
+  // unique identificator of layer+absorber
+  G4int Idnow = (fDetector->GetNbOfAbsor())*layerNum + absorNum;
+  G4int plane;
+  //
+  //leaving the absorber ?
+  if (endPoint->GetStepStatus() == fGeomBoundary) {
+    G4ThreeVector position  = endPoint->GetPosition();
+    G4ThreeVector direction = endPoint->GetMomentumDirection();
+    G4double sizeYZ = 0.5*fDetector->GetCalorSizeYZ();       
+    G4double Eflow = endPoint->GetKineticEnergy();
+    if (particle == G4Positron::Positron()) Eflow += 2*electron_mass_c2;
+   if ((std::abs(position.y()) >= sizeYZ) || (std::abs(position.z()) >= sizeYZ))
+                                  run->SumLateralEleak(Idnow, Eflow);
+    else if (direction.x() >= 0.) run->SumEnergyFlow(plane=Idnow+1, Eflow);
+    else                          run->SumEnergyFlow(plane=Idnow,  -Eflow);    
+  }   
+
+////  example of Birk attenuation
+///G4double destep   = aStep->GetTotalEnergyDeposit();
+///G4double response = BirksAttenuation(aStep);
+///G4cout << " Destep: " << destep/keV << " keV"
+///       << " response after Birks: " << response/keV << " keV" << G4endl;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+G4double SteppingAction::BirksAttenuation(const G4Step* aStep)
+{
+ //Example of Birk attenuation law in organic scintillators.
+ //adapted from Geant3 PHYS337. See MIN 80 (1970) 239-244
+ //
+ G4Material* material = aStep->GetTrack()->GetMaterial();
+ G4double birk1       = material->GetIonisation()->GetBirksConstant();
+ G4double destep      = aStep->GetTotalEnergyDeposit();
+ G4double stepl       = aStep->GetStepLength();  
+ G4double charge      = aStep->GetTrack()->GetDefinition()->GetPDGCharge();
+ //
+ G4double response = destep;
+ if (birk1*destep*stepl*charge != 0.)
+   {
+     response = destep/(1. + birk1*destep/stepl);
+   }
+ return response;
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+

--- a/apps/examples/TestEm3/src/SteppingVerbose.cc
+++ b/apps/examples/TestEm3/src/SteppingVerbose.cc
@@ -1,0 +1,158 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/SteppingVerbose.cc
+/// \brief Implementation of the SteppingVerbose class
+//
+//
+// $Id: SteppingVerbose.cc 98762 2016-08-09 14:08:07Z gcosmo $
+// 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "SteppingVerbose.hh"
+
+#include "G4SteppingManager.hh"
+#include "G4ParticleTypes.hh"
+#include "G4UnitsTable.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+SteppingVerbose::SteppingVerbose()
+ : G4SteppingVerbose()
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+SteppingVerbose::~SteppingVerbose()
+{} 
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void SteppingVerbose::TrackingStarted()
+{  
+  CopyState();
+  
+  G4int prec = G4cout.precision(3);
+  
+  //Step zero
+  //  
+  if( verboseLevel > 0 ){
+    G4cout << std::setw( 5) << "Step#"      << " "
+           << std::setw( 6) << "X"          << "    "
+           << std::setw( 6) << "Y"          << "    "  
+           << std::setw( 6) << "Z"          << "    "
+           << std::setw( 9) << "KineE"      << " "
+           << std::setw( 9) << "dEStep"     << " "  
+           << std::setw(10) << "StepLeng"  
+           << std::setw(10) << "TrakLeng"
+           << std::setw(10) << "Volume"     << "  "
+           << std::setw(10) << "Process"    << G4endl;             
+
+    G4cout << std::setw(5) << fTrack->GetCurrentStepNumber() << " "
+        << std::setw(6) << G4BestUnit(fTrack->GetPosition().x(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetPosition().y(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetPosition().z(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetKineticEnergy(),"Energy")
+        << std::setw(6) << G4BestUnit(fStep->GetTotalEnergyDeposit(),"Energy")
+        << std::setw(6) << G4BestUnit(fStep->GetStepLength(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetTrackLength(),"Length")
+        << std::setw(10) << fTrack->GetVolume()->GetName()
+        << "   initStep" << G4endl;        
+  }
+  G4cout.precision(prec);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void SteppingVerbose::StepInfo()
+{  
+  CopyState();
+    
+  G4int prec = G4cout.precision(3);
+
+  if( verboseLevel >= 1 ){
+    if( verboseLevel >= 4 ) VerboseTrack();
+    if( verboseLevel >= 3 ){
+      G4cout << G4endl;    
+      G4cout << std::setw( 5) << "#Step#"     << " "
+             << std::setw( 6) << "X"          << "    "
+             << std::setw( 6) << "Y"          << "    "  
+             << std::setw( 6) << "Z"          << "    "
+             << std::setw( 9) << "KineE"      << " "
+             << std::setw( 9) << "dEStep"     << " "  
+             << std::setw(10) << "StepLeng"     
+             << std::setw(10) << "TrakLeng" 
+             << std::setw(10) << "Volume"    << "  "
+             << std::setw(10) << "Process"   << G4endl;                  
+    }
+
+    G4cout << std::setw( 5) << fTrack->GetCurrentStepNumber() << " "
+        << std::setw(6) << G4BestUnit(fTrack->GetPosition().x(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetPosition().y(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetPosition().z(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetKineticEnergy(),"Energy")
+        << std::setw(6) << G4BestUnit(fStep->GetTotalEnergyDeposit(),"Energy")
+        << std::setw(6) << G4BestUnit(fStep->GetStepLength(),"Length")
+        << std::setw(6) << G4BestUnit(fTrack->GetTrackLength(),"Length")
+        << std::setw(10) << fTrack->GetVolume()->GetName();
+
+    const G4VProcess* process 
+                      = fStep->GetPostStepPoint()->GetProcessDefinedStep();
+    G4String procName = " UserLimit";
+    if (process) procName = process->GetProcessName();
+    if (fStepStatus == fWorldBoundary) procName = "OutOfWorld";
+    G4cout << "   " << std::setw(10) << procName;
+    G4cout << G4endl;
+
+    if (verboseLevel == 2) {
+      const std::vector<const G4Track*>* secondary 
+                                    = fStep->GetSecondaryInCurrentStep();
+      size_t nbtrk = (*secondary).size();
+      if (nbtrk) {
+        G4cout << "\n    :----- List of secondaries ----------------" << G4endl;
+        G4cout.precision(4);
+        for (size_t lp=0; lp<(*secondary).size(); lp++) {
+          G4cout << "   "
+                 << std::setw(13)                 
+                 << (*secondary)[lp]->GetDefinition()->GetParticleName()
+                 << ":  energy ="
+                 << std::setw(6)
+                 << G4BestUnit((*secondary)[lp]->GetKineticEnergy(),"Energy")
+                 << "  time ="
+                 << std::setw(6)
+                 << G4BestUnit((*secondary)[lp]->GetGlobalTime(),"Time");
+          G4cout << G4endl;
+        }
+              
+        G4cout << "    :------------------------------------------\n" << G4endl;
+      }
+    }
+    
+  }
+  G4cout.precision(prec);
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/TrackingAction.cc
+++ b/apps/examples/TestEm3/src/TrackingAction.cc
@@ -1,0 +1,87 @@
+//
+// ********************************************************************
+// * License and Disclaimer                                           *
+// *                                                                  *
+// * The  Geant4 software  is  copyright of the Copyright Holders  of *
+// * the Geant4 Collaboration.  It is provided  under  the terms  and *
+// * conditions of the Geant4 Software License,  included in the file *
+// * LICENSE and available at  http://cern.ch/geant4/license .  These *
+// * include a list of copyright holders.                             *
+// *                                                                  *
+// * Neither the authors of this software system, nor their employing *
+// * institutes,nor the agencies providing financial support for this *
+// * work  make  any representation or  warranty, express or implied, *
+// * regarding  this  software system or assume any liability for its *
+// * use.  Please see the license in the file  LICENSE  and URL above *
+// * for the full disclaimer and the limitation of liability.         *
+// *                                                                  *
+// * This  code  implementation is the result of  the  scientific and *
+// * technical work of the GEANT4 collaboration.                      *
+// * By using,  copying,  modifying or  distributing the software (or *
+// * any work based  on the software)  you  agree  to acknowledge its *
+// * use  in  resulting  scientific  publications,  and indicate your *
+// * acceptance of all terms of the Geant4 Software license.          *
+// ********************************************************************
+//
+/// \file electromagnetic/TestEm3/src/TrackingAction.cc
+/// \brief Implementation of the TrackingAction class
+//
+//
+// $Id: TrackingAction.cc 78655 2014-01-14 11:13:41Z gcosmo $
+//
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+#include "TrackingAction.hh"
+
+#include "DetectorConstruction.hh"
+#include "Run.hh"
+
+#include "G4RunManager.hh"
+#include "G4Positron.hh"
+#include "G4PhysicalConstants.hh"
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+TrackingAction::TrackingAction(DetectorConstruction* det)
+:G4UserTrackingAction(),fDetector(det)
+{ }
+ 
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void TrackingAction::PreUserTrackingAction(const G4Track* track )
+{
+  //get Run
+  Run* run = static_cast<Run*>(
+             G4RunManager::GetRunManager()->GetNonConstCurrentRun());
+             
+  // Energy flow initialisation for primary particle
+  //
+  if (track->GetTrackID() == 1) {
+    G4int Idnow = 1;
+    if (track->GetVolume() != fDetector->GetphysiWorld()) {
+      // unique identificator of layer+absorber
+      const G4VTouchable* touchable = track->GetTouchable();
+      G4int absorNum = touchable->GetCopyNumber();
+      G4int layerNum = touchable->GetReplicaNumber(1);
+      Idnow = (fDetector->GetNbOfAbsor())*layerNum + absorNum;
+    }
+    
+    G4double Eflow = track->GetKineticEnergy();
+    if (track->GetDefinition() == G4Positron::Positron())
+      Eflow += 2*electron_mass_c2; 
+         
+    //flux artefact, if primary vertex is inside the calorimeter   
+    for (G4int pl=1; pl<=Idnow; pl++) {run->SumEnergyFlow(pl, Eflow);}
+  } else {
+    run->AddSecondaryTrack(track);
+  }
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+void TrackingAction::PostUserTrackingAction(const G4Track* )
+{ }
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+


### PR DESCRIPTION
The `G4HepEm` EM physics can be used (default) for EM shower simulation in simplified sampling
calorimeters in this version. Moreover, the `Geant4` EM physics constructor, that corresponds to
the current physics modelling capabilities of `G4HepEm` is also available. The user can switch
between the native `Geant4` and `G4HepEm` physics by a simple UI command (see the provided
`ATLASbar.mac` Geant4 macro file). The original Geant4 EM Standard Opt0 physics constructor
(as well as many others) are also available.

The sampling calorimeter can be configured (#layers, composition of the layer such as number
of absorbers with their thickness and material) as well as the primary particle properties
(primary particle type and kinetic energy).

At termination, the mean energy deposits and charged particle track lengths in the individual
absorbers are reported. A summary, about the mean number of secondary particles per type, the
mean number of charged and neutral particle steps, is also given. The layer-by-layer mean
charged particle track lengths as well as the mean energy deposits are also provided.