### PR TITLE
Implemented copy of the G4HepEm Seltzer-Berger brem.  sampling tables to the device

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmData.hh
@@ -66,6 +66,8 @@ struct G4HepEmData {
 
   struct G4HepEmElectronData*          fTheElectronData_gpu = nullptr;
   struct G4HepEmElectronData*          fThePositronData_gpu = nullptr;
+
+  struct G4HepEmSBTableData*           fTheSBTableData_gpu  = nullptr;
 #endif  // G4HepEm_CUDA_BUILD
 
 };

--- a/G4HepEm/G4HepEmData/include/G4HepEmSBTableData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmSBTableData.hh
@@ -19,25 +19,26 @@ struct G4HepEmSBTableData {
   double                  fElEnergyVect[65];   // [fNumElEnergy]
   double                  fLElEnergyVect[65];  // [fNumElEnergy]
   double                  fKappaVect[54];      // [fNumKappa]
-  double                  fLKappaVect[54];     // [fNumKappa] 
-  
+  double                  fLKappaVect[54];     // [fNumKappa]
+
   int                     fNumHepEmMatCuts;              // #hepEm-MC
+  int                     fNumElemsInMatCuts;            // #elements-in-all-hepEm-MC
   int*                    fGammaCutIndxStartIndexPerMC;  // [ #hepEm-MC]
-  int*                    fGammaCutIndices;              // for each mat-cut and for each of their elements in the corresponding elemnt SB-table [ #hepEM-MC x #elements-per-mc]
+  int*                    fGammaCutIndices;              // for each mat-cut and for each of their elements in the corresponding elemnt SB-table [ #elements-in-all-hepEm-MC]
 
   // data starts index for a given Z
   int                     fNumSBTableData;         // # all data stored in fSBTableData
   int                     fSBTablesStartPerZ[121]; // max Z is 99 so all values above 99 will cast to 99 if any
-  double*                 fSBTableData;            // [fNumSBTableData] 
+  double*                 fSBTableData;            // [fNumSBTableData]
   // for each Z:
   // - [0] #data
   // - [1] minE-grid index for table
-  // - [2] maxE-grid index for table 
+  // - [2] maxE-grid index for table
   // - [3] #gamma-cuts i.e. #materia-cuts (with gamma-cut below upper model elenrgy i.e. 1 GeV)
   //       in which this Z appears
   // - then the S-tables for each energy grid i.e. (maxE-grid-index-minE-grid-indx)+1
-  //   and each has ()#gamma-cuts + 3x#kappa-values) entries ==> i.e. for a given Z 
-  //   there are ([2]-[1]+1) x ([3] + 3x54) values stored.  
+  //   and each has ()#gamma-cuts + 3x#kappa-values) entries ==> i.e. for a given Z
+  //   there are ([2]-[1]+1) x ([3] + 3x54) values stored.
 };
 
 
@@ -46,6 +47,29 @@ void AllocateSBTableData(struct G4HepEmSBTableData** theSBTableData, int numHepE
 
 // Clears all the dynamic part of the G4HepEmSBTableData structure (filled in G4HepEmElectronInit)
 void FreeSBTableData (struct G4HepEmSBTableData** theSBTableData);
+
+
+#ifdef G4HepEm_CUDA_BUILD
+  /**
+    * Allocates memory for and copies the G4HepEmSBTableData structure from the
+    * host to the device.
+    *
+    * @param onHost    pointer to the host side, already initialised G4HepEmSBTableData structure.
+    * @param onDevice  host side address of a device side G4HepEmSBTableData structure memory pointer.
+    *   The pointed memory is cleaned (if not null at input) and points to the device side memory at
+    *   termination that stores the copied G4HepEmSBTableDataa structure.
+    */
+  void CopySBTableDataToDevice(struct G4HepEmSBTableData* onHost, struct G4HepEmSBTableData** onDevice);
+
+  /**
+    * Frees all memory related to the device side G4HepEmSBTableDataa structure referred
+    * by the pointer stored on the host side input argument address.
+    *
+    * @param onDevice host side address of a G4HepEmSBTableData structure located on the device side memory.
+    *   The correspondig device memory will be freed and the input argument address will be set to null.
+    */
+  void FreeSBTableDataOnDevice(struct G4HepEmSBTableData** onDevice);
+#endif // DG4HepEm_CUDA_BUILD
 
 
 #endif // G4HepEmSBTables_HH

--- a/G4HepEm/G4HepEmData/src/G4HepEmData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmData.cc
@@ -14,13 +14,14 @@ void InitG4HepEmData (struct G4HepEmData* theHepEmData) {
   FreeG4HepEmData (theHepEmData);
   //
   theHepEmData->fTheMatCutData       = nullptr;
-  theHepEmData->fTheMaterialData     = nullptr;  
+  theHepEmData->fTheMaterialData     = nullptr;
   theHepEmData->fTheElementData      = nullptr;
-  
+
   theHepEmData->fTheElectronData     = nullptr;
   theHepEmData->fThePositronData     = nullptr;
+
   theHepEmData->fTheSBTableData      = nullptr;
-  
+
 #ifdef G4HepEm_CUDA_BUILD
   theHepEmData->fTheMatCutData_gpu   = nullptr;
   theHepEmData->fTheMaterialData_gpu = nullptr;
@@ -28,6 +29,8 @@ void InitG4HepEmData (struct G4HepEmData* theHepEmData) {
 
   theHepEmData->fTheElectronData_gpu = nullptr;
   theHepEmData->fThePositronData_gpu = nullptr;
+
+  theHepEmData->fTheSBTableData_gpu  = nullptr;
 #endif // G4HepEm_CUDA_BUILD
 
 
@@ -39,9 +42,10 @@ void FreeG4HepEmData (struct G4HepEmData* theHepEmData) {
   FreeMatCutData   ( &(theHepEmData->fTheMatCutData)   );
   FreeMaterialData ( &(theHepEmData->fTheMaterialData) );
   FreeElementData  ( &(theHepEmData->fTheElementData)  );
-  
+
   FreeElectronData ( &(theHepEmData->fTheElectronData) );
   FreeElectronData ( &(theHepEmData->fThePositronData) );
+
   FreeSBTableData  ( &(theHepEmData->fTheSBTableData)  );
 
 #ifdef G4HepEm_CUDA_BUILD
@@ -51,11 +55,8 @@ void FreeG4HepEmData (struct G4HepEmData* theHepEmData) {
 
   FreeElectronDataOnDevice ( &(theHepEmData->fTheElectronData_gpu) );
   FreeElectronDataOnDevice ( &(theHepEmData->fThePositronData_gpu) );
-  // 
-  // no SB data on device yet...
-#endif // G4HepEm_CUDA_BUILD  
- 
+
+  FreeSBTableDataOnDevice  ( &(theHepEmData->fTheSBTableData_gpu)  );
+#endif // G4HepEm_CUDA_BUILD
+
 }
-
-
-

--- a/G4HepEm/G4HepEmData/src/G4HepEmData.cu
+++ b/G4HepEm/G4HepEmData/src/G4HepEmData.cu
@@ -7,9 +7,10 @@
 #include "G4HepEmMaterialData.hh"
 #include "G4HepEmElementData.hh"
 #include "G4HepEmElectronData.hh"
+#include "G4HepEmSBTableData.hh"
 
 void CopyG4HepEmDataToGPU (struct G4HepEmData* onCPU) {
-  // Deep copy each members represented by their pointers.  
+  // Deep copy each members represented by their pointers.
 
   // 1. Copy the G4HepEmMatCutData member and set the device ptr.
   CopyMatCutDataToGPU ( onCPU->fTheMatCutData, &(onCPU->fTheMatCutData_gpu) );
@@ -20,7 +21,7 @@ void CopyG4HepEmDataToGPU (struct G4HepEmData* onCPU) {
   CopyMaterialDataToGPU ( onCPU->fTheMaterialData, &(onCPU->fTheMaterialData_gpu) );
 
 //  FreeMaterialDataOnGPU( &(onCPU->fTheMaterialData_gpu) );
-  
+
   // 3. Copy the G4HepEmElementData member and set the device ptr.
   CopyElementDataToGPU ( onCPU->fTheElementData, &(onCPU->fTheElementData_gpu) );
 
@@ -30,8 +31,10 @@ void CopyG4HepEmDataToGPU (struct G4HepEmData* onCPU) {
   // 4. Copy electron data to the GPU
   CopyElectronDataToDevice( onCPU->fTheElectronData, &(onCPU->fTheElectronData_gpu));
 
-
   // 5. Copy positron data to the GPU
   CopyElectronDataToDevice( onCPU->fThePositronData, &(onCPU->fThePositronData_gpu));
+
+  // 6. Copy SB-brem sampling tables to the GPU
+  CopySBTableDataToDevice( onCPU->fTheSBTableData,   &(onCPU->fTheSBTableData_gpu));
 
 }

--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cu
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cu
@@ -68,11 +68,6 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
   gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut,  onHOST->fElemSelectorBremRBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
   gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBData,                 onHOST->fElemSelectorBremRBData,                sizeof( double ) * numBremRBData,   cudaMemcpyHostToDevice ) );
   //
-  // === Sampling tables for the SB brem model:
-  //
-  // TODO:
-
-  //
   // Finaly copy the top level, i.e. the main struct with the already
   // appropriate pointers to device side memory locations but stored on the host
   gpuErrchk ( cudaMalloc (  onDEVICE,              sizeof(  struct G4HepEmElectronData ) ) );
@@ -101,7 +96,6 @@ void FreeElectronDataOnDevice(struct G4HepEmElectronData** onDEVICE) {
     cudaFree( onHostTo_d->fElemSelectorBremSBData                );
     cudaFree( onHostTo_d->fElemSelectorBremRBStartIndexPerMatCut );
     cudaFree( onHostTo_d->fElemSelectorBremRBData                );
-    // TODO: sampling tables for the SB brem
     //
     // free the remaining device side electron data and set the host side ptr to null
     cudaFree( *onDEVICE );

--- a/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cc
@@ -9,6 +9,7 @@ void AllocateSBTableData(struct G4HepEmSBTableData** theSBTableData, int numHepE
   for (int i=0; i<numHepEmMatCuts; ++i) {
     (*theSBTableData)->fGammaCutIndxStartIndexPerMC[i] = -1;
   }
+  (*theSBTableData)->fNumElemsInMatCuts           = numElemsInMC;
   (*theSBTableData)->fGammaCutIndices             = new int[numElemsInMC];
   for (int i=0; i<numElemsInMC; ++i) {
     (*theSBTableData)->fGammaCutIndices[i] = -1;
@@ -36,4 +37,4 @@ void FreeSBTableData(struct G4HepEmSBTableData** theSBTableData) {
     delete (*theSBTableData);
     *theSBTableData = nullptr;
   }
-} 
+}

--- a/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cu
+++ b/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cu
@@ -1,0 +1,63 @@
+#include "G4HepEmSBTableData.hh"
+//#include <iostream>
+
+#include <cuda_runtime.h>
+#include "G4HepEmCuUtils.hh"
+
+
+void CopySBTableDataToDevice(struct G4HepEmSBTableData* onHOST, struct G4HepEmSBTableData** onDEVICE) {
+  if ( !onHOST ) return;
+  // clean away previous (if any)
+  if ( *onDEVICE ) {
+    FreeSBTableDataOnDevice ( onDEVICE );
+  }
+  // Create a G4HepEmSBTableData structure on the host to store pointers to _d
+  // side arrays on the _h side.
+  struct G4HepEmSBTableData* sbTablesHTo_d = new G4HepEmSBTableData;
+  //
+  // set member values
+  sbTablesHTo_d->fLogMinElEnergy    = onHOST->fLogMinElEnergy;
+  sbTablesHTo_d->fILDeltaElEnergy   = onHOST->fILDeltaElEnergy;
+  const int numHepEmMatCuts         = onHOST->fNumHepEmMatCuts;
+  const int numElemsInMatCuts       = onHOST->fNumElemsInMatCuts;
+  const int numSBTableData          = onHOST->fNumSBTableData;
+  sbTablesHTo_d->fNumHepEmMatCuts   = numHepEmMatCuts;
+  sbTablesHTo_d->fNumElemsInMatCuts = numElemsInMatCuts;
+  sbTablesHTo_d->fNumSBTableData    = numSBTableData;
+  //
+  // allocate device side memory for the dynamic arrys
+  gpuErrchk ( cudaMalloc ( &(sbTablesHTo_d->fGammaCutIndxStartIndexPerMC), sizeof( int )    * numHepEmMatCuts   ) );
+  gpuErrchk ( cudaMalloc ( &(sbTablesHTo_d->fGammaCutIndices),             sizeof( int )    * numElemsInMatCuts ) );
+  gpuErrchk ( cudaMalloc ( &(sbTablesHTo_d->fSBTableData),                 sizeof( double ) * numSBTableData    ) );
+  //
+  gpuErrchk ( cudaMemcpy (   sbTablesHTo_d->fGammaCutIndxStartIndexPerMC,  onHOST->fGammaCutIndxStartIndexPerMC, sizeof( int )    * numHepEmMatCuts,   cudaMemcpyHostToDevice ) );
+  gpuErrchk ( cudaMemcpy (   sbTablesHTo_d->fGammaCutIndices,              onHOST->fGammaCutIndices,             sizeof( int )    * numElemsInMatCuts, cudaMemcpyHostToDevice ) );
+  gpuErrchk ( cudaMemcpy (   sbTablesHTo_d->fSBTableData,                  onHOST->fSBTableData,                 sizeof( double ) * numSBTableData ,   cudaMemcpyHostToDevice ) );
+  //
+  // Finaly copy the top level, i.e. the main struct with the already
+  // appropriate pointers to device side memory locations but stored on the host
+  gpuErrchk ( cudaMalloc (  onDEVICE,                sizeof(  struct G4HepEmSBTableData ) ) );
+  gpuErrchk ( cudaMemcpy ( *onDEVICE, sbTablesHTo_d, sizeof(  struct G4HepEmSBTableData ), cudaMemcpyHostToDevice ) );
+  // and clean
+  delete sbTablesHTo_d;
+}
+
+
+void FreeSBTableDataOnDevice(struct G4HepEmSBTableData** onDEVICE) {
+  if (*onDEVICE) {
+    // copy the on-device data back to host in order to be able to free the device
+    // side dynamically allocated memories
+    struct G4HepEmSBTableData* onHostTo_d = new G4HepEmSBTableData;
+    gpuErrchk ( cudaMemcpy( onHostTo_d, onDEVICE, sizeof( struct G4HepEmSBTableData ), cudaMemcpyDeviceToHost ) );
+    // ELoss data
+    cudaFree( onHostTo_d->fGammaCutIndxStartIndexPerMC );
+    cudaFree( onHostTo_d->fGammaCutIndices             );
+    cudaFree( onHostTo_d->fSBTableData                 );
+    //
+    // free the remaining device side electron data and set the host side ptr to null
+    cudaFree( *onDEVICE );
+    *onDEVICE = nullptr;
+
+    delete onHostTo_d;
+  }
+}


### PR DESCRIPTION
These sampling tables are used (only) at run-time in `G4HepEm` at the final state generation of the low energy e-/e+ model (SB) for bremsstrahlung photon emission.  These makes possible a rejection free sampling of the emitted photon energy (according to the **Seltzer-Berger DCS**-s, i.e. below 1 [GeV] primary energy. Note, that this is special for `G4HepEm` since the corresponding `Geant4` model, `G4SeltzerBergerModel` utilises a rejection based sampling requiring even an expensive 2D interpolation at run-time.  