### PR TITLE
Modern CMake updates for CPU portion of code/tests

### DIFF
--- a/.github/workflows/cpu_build.yml
+++ b/.github/workflows/cpu_build.yml
@@ -78,7 +78,7 @@ jobs:
           export G4INCLDATA=/usr/local/geant4/10.6.3/share/Geant4-10.6.3/data/G4INCL1.0
           export G4ENSDFSTATEDATA=/usr/local/geant4/10.6.3/share/Geant4-10.6.3/data/G4ENSDFSTATE2.2                    
           cmake -E remove_directory build
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DGeant4_DIR=/usr/local/geant4/10.6.3/lib/Geant4-10.6.3
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DGeant4_DIR=/usr/local/geant4/10.6.3/lib/Geant4-10.6.3
           cmake --build build
           cd build && ctest -j2 --verbose --output-on-failure
 
@@ -97,6 +97,6 @@ jobs:
           export G4INCLDATA=/usr/local/geant4/10.6.3/share/Geant4-10.6.3/data/G4INCL1.0
           export G4ENSDFSTATEDATA=/usr/local/geant4/10.6.3/share/Geant4-10.6.3/data/G4ENSDFSTATE2.2                    
           cmake -E remove_directory build
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON -DGeant4_DIR=/usr/local/geant4/10.6.3/lib/Geant4-10.6.3
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DGeant4_DIR=/usr/local/geant4/10.6.3/lib/Geant4-10.6.3
           cmake --build build
           cd build && ctest -j2 --verbose --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,77 +1,121 @@
 #----------------------------------------------------------------------------
 # Setup the project; take policies from up to CMake 3.18 to avoid warnings
 # concerning CMP0104.
-cmake_minimum_required(VERSION 3.3...3.18 FATAL_ERROR)
-project( G4HepEm )
+cmake_minimum_required(VERSION 3.8...3.18 FATAL_ERROR)
+if(${CMAKE_VERSION} VERSION_LESS 3.12)
+  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
+endif()
 
+project(G4HepEm VERSION 0.1.0)
+
+# Core Modules, CMake and Build Settings
+include(GNUInstallDirs)
+
+# - Don't allow absolute paths other than CMAKE_INSTALL_PREFIX
+set(CMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION ON)
+
+# - Never export to or search in user/system package registry
+set(CMAKE_EXPORT_NO_PACKAGE_REGISTRY ON)
+set(CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY ON)
+set(CMAKE_FIND_PACKAGE_NO_SYSTEM_PACKAGE_REGISTRY ON)
+
+# - Force project directories to appear first in any list of includes
+set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)
+
+# - Only relink shared libs when interface changes
+set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
+
+# - Only report newly installed files
+set(CMAKE_INSTALL_MESSAGE LAZY)
+
+# - Minimums required by G4HepEm
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+# - Prefer shared libs
+set(BUILD_SHARED_LIBS ON)
+set(BUILD_STATIC_LIBS OFF)
+
+# - Single location for library build products
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
 #----------------------------------------------------------------------------
-# Find Geant4 and set G4 libraries, include directories, etc... 
+# Find Geant4, changing library build type to default Geant4 variant
 #
 find_package(Geant4 REQUIRED)
-#message (STATUS "Geant4_INCLUDE_DIRS = ${Geant4_INCLUDE_DIRS}")
-#message (STATUS "Geant4_LIBRARIES    = ${Geant4_LIBRARIES}")
-#message (STATUS "Geant4_CXX_FLAGS    = ${Geant4_CXX_FLAGS}")
-#message (STATUS "Geant4_BUILD_TYPE   = ${Geant4_BUILD_TYPE}")
-#message (STATUS "Geant4_static_FOUND = ${Geant4_static_FOUND}")
-
-# set the same configuration that was used to build G4 
-set (CMAKE_CXX_FLAGS "${Geant4_CXX_FLAGS}")
-#set (CMAKE_CXX_FLAGS "-g -O0 -fno-inline -std=c++11")
-set (CMAKE_BUILD_TYPE "${Geant4_BUILD_TYPE}")
-
-#message(STATUS "${CMAKE_CXX_FLAGS}")
-
-set (BUILD_SHARED_LIBS ON)
-set (BUILD_STATIC_LIBS OFF)
-if (Geant4_static_FOUND)
-  set (BUILD_SHARED_LIBS OFF)
-  set (BUILD_STATIC_LIBS ON)
-endif ()
-
-
-# set the directory where the libraries will be placed 
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-
+if(Geant4_static_FOUND AND NOT Geant4_shared_FOUND)
+  set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_STATIC_LIBS ON)
+endif()
 
 #----------------------------------------------------------------------------
 # CUDA
-option (G4HepEm_CUDA_BUILD "BUILD with CUDA support" OFF)
-if (G4HepEm_CUDA_BUILD)
-  find_package (CUDA 6.0 REQUIRED)
-  if (CUDA_FOUND)
-    add_definitions (-DG4HepEm_CUDA_BUILD)
-    message (STATUS "Found CUDA at ${CUDA_TOOLKIT_ROOT_DIR} (${CUDA_VERSION_STRING})")
-    include_directories (AFTER SYSTEM ${CUDA_INCLUDE_DIRS})
-#    message (STATUS "CUDA INCLUDE DIRECTORY = ${CUDA_INCLUDE_DIRS}")
-#    message (STATUS "CUDA LIBRARIES = ${CUDA_LIBRARIES}")
-#    message (STATUS "CUDA CUBLAS LIBRARIES = ${CUDA_CUBLAS_LIBRARIES}")
-#    message (STATUS "CUDA cudart static LIBRARY = ${CUDA_cudart_static_LIBRARY}")
-#    message (STATUS "CUDA cusolver LIBRARY = ${CUDA_cusolver_LIBRARY}")
-#    message (STATUS " ")
-######
-     enable_language(CUDA)
-     # Disable -pedantic because nvcc uses GCC extensions for line directives;
-     # leave all other warnings enabled.
-     set (CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -Wno-pedantic")
-  else (CUDA_FOUND)
+option(G4HepEm_CUDA_BUILD "BUILD with CUDA support" OFF)
+if(G4HepEm_CUDA_BUILD)
+  find_package(CUDA 6.0 REQUIRED)
+  if(CUDA_FOUND)
+    add_definitions(-DG4HepEm_CUDA_BUILD)
+    message(STATUS "Found CUDA at ${CUDA_TOOLKIT_ROOT_DIR} (${CUDA_VERSION_STRING})")
+    include_directories(AFTER SYSTEM ${CUDA_INCLUDE_DIRS})
+    enable_language(CUDA)
+    # Disable -pedantic because nvcc uses GCC extensions for line directives;
+    # leave all other warnings enabled.
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -Wno-pedantic")
+  else()
     message(FATAL_ERROR "REQUIRED CUDA LIBRARIES WERE NOT FOUND")
-  endif (CUDA_FOUND)  
-endif (G4HepEm_CUDA_BUILD)
-
+  endif()
+endif()
 
 #----------------------------------------------------------------------------
 # Build G4HepEm libraries
-add_subdirectory (G4HepEm)
-
+add_subdirectory(G4HepEm)
 
 ## ----------------------------------------------------------------------------
-## Add testing option (OFF by default)
+## Add testing option (ON by default)
 ##
-option (BUILD_TESTS "Build test programs" OFF)
-if (BUILD_TESTS)
-  message (STATUS "Building test programs is enabled!")
-  enable_testing ()
-  add_subdirectory (testing)
-endif ()
+include(CTest)
+if(BUILD_TESTING)
+  message(STATUS "Building test programs is enabled!")
+  add_subdirectory(testing)
+endif()
+
+#-----------------------------------------------------------------------------
+# Create/install support files
+include(CMakePackageConfigHelpers)
+
+# - Common
+write_basic_package_version_file(
+  ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+  VERSION ${PROJECT_VERSION}
+  COMPATIBILITY AnyNewerVersion)
+
+# - Build Tree
+set(G4HEPEM_EXPORTED_INCLUDE_DIR "${PROJECT_SOURCE_DIR}/G4HepEm")
+
+configure_package_config_file(cmake/G4HepEmConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/G4HepEmConfig.cmake
+  INSTALL_PREFIX "${PROJECT_BINARY_DIR}"
+  INSTALL_DESTINATION "${PROJECT_BINARY_DIR}"
+  PATH_VARS G4HEPEM_EXPORTED_INCLUDE_DIR)
+
+export(EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE ${PROJECT_NAME}::
+  FILE ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake)
+
+# - Install Tree
+set(G4HEPEM_EXPORTED_INCLUDE_DIR "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+
+configure_package_config_file(cmake/G4HepEmConfig.cmake.in
+  ${PROJECT_BINARY_DIR}/InstallTree/G4HepEmConfig.cmake
+  INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+  PATH_VARS G4HEPEM_EXPORTED_INCLUDE_DIR)
+
+install(FILES ${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+              ${PROJECT_BINARY_DIR}/InstallTree/${PROJECT_NAME}Config.cmake
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
+
+install(EXPORT ${PROJECT_NAME}Targets
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,14 @@
 #----------------------------------------------------------------------------
 # Setup the project; take policies from up to CMake 3.18 to avoid warnings
 # concerning CMP0104.
-cmake_minimum_required(VERSION 3.8...3.18 FATAL_ERROR)
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-endif()
-
+cmake_minimum_required(VERSION 3.17...3.18 FATAL_ERROR)
 project(G4HepEm VERSION 0.1.0)
 
-# Core Modules, CMake and Build Settings
+# Local and Core Modules
 include(GNUInstallDirs)
+include(CheckLanguage)
 
+# CMake and Build Settings
 # - Don't allow absolute paths other than CMAKE_INSTALL_PREFIX
 set(CMAKE_ERROR_ON_ABSOLUTE_INSTALL_DESTINATION ON)
 
@@ -59,18 +57,28 @@ endif()
 # CUDA
 option(G4HepEm_CUDA_BUILD "BUILD with CUDA support" OFF)
 if(G4HepEm_CUDA_BUILD)
-  find_package(CUDA 6.0 REQUIRED)
-  if(CUDA_FOUND)
-    add_definitions(-DG4HepEm_CUDA_BUILD)
-    message(STATUS "Found CUDA at ${CUDA_TOOLKIT_ROOT_DIR} (${CUDA_VERSION_STRING})")
-    include_directories(AFTER SYSTEM ${CUDA_INCLUDE_DIRS})
+  # Use host compiler by default to ensure ABI consistency
+  set(CMAKE_CUDA_HOST_COMPILER "${CMAKE_CXX_COMPILER}" CACHE STRING
+    "Set to CMAKE_CXX_COMPILER by G4HepEM CMakeLists")
+
+  check_language(CUDA)
+  if(CMAKE_CUDA_COMPILER)
     enable_language(CUDA)
-    # Disable -pedantic because nvcc uses GCC extensions for line directives;
-    # leave all other warnings enabled.
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -Xcompiler -Wno-pedantic")
   else()
-    message(FATAL_ERROR "REQUIRED CUDA LIBRARIES WERE NOT FOUND")
+    message(FATAL_ERROR "No CUDA compiler/support available")
   endif()
+
+  # On CMake < 3.18, need FindCUDA for Arch flags, and it's messy...
+  if(CMAKE_VERSION VERSION_LESS 3.18)
+    find_package(CUDA 10 REQUIRED QUIET)
+    cuda_select_nvcc_arch_flags(G4HEPEM_CUDA_ARCH_FLAGS)
+    string(REPLACE ";" " " G4HEPEM_CUDA_ARCH_FLAGS "${G4HEPEM_CUDA_ARCH_FLAGS}")
+    set(CMAKE_CUDA_FLAGS "${G4HEPEM_CUDA_ARCH_FLAGS}")
+  endif()
+
+  set(CMAKE_CUDA_STANDARD ${CMAKE_CXX_STANDARD})
+  set(CMAKE_CUDA_STANDARD_REQUIRED ON)
+  set(CMAKE_CUDA_EXTENSIONS OFF)
 endif()
 
 #----------------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,12 +42,17 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 
 #----------------------------------------------------------------------------
-# Find Geant4, changing library build type to default Geant4 variant
-#
+# Find Geant4, changing library build type to default Geant4 variant and
+# determining which CLHEP target to use
 find_package(Geant4 REQUIRED)
 if(Geant4_static_FOUND AND NOT Geant4_shared_FOUND)
   set(BUILD_SHARED_LIBS OFF)
   set(BUILD_STATIC_LIBS ON)
+endif()
+
+set(G4HepEm_CLHEP_TARGET CLHEP::CLHEP)
+if(TARGET Geant4::G4clhep)
+  set(G4HepEm_CLHEP_TARGET Geant4::G4clhep)
 endif()
 
 #----------------------------------------------------------------------------

--- a/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/CMakeLists.txt
@@ -1,57 +1,33 @@
+# - Build component libraries
+add_subdirectory(G4HepEmData)
+add_subdirectory(G4HepEmInit)
+add_subdirectory(G4HepEmRun)
 
+# - Now top level G4HepEm library
+file(GLOB G4HEPEM_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
+file(GLOB G4HEPEM_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 
-add_subdirectory (G4HepEmData)
-add_subdirectory (G4HepEmInit)
-add_subdirectory (G4HepEmRun)
+if(BUILD_STATIC_LIBS)
+  add_library(g4HepEm STATIC ${G4HEPEM_sources})
+else()
+  add_library(g4HepEm SHARED ${G4HEPEM_sources})
+endif()
 
+add_library(${PROJECT_NAME}::g4HepEm ALIAS g4HepEm)
 
-include_directories (
- ${CMAKE_CURRENT_SOURCE_DIR}/include
- ${G4HEPEMDATA_INC_DIR}
- ${G4HEPEMINIT_INC_DIR}
- ${G4HEPEMRUN_INC_DIR}
-)
+target_compile_features(g4HepEm PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 
+target_include_directories(g4HepEm PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
 
-file ( GLOB G4HEPEM_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
-file ( GLOB G4HEPEM_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
-if (BUILD_STATIC_LIBS)
-  add_library (g4HepEm STATIC ${G4HEPEM_sources})
-else ()
-  add_library (g4HepEm SHARED ${G4HEPEM_sources})
-endif ()
-
-set_target_properties(g4HepEm PROPERTIES COMPILE_FLAGS ${CMAKE_CXX_FLAGS})
-target_link_libraries(g4HepEm g4HepEmData g4HepEmInit g4HepEmRun) # ${Geant4_LIBRARIES})
+target_link_libraries(g4HepEm PUBLIC g4HepEmData g4HepEmInit g4HepEmRun) # ${Geant4_LIBRARIES})
 
 ## ----------------------------------------------------------------------------
 ## Install G4HepEm libraries and headers
-install (FILES ${G4HEPEM_headers} DESTINATION includes)
-install (TARGETS g4HepEm DESTINATION lib)
-
-## ----------------------------------------------------------------------------
-## Create and install G4HepEm CMake Config file
-##
-configure_file (${PROJECT_SOURCE_DIR}/cmake/G4HepEmConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/G4HepEmConfig.cmake @ONLY)
-
-install (FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/G4HepEmConfig.cmake
-    DESTINATION lib/cmake/G4HepEm
-)
-
-
-
-###############################################################################
-##  Set some global properties for retrieving proper configuration at testing 
-###############################################################################
-
-# local directory in the build for the header files
-FILE ( GLOB G4HEPEMDATA_HEADERS "${G4HEPEMDATA_INC_DIR}/*")
-FILE ( GLOB G4HEPEMINIT_HEADERS "${G4HEPEMINIT_INC_DIR}/*")
-FILE ( GLOB G4HEPEMRUN_HEADERS "${G4HEPEMRUN_INC_DIR}/*")
-FILE ( COPY ${G4HEPEM_headers} ${G4HEPEMDATA_HEADERS} ${G4HEPEMINIT_HEADERS} ${G4HEPEMRUN_HEADERS} DESTINATION ${CMAKE_BINARY_DIR}/includes)
-set (G4HEPEM_TESTING_INCLUDE_DIR "${CMAKE_BINARY_DIR}/includes")
-
-# set G4HepEm include directory property used (only) property for testing 
-set_property ( GLOBAL PROPERTY G4HEPEM_TESTING_INCLUDE_DIR_PROP  "${G4HEPEM_TESTING_INCLUDE_DIR}" )
+install(FILES ${G4HEPEM_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+install(TARGETS g4HepEm
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/G4HepEm/G4HepEmData/CMakeLists.txt
+++ b/G4HepEm/G4HepEmData/CMakeLists.txt
@@ -1,39 +1,41 @@
-
-
-set (G4HEPEMDATA_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
-
-include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
-file ( GLOB G4HEPEMDATA_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
-file ( GLOB G4HEPEMDATA_CXX_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
+file(GLOB G4HEPEMDATA_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
+file(GLOB G4HEPEMDATA_CXX_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 
 #
 # CUDA
-
+#
 if (G4HepEm_CUDA_BUILD)
-  file (GLOB G4HEPEMDATA_CUDA_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu)
+  file(GLOB G4HEPEMDATA_CUDA_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu)
   # add possible CUDA headers
   # list (APPEND G4HEPEMDATA_headers )
   #
-  if (BUILD_STATIC_LIBS)
-    cuda_add_library (g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
-  else (BUILD_STATIC_LIBS)
-    cuda_add_library (g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
-  endif (BUILD_STATIC_LIBS)
+  if(BUILD_STATIC_LIBS)
+    cuda_add_library(g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
+  else()
+    cuda_add_library(g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
+  endif()
   set_property(TARGET g4HepEmData PROPERTY CUDA_SEPARABLE_COMPILATION ON)
   target_link_libraries(g4HepEmData ${CUDA_LIBRARIES})
-else (G4HepEm_CUDA_BUILD)
-  if (BUILD_STATIC_LIBS)
-    add_library (g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources})
-  else (BUILD_STATIC_LIBS)
-    add_library (g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources})
-  endif (BUILD_STATIC_LIBS)
-  set_target_properties(g4HepEmData PROPERTIES COMPILE_FLAGS ${CMAKE_CXX_FLAGS})
-endif (G4HepEm_CUDA_BUILD)
+else()
+  if(BUILD_STATIC_LIBS)
+    add_library(g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources})
+  else()
+    add_library(g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources})
+  endif()
+endif()
 
+add_library(${PROJECT_NAME}::g4HepEmData ALIAS g4HepEmData)
+
+target_compile_features(g4HepEmData PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+target_include_directories(g4HepEmData PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
 
 ## ----------------------------------------------------------------------------
 ## Install G4HepEm libraries and headers
-install (FILES ${G4HEPEMDATA_headers} DESTINATION includes)
-install (TARGETS g4HepEmData DESTINATION lib)
-
-
+install(FILES ${G4HEPEMDATA_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+install(TARGETS g4HepEmData
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/G4HepEm/G4HepEmData/CMakeLists.txt
+++ b/G4HepEm/G4HepEmData/CMakeLists.txt
@@ -4,32 +4,29 @@ file(GLOB G4HEPEMDATA_CXX_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 #
 # CUDA
 #
-if (G4HepEm_CUDA_BUILD)
+if(G4HepEm_CUDA_BUILD)
   file(GLOB G4HEPEMDATA_CUDA_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu)
-  # add possible CUDA headers
-  # list (APPEND G4HEPEMDATA_headers )
-  #
-  if(BUILD_STATIC_LIBS)
-    cuda_add_library(g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
-  else()
-    cuda_add_library(g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
-  endif()
-  set_property(TARGET g4HepEmData PROPERTY CUDA_SEPARABLE_COMPILATION ON)
-  target_link_libraries(g4HepEmData ${CUDA_LIBRARIES})
+endif()
+
+if(BUILD_STATIC_LIBS)
+  add_library(g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
 else()
-  if(BUILD_STATIC_LIBS)
-    add_library(g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources})
-  else()
-    add_library(g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources})
-  endif()
+  add_library(g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources} ${G4HEPEMDATA_CUDA_sources})
 endif()
 
 add_library(${PROJECT_NAME}::g4HepEmData ALIAS g4HepEmData)
 
+target_compile_definitions(g4HepEmData PUBLIC $<$<BOOL:${G4HepEm_CUDA_BUILD}>:G4HepEm_CUDA_BUILD>)
+
 target_compile_features(g4HepEmData PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+
 target_include_directories(g4HepEmData PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
+
+if(G4HepEm_CUDA_BUILD)
+  set_property(TARGET g4HepEmData PROPERTY CUDA_SEPARABLE_COMPILATION ON)
+endif()
 
 ## ----------------------------------------------------------------------------
 ## Install G4HepEm libraries and headers

--- a/G4HepEm/G4HepEmInit/CMakeLists.txt
+++ b/G4HepEm/G4HepEmInit/CMakeLists.txt
@@ -1,25 +1,25 @@
+file(GLOB G4HEPEMInit_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
+file(GLOB G4HEPEMInit_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 
-set (G4HEPEMINIT_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
+if(BUILD_STATIC_LIBS)
+  add_library(g4HepEmInit STATIC ${G4HEPEMInit_sources})
+else()
+  add_library(g4HepEmInit SHARED ${G4HEPEMInit_sources})
+endif()
 
-include_directories (
-   ${CMAKE_CURRENT_SOURCE_DIR}/include
-   ${G4HEPEMDATA_INC_DIR}
-)
+add_library(${PROJECT_NAME}::g4HepEmInit ALIAS g4HepEmInit)
 
-file ( GLOB G4HEPEMInit_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
-file ( GLOB G4HEPEMInit_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
-if (BUILD_STATIC_LIBS)
-  add_library (g4HepEmInit STATIC ${G4HEPEMInit_sources})
-else ()
-  add_library (g4HepEmInit SHARED ${G4HEPEMInit_sources})
-endif ()
-
-set_target_properties(g4HepEmInit PROPERTIES COMPILE_FLAGS ${CMAKE_CXX_FLAGS})
-target_link_libraries(g4HepEmInit g4HepEmData ${Geant4_LIBRARIES})
+target_compile_features(g4HepEmInit PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+target_include_directories(g4HepEmInit PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
+target_link_libraries(g4HepEmInit PUBLIC g4HepEmData ${Geant4_LIBRARIES})
 
 ## ----------------------------------------------------------------------------
 ## Install G4HepEm libraries and headers
-install (FILES ${G4HEPEMInit_headers} DESTINATION includes)
-install (TARGETS g4HepEmInit DESTINATION lib)
-
-
+install(FILES ${G4HEPEMInit_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+install(TARGETS g4HepEmInit
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/G4HepEm/G4HepEmRun/CMakeLists.txt
+++ b/G4HepEm/G4HepEmRun/CMakeLists.txt
@@ -1,26 +1,31 @@
-
-set (G4HEPEMRUN_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
-
-include_directories (
-  ${CMAKE_CURRENT_SOURCE_DIR}/include
-  ${CMAKE_CURRENT_SOURCE_DIR}/../G4HepEmData/include
-  ${Geant4_INCLUDE_DIRS}  # only for CLHEP:: Random and units/constants
-  )
-file ( GLOB G4HEPEmRun_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh
-                               ${CMAKE_CURRENT_SOURCE_DIR}/include/*.icc)
-file ( GLOB G4HEPEmRun_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc
-                               ${CMAKE_CURRENT_SOURCE_DIR}/include/*.icc)
+file(GLOB G4HEPEmRun_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh
+                             ${CMAKE_CURRENT_SOURCE_DIR}/include/*.icc)
+file(GLOB G4HEPEmRun_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc
+                             ${CMAKE_CURRENT_SOURCE_DIR}/include/*.icc)
+# See Issue #11 and discussion...
 set_source_files_properties(${G4HEPEmRun_sources} PROPERTIES LANGUAGE CXX)
-if (BUILD_STATIC_LIBS)
-  add_library (g4HepEmRun STATIC ${G4HEPEmRun_sources})
-else ()
-  add_library (g4HepEmRun SHARED ${G4HEPEmRun_sources})
-endif ()
+if(BUILD_STATIC_LIBS)
+  add_library(g4HepEmRun STATIC ${G4HEPEmRun_sources})
+else()
+  add_library(g4HepEmRun SHARED ${G4HEPEmRun_sources})
+endif()
 
 set_target_properties(g4HepEmRun PROPERTIES COMPILE_FLAGS "-x c++ ${CMAKE_CXX_FLAGS}")
+
+add_library(${PROJECT_NAME}::g4HepEmRun ALIAS g4HepEmRun)
+
+target_compile_features(g4HepEmRun PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+target_include_directories(g4HepEmRun PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
 target_link_libraries(g4HepEmRun g4HepEmData Geant4::G4clhep) # only rng is used from G4 at run
 
 ## ----------------------------------------------------------------------------
 ## Install G4HepEm libraries and headers
-install (FILES ${G4HEPEmRun_headers} DESTINATION includes)
-install (TARGETS g4HepEmRun DESTINATION lib)
+install(FILES ${G4HEPEmRun_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+install(TARGETS g4HepEmRun
+  EXPORT ${PROJECT_NAME}Targets
+  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+

--- a/G4HepEm/G4HepEmRun/CMakeLists.txt
+++ b/G4HepEm/G4HepEmRun/CMakeLists.txt
@@ -18,7 +18,7 @@ target_compile_features(g4HepEmRun PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
 target_include_directories(g4HepEmRun PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(g4HepEmRun g4HepEmData Geant4::G4clhep) # only rng is used from G4 at run
+target_link_libraries(g4HepEmRun g4HepEmData ${G4HepEm_CLHEP_TARGET}) # only rng is used from G4 at run
 
 ## ----------------------------------------------------------------------------
 ## Install G4HepEm libraries and headers

--- a/apps/tests/ElectronXSections/src/Implementation.cc
+++ b/apps/tests/ElectronXSections/src/Implementation.cc
@@ -10,6 +10,7 @@
 // don't worry it's just for testing
 #define private public
 #include "G4HepEmElectronManager.hh"
+#undef private
 
 #include <cmath>
 #include <random>

--- a/cmake/G4HepEmConfig.cmake.in
+++ b/cmake/G4HepEmConfig.cmake.in
@@ -14,12 +14,9 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Geant4 @Geant4_VERSION@ REQUIRED)
 
-# TODO: Convert to Target/language/find_dependency
-set(G4HepEm_CMAKE_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
-set(G4HepEm_CUDA_LIBRARIES "@CUDA_LIBRARIES@;@CUDA_cudart_static_LIBRARY@")
-set(G4HepEm_CUDA_INCLUDE_DIR "@CUDA_INCLUDE_DIRS@")
-set(G4HepEm_CUDA_NVCC_FLAGS "@CUDA_NVCC_FLAGS@")
-set(G4HepEm_CUDA_BUILD "@G4HepEm_CUDA_BUILD@")
+# Direct CUDA deps to be determined, but should be handled by
+# target properties (remains to be seen if we need find_dependency on CUDA Toolkit
+# and to transport CUDA architecture flags)
 
 # - Project targets
 include(${CMAKE_CURRENT_LIST_DIR}/G4HepEmTargets.cmake)

--- a/cmake/G4HepEmConfig.cmake.in
+++ b/cmake/G4HepEmConfig.cmake.in
@@ -2,33 +2,34 @@
 ## Simple CMake configuration file for the G4HepEm extensions
 ##
 
-## G4HepEm_INCLUDE_DIR to the include directory
-## G4HepEm_LIBRARIES contains all the 4 libraries
-##
+@PACKAGE_INIT@
 
+# - Project properties
+set_and_check(G4HepEm_INCLUDE_DIR "@PACKAGE_G4HEPEM_EXPORTED_INCLUDE_DIR@")
 
-set(G4HepEm_INSTALL_DIR "@CMAKE_INSTALL_PREFIX@")
+set(G4HepEm_cuda_FOUND @G4HepEm_CUDA_BUILD@)
 
-set(G4HepEm_LIB_DIR "@CMAKE_INSTALL_PREFIX@/lib")
+# - Project dependencies
+include(CMakeFindDependencyMacro)
 
-find_path(G4HepEm_INCLUDE_DIR NAMES G4HepEmRunManager.hh HINTS "@CMAKE_INSTALL_PREFIX@/includes" NO_DEFAULT_PATH)
+find_dependency(Geant4 @Geant4_VERSION@ REQUIRED)
 
-find_library(G4HepEm_LIB     NAMES libg4HepEm.a     g4HepEm     PATHS "${G4HepEm_LIB_DIR}" NO_DEFAULT_PATH)
-find_library(G4HepEmData_LIB NAMES libg4HepEmData.a g4HepEmData PATHS "${G4HepEm_LIB_DIR}" NO_DEFAULT_PATH)
-find_library(G4HepEmInit_LIB NAMES libg4HepEmInit.a g4HepEmInit PATHS "${G4HepEm_LIB_DIR}" NO_DEFAULT_PATH)
-find_library(G4HepEmRun_LIB  NAMES libg4HepEmRun.a  g4HepEmRun  PATHS "${G4HepEm_LIB_DIR}" NO_DEFAULT_PATH)
+# TODO: Convert to Target/language/find_dependency
+set(G4HepEm_CMAKE_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+set(G4HepEm_CUDA_LIBRARIES "@CUDA_LIBRARIES@;@CUDA_cudart_static_LIBRARY@")
+set(G4HepEm_CUDA_INCLUDE_DIR "@CUDA_INCLUDE_DIRS@")
+set(G4HepEm_CUDA_NVCC_FLAGS "@CUDA_NVCC_FLAGS@")
+set(G4HepEm_CUDA_BUILD "@G4HepEm_CUDA_BUILD@")
 
-set (G4HepEm_LIBRARIES
-  ${G4HepEm_LIB}
-  ${G4HepEmData_LIB}
-  ${G4HepEmInit_LIB}
-  ${G4HepEmRun_LIB}
-)
+# - Project targets
+include(${CMAKE_CURRENT_LIST_DIR}/G4HepEmTargets.cmake)
 
-set (G4HepEm_CMAKE_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+# - TEMPORARY back compatibility
+set(G4HepEm_LIBRARIES
+  G4HepEm::g4HepEm
+  G4HepEm::g4HepEmData
+  G4HepEm::g4HepEmInit
+  G4HepEm::g4HepEmInit)
 
-set (G4HepEm_CUDA_LIBRARIES "@CUDA_LIBRARIES@;@CUDA_cudart_static_LIBRARY@")
-set (G4HepEm_CUDA_INCLUDE_DIR "@CUDA_INCLUDE_DIRS@")
-set (G4HepEm_CUDA_NVCC_FLAGS "@CUDA_NVCC_FLAGS@")
-set (G4HepEm_CUDA_BUILD "@G4HepEm_CUDA_BUILD@")
-
+# - Requested component check
+check_required_components(G4HepEm)

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -1,9 +1,4 @@
 ## ----------------------------------------------------------------------------
-## Retrieve G4HepEm_INCLUDE_DIR (a collection of all headers set only for testing)
-##
-get_property(G4HepEm_INCLUDE_DIR GLOBAL PROPERTY G4HEPEM_TESTING_INCLUDE_DIR_PROP)
-
-## ----------------------------------------------------------------------------
 ## List of unit tests: under the '/apps/tests/' directory
 ##
 set(UNIT_TESTS_DIR_NAME
@@ -42,7 +37,7 @@ foreach(val RANGE ${len})
   list(GET UNIT_TESTS_DIR_NAME ${val}  t_DIR)
   list(GET UNIT_TESTS_NAME     ${val}  t_NAME)
 
-  file(GLOB SOURCES ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/apps/tests/TestUtils/src/*.cc)
+  file(GLOB SOURCES ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/src/*.cu ${PROJECT_SOURCE_DIR}/apps/tests/TestUtils/src/*.cc)
   file(GLOB HEADERS ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/include/*.hh ${PROJECT_SOURCE_DIR}/apps/tests/TestUtils/include/*.hh)
 
   add_executable(${t_NAME} ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/${t_NAME}.cc ${SOURCES} ${HEADERS})

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -6,75 +6,71 @@ get_property(G4HepEm_INCLUDE_DIR GLOBAL PROPERTY G4HEPEM_TESTING_INCLUDE_DIR_PRO
 ## ----------------------------------------------------------------------------
 ## List of unit tests: under the '/apps/tests/' directory
 ##
-set ( UNIT_TESTS_DIR_NAME
-      "MaterialAndRelated"
-      "ElectronEnergyLoss"
-      "ElectronTargetElementSelector"
-      "ElectronXSections"
-    )
-set ( UNIT_TESTS_NAME
-      "TestMaterialAndRelated"
-      "TestEnergyLossData"
-      "TestElemSelectorData"
-      "TestXSectionData"
-     )
+set(UNIT_TESTS_DIR_NAME
+  "MaterialAndRelated"
+  "ElectronEnergyLoss"
+  "ElectronTargetElementSelector"
+  "ElectronXSections")
+set(UNIT_TESTS_NAME
+  "TestMaterialAndRelated"
+  "TestEnergyLossData"
+  "TestElemSelectorData"
+  "TestXSectionData")
 
 ## ----------------------------------------------------------------------------
 ## List of test applications: under the '/apps/examples' directory
 ##
-set ( TESTS
-      "TestEm3"
-    )
-set ( TESTS_INPUT
-      "-m ${CMAKE_SOURCE_DIR}/apps/examples/TestEm3/ATLASbar.mac"
-    )
-
+set(TESTS
+  "TestEm3")
+set(TESTS_INPUT
+  "-m ${PROJECT_SOURCE_DIR}/apps/examples/TestEm3/ATLASbar.mac")
 
 ## ----------------------------------------------------------------------------
 ## Inactivate GPU build for the testing (if it was active) since there is no DEVICE
 ##
-if ( G4HepEm_CUDA_BUILD )
-  remove_definitions ( -DG4HepEm_CUDA_BUILD )
-endif ( G4HepEm_CUDA_BUILD )
+if(NOT G4HepEm_CUDA_BUILD)
+  remove_definitions(-DG4HepEm_CUDA_BUILD)
+endif()
 
 
 ## ----------------------------------------------------------------------------
 ## First: the unit tests
 ##
-list ( LENGTH UNIT_TESTS_DIR_NAME num )
-math (EXPR len "${num} - 1")
-foreach ( val RANGE ${len} )
-  list (GET UNIT_TESTS_DIR_NAME ${val}  t_DIR  )
-  list (GET UNIT_TESTS_NAME     ${val}  t_NAME )
+list(LENGTH UNIT_TESTS_DIR_NAME num)
+math(EXPR len "${num} - 1")
+foreach(val RANGE ${len})
+  list(GET UNIT_TESTS_DIR_NAME ${val}  t_DIR)
+  list(GET UNIT_TESTS_NAME     ${val}  t_NAME)
 
-  file ( GLOB SOURCES ${CMAKE_SOURCE_DIR}/apps/tests/${t_DIR}/src/*.cc ${CMAKE_SOURCE_DIR}/apps/tests/TestUtils/src/*.cc)
-  file ( GLOB HEADERS ${CMAKE_SOURCE_DIR}/apps/tests/${t_DIR}/include/*.hh ${CMAKE_SOURCE_DIR}/apps/tests/TestUtils/include/*.hh)
+  file(GLOB SOURCES ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/src/*.cc ${PROJECT_SOURCE_DIR}/apps/tests/TestUtils/src/*.cc)
+  file(GLOB HEADERS ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/include/*.hh ${PROJECT_SOURCE_DIR}/apps/tests/TestUtils/include/*.hh)
 
-  add_executable ( ${t_NAME} ${CMAKE_SOURCE_DIR}/apps/tests/${t_DIR}/${t_NAME}.cc ${SOURCES} ${HEADERS})
-  target_include_directories ( ${t_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/apps/tests/${t_DIR}/include;${CMAKE_SOURCE_DIR}/apps/tests/TestUtils/include;${Geant4_INCLUDE_DIR};${G4HepEm_INCLUDE_DIR}" )
-  target_link_libraries ( ${t_NAME} ${Geant4_LIBRARIES};g4HepEmData;g4HepEmInit;g4HepEmRun;g4HepEm )
+  add_executable(${t_NAME} ${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/${t_NAME}.cc ${SOURCES} ${HEADERS})
+  target_include_directories(${t_NAME}
+    PRIVATE
+      "${PROJECT_SOURCE_DIR}/apps/tests/${t_DIR}/include"
+      "${PROJECT_SOURCE_DIR}/apps/tests/TestUtils/include")
+  target_link_libraries(${t_NAME} PRIVATE ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit g4HepEmRun g4HepEm)
 
-  add_test       (${t_NAME}  ${t_NAME} )
-
+  add_test(${t_NAME} ${t_NAME})
 endforeach ()
 
 
 ## ----------------------------------------------------------------------------
 ## Second: the test applications
 ##
-list ( LENGTH TESTS num )
-math (EXPR len "${num} - 1")
-foreach ( val RANGE ${len} )
-  list (GET TESTS      ${val}  t_NAME  )
-  list (GET TESTS_INPU ${val}  t_INPARS )
+list(LENGTH TESTS num)
+math(EXPR len "${num} - 1")
+foreach(val RANGE ${len})
+  list(GET TESTS       ${val}  t_NAME)
+  list(GET TESTS_INPUT ${val}  t_INPARS)
 
-  file ( GLOB SOURCES ${CMAKE_SOURCE_DIR}/apps/examples/${t_NAME}/src/*.cc )
-  file ( GLOB HEADERS ${CMAKE_SOURCE_DIR}/apps/examples/${t_NAME}/include/*.hh )
+  file(GLOB SOURCES ${PROJECT_SOURCE_DIR}/apps/examples/${t_NAME}/src/*.cc)
+  file(GLOB HEADERS ${PROJECT_SOURCE_DIR}/apps/examples/${t_NAME}/include/*.hh)
 
-  add_executable ( ${t_NAME} ${CMAKE_SOURCE_DIR}/apps/examples/${t_NAME}/${t_NAME}.cc ${SOURCES} ${HEADERS})
-  target_include_directories ( ${t_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/apps/examples/${t_NAME}/include;${Geant4_INCLUDE_DIR};${G4HepEm_INCLUDE_DIR}" )
-  target_link_libraries ( ${t_NAME} ${Geant4_LIBRARIES};g4HepEmData;g4HepEmInit;g4HepEmRun;g4HepEm )
+  add_executable(${t_NAME} ${PROJECT_SOURCE_DIR}/apps/examples/${t_NAME}/${t_NAME}.cc ${SOURCES} ${HEADERS})
+  target_include_directories(${t_NAME} PRIVATE "${PROJECT_SOURCE_DIR}/apps/examples/${t_NAME}/include")
+  target_link_libraries(${t_NAME} PRIVATE ${Geant4_LIBRARIES} g4HepEmData g4HepEmInit g4HepEmRun g4HepEm)
 
-  add_test (${t_NAME} ${t_NAME} ${t_INPARS})
-
+  add_test(${t_NAME} ${t_NAME} ${t_INPARS})
 endforeach ()

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -21,14 +21,6 @@ set(TESTS_INPUT
   "-m ${PROJECT_SOURCE_DIR}/apps/examples/TestEm3/ATLASbar.mac")
 
 ## ----------------------------------------------------------------------------
-## Inactivate GPU build for the testing (if it was active) since there is no DEVICE
-##
-if(NOT G4HepEm_CUDA_BUILD)
-  remove_definitions(-DG4HepEm_CUDA_BUILD)
-endif()
-
-
-## ----------------------------------------------------------------------------
 ## First: the unit tests
 ##
 list(LENGTH UNIT_TESTS_DIR_NAME num)


### PR DESCRIPTION
This is a reasonbly large update to G4HepEm's buildscripts to follow recommendations from modern cmake (e.g. https://cliutils.gitlab.io/modern-cmake/) to improve overall simplicity, readability, and reliability. The primary changes are:

- Always set all policies in used version in supported range
- Use `project(... VERSION)` so there is a version number to check, even if it's not especially meaningful yet.
- Use [`GNUInstallDirs`](https://cmake.org/cmake/help/v3.8/module/GNUInstallDirs.html) module for standardized install locations
- Use "target_..." commands to set [usage requirements](https://cmake.org/cmake/help/v3.8/manual/cmake-buildsystem.7.html#build-specification-and-usage-requirements) on targets and ease their use by both internal and external consumers.
- Use [`CMakePackageConfigHelpers`](https://cmake.org/cmake/help/v3.8/module/CMakePackageConfigHelpers.html) to configure/write/install the `G4HepEMConfig` files and helper scripts for use from both the build and install trees.
- Add [`ALIAS`](https://cliutils.gitlab.io/modern-cmake/chapters/install.html) targets to allow G4HepEm to be easily added as a submodule in another project.
- Canonical modern style and formatting of commands, if/foreach blocks

It's currently in WIP form as the CUDA use can also be addressed in the same way, but my GPU machine is offline for a couple of days. I'll add commits for this when I can test again, but the core here is ready for initial tests and review.