### PR TITLE
Changes to reuse G4HepEmElectronManager::HowFar on the GPU

### DIFF
--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cu
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cu
@@ -87,7 +87,7 @@ void FreeElectronDataOnDevice(struct G4HepEmElectronData** onDEVICE) {
     // copy the on-device data back to host in order to be able to free the device
     // side dynamically allocated memories
     struct G4HepEmElectronData* onHostTo_d = new G4HepEmElectronData;
-    gpuErrchk ( cudaMemcpy( onHostTo_d, onDEVICE, sizeof( struct G4HepEmElectronData ), cudaMemcpyDeviceToHost ) );
+    gpuErrchk ( cudaMemcpy( onHostTo_d, *onDEVICE, sizeof( struct G4HepEmElectronData ), cudaMemcpyDeviceToHost ) );
     // ELoss data
     cudaFree( onHostTo_d->fELossEnergyGrid );
     cudaFree( onHostTo_d->fELossData       );

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -98,6 +98,17 @@ public:
   G4HepEmHostDevice
   bool PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack);
 
+  /** Function to check if a delta interaction happens instead of the discrete process.
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theTrack pointer to the input information of the track.
+    * @param rand number drawn at random
+    * @return boolean whether a delta interaction happens
+    */
+  G4HepEmHostDevice
+  bool CheckDelta(struct G4HepEmData* hepEmData, struct G4HepEmTrack* theTrack, double rand);
+
   /** Functions that performs all physics interactions for a given e-/e+ particle.
     *
     * This functions can be invoked when the particle is propagated to its post-step point to perform all

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -65,6 +65,22 @@ public:
     */
   void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData);
 
+  /** Function that provides the information regarding how far a given e-/e+ particle goes.
+    *
+    * This function provides the information regarding how far a given e-/e+ particle goes
+    * till it's needed to be stopped again because some physics interaction(s) needs to be performed.
+    * The input/primary e-/e+ particle track is provided as G4HepEmElectronTrack which must have sampled
+    * `number-of-interaction-left`. The computed physics step length is written directly into the input
+    * track. There is no local (state) variable used in the computation.
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input information of the track. The data structure must have all entries
+    *   `number-of-interaction-left` sampled and is also used to deliver the results of the function call, i.e.
+    *   the computed physics step limit is written into its fGStepLength member.
+    */
+  G4HepEmHostDevice
+  void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack);
 
   /** Functions that performs all physics interactions for a given e-/e+ particle.
     *

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -82,6 +82,22 @@ public:
   G4HepEmHostDevice
   void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack);
 
+  /** Functions that performs all continuous physics interactions for a given e-/e+ particle.
+    *
+    * This functions can be invoked when the particle is propagated to its post-step point to perform all
+    * continuous physics interactions. The input/primary e-/e+ particle track is provided through as
+    * G4HepEmElectronTrack. There is no local (state) variable used in the computation.
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input information of the track. All the results of this function call,
+    *   i.e. the primary particle's energy updated to its post-interaction(s), are also delivered through this
+    *   object.
+    * @return boolean whether the particle was stopped
+    */
+  G4HepEmHostDevice
+  bool PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack);
+
   /** Functions that performs all physics interactions for a given e-/e+ particle.
     *
     * This functions can be invoked when the particle is propagated to its post-step point to perform all

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -98,16 +98,15 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
 
 // Note: energy deposit will be set here i.e. this is the first access to it that
 //       will clear the previous step value.
-void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
+bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack) {
   //
   // === 1. MSC should be invoked to obtain the physics step lenght
-  G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack*   theTrack = theElTrack->GetTrack();
   const double gStepLength = theTrack->GetGStepLength();
   const double pStepLength = gStepLength;
   // P-STEP LENGTH SHOUDL BE SET IN EL-TRACK
   if (pStepLength<=0.0) {
-    return;
+    return false;
   }
   //
   // === 2. The `number-of-interaction-left` needs to be updated based on the actual
@@ -121,7 +120,7 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
   // === 3. Continuous energy loss needs to be computed
   const bool isElectron = (theTrack->GetCharge() < 0.0);
   const double theRange = theElTrack->GetRange();
-  double       theEkin  = theTrack->GetEKin();
+  const double theEkin  = theTrack->GetEKin();
   // 3./1. stop tracking when reached the end (i.e. it has been ranged out by the limit)
   // @TODO: actually the tracking cut is around 1 keV and the min-table energy is 100 eV so the second should never
   //        under standard EM constructor configurations
@@ -129,11 +128,7 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
     // stop and deposit the remaining energy
     theTrack->SetEnergyDeposit(theEkin);
     theTrack->SetEKin(0.0);
-    // call annihilation for e+ !!!
-    if (!isElectron) {
-      PerformPositronAnnihilation(tlData, true);
-    }
-    return;
+    return true;
   }
   // 3/1. try linear energy loss approximation:
   const G4HepEmElectronData* elData = isElectron
@@ -152,19 +147,31 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
   if (finalEkin <= hepEmPars->fElectronTrackingCut) {
     eloss     = theEkin;
     finalEkin = 0.0;
-    // call annihilation for e+ !!!
     eloss = G4HepEmMax(eloss, 0.0);
     theTrack->SetEKin(finalEkin);
     theTrack->SetEnergyDeposit(eloss);
+    return true;
+  }
+  eloss = G4HepEmMax(eloss, 0.0);
+  theTrack->SetEKin(finalEkin);
+  theTrack->SetEnergyDeposit(eloss);
+  return false;
+}
+
+void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
+  G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
+  G4HepEmTrack*   theTrack = theElTrack->GetTrack();
+  const bool isElectron = (theTrack->GetCharge() < 0.0);
+
+  bool stopped = PerformContinuous(hepEmData, hepEmPars, theElTrack);
+  if (stopped) {
+    // call annihilation for e+ !!!
     if (!isElectron) {
       PerformPositronAnnihilation(tlData, true);
     }
     return;
   }
-  eloss = G4HepEmMax(eloss, 0.0);
-  theTrack->SetEKin(finalEkin);
-  theTrack->SetEnergyDeposit(eloss);
-  //
+
   // === 4. Discrete part of the interaction (if any)
   // 4/1. check if discrete process limited the step return otherwise (i.e. if
   //      continous or boundary process limited the step)
@@ -176,8 +183,12 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
   theTrack->SetNumIALeft(-1.0, iDProc);
   // 4/2. check if delta interaction happens instead of the real discrete process
   // reset here the number of intercation left for the iDProcess
-  theEkin  = theTrack->GetEKin();
-  theLEkin = theTrack->GetLogEKin();
+  const G4HepEmElectronData* elData = isElectron
+                                      ? hepEmData->fTheElectronData
+                                      : hepEmData->fThePositronData;
+  const int theIMC      = theTrack->GetMCIndex();
+  const double theEkin  = theTrack->GetEKin();
+  const double theLEkin = theTrack->GetLogEKin();
   const double mxsec = (iDProc<2)
                       ? GetRestMacXSec(elData, theIMC, theEkin, theLEkin, iDProc==0)
                       : ComputeMacXsecAnnihilation(theEkin, hepEmData->fTheMaterialData->fMaterialData[hepEmData->fTheMatCutData->fMatCutData[theIMC].fHepEmMatIndex].fElectronDensity);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -158,6 +158,22 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
   return false;
 }
 
+bool G4HepEmElectronManager::CheckDelta(struct G4HepEmData* hepEmData, struct G4HepEmTrack* theTrack, double rand) {
+  const bool isElectron = (theTrack->GetCharge() < 0.0);
+  const G4HepEmElectronData* elData = isElectron
+                                      ? hepEmData->fTheElectronData
+                                      : hepEmData->fThePositronData;
+  const int iDProc      = theTrack->GetWinnerProcessIndex();
+  const int theIMC      = theTrack->GetMCIndex();
+  const int theMatIndex = hepEmData->fTheMatCutData->fMatCutData[theIMC].fHepEmMatIndex;
+  const double theEkin  = theTrack->GetEKin();
+  const double theLEkin = theTrack->GetLogEKin();
+  const double mxsec = (iDProc<2)
+                      ? GetRestMacXSec(elData, theIMC, theEkin, theLEkin, iDProc==0)
+                      : ComputeMacXsecAnnihilation(theEkin, hepEmData->fTheMaterialData->fMaterialData[theMatIndex].fElectronDensity);
+  return mxsec <= 0.0 || rand > mxsec*theTrack->GetMFP(iDProc);
+}
+
 void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
   G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack*   theTrack = theElTrack->GetTrack();
@@ -181,22 +197,14 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
   }
   // reset number of interaction left for the winner discrete process
   theTrack->SetNumIALeft(-1.0, iDProc);
+
   // 4/2. check if delta interaction happens instead of the real discrete process
-  // reset here the number of intercation left for the iDProcess
-  const G4HepEmElectronData* elData = isElectron
-                                      ? hepEmData->fTheElectronData
-                                      : hepEmData->fThePositronData;
-  const int theIMC      = theTrack->GetMCIndex();
-  const double theEkin  = theTrack->GetEKin();
-  const double theLEkin = theTrack->GetLogEKin();
-  const double mxsec = (iDProc<2)
-                      ? GetRestMacXSec(elData, theIMC, theEkin, theLEkin, iDProc==0)
-                      : ComputeMacXsecAnnihilation(theEkin, hepEmData->fTheMaterialData->fMaterialData[hepEmData->fTheMatCutData->fMatCutData[theIMC].fHepEmMatIndex].fElectronDensity);
-  if (mxsec <= 0.0 || tlData->GetRNGEngine()->flat() > mxsec*theTrack->GetMFP(iDProc)) {
-    // delta interaction happens
+  if (CheckDelta(hepEmData, theTrack, tlData->GetRNGEngine()->flat())) {
     return;
   }
+
   // 4/3. perform the discrete part of the winner interaction
+  const double theEkin = theTrack->GetEKin();
   switch (iDProc) {
     case 0: // invoke ioni (for e-/e+):
             PerformElectronIoni(tlData, hepEmData, isElectron);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -24,11 +24,22 @@
 
 // Note: pStepLength will be set here i.e. this is the first access to it that
 //       will clear the previous step value.
-void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
+void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmTLData* tlData) {
+  G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
+  G4HepEmTrack* theTrack = theElTrack->GetTrack();
+  // Sample the `number-of-interaction-left`
+  for (int ip=0; ip<3; ++ip) {
+    if (theTrack->GetNumIALeft(ip)<=0.) {
+      theTrack->SetNumIALeft(-std::log(tlData->GetRNGEngine()->flat()), ip);
+    }
+  }
+  HowFar(hepEmData, hepEmPars, theElTrack);
+}
+
+void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack) {
   int indxWinnerProcess = -1;  // init to continous
   // === 1. Continuous energy loss limit
   double pStepLength    = kALargeValue;
-  G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack* theTrack = theElTrack->GetTrack();
   const double   theEkin = theTrack->GetEKin();
   const double  theLEkin = theTrack->GetLogEKin();
@@ -60,10 +71,7 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
   for (int ip=0; ip<3; ++ip) {
     const double mxsec = mxSecs[ip];
     const double   mfp = (mxsec>0.) ? 1./mxsec : kALargeValue;
-    if (theTrack->GetNumIALeft(ip)<=0.) {
-      theTrack->SetNumIALeft(-std::log(tlData->GetRNGEngine()->flat()), ip);
-    }
-    // save the mac-xsec for the update of the `number-of-intercation-left`:
+    // save the mac-xsec for the update of the `number-of-interaction-left`:
     // the `number-of-intercation-left` should be updated in the along-step-action
     // after the MSC has changed the step.
     theTrack->SetMFP(mfp, ip);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronTrack.hh
@@ -4,6 +4,7 @@
 #define G4HepEmElectronTrack_HH
 
 
+#include "G4HepEmMacros.hh"
 #include "G4HepEmTrack.hh"
 
 // A simple track structure for e-/e+ particles.
@@ -18,6 +19,7 @@
 class G4HepEmElectronTrack {
 
 public:
+  G4HepEmHostDevice
   G4HepEmElectronTrack() {     
     fTrack.ReSet(); 
     fTrack.SetCharge(-1.0);
@@ -25,6 +27,7 @@ public:
     fPStepLength   =  0.0;
   }
   
+  G4HepEmHostDevice
   G4HepEmElectronTrack(const G4HepEmElectronTrack& o) { 
     fTrack         = o.fTrack;
     fTrack.SetCharge(o.GetCharge());
@@ -32,17 +35,24 @@ public:
     fPStepLength   = o.fPStepLength;
   }
   
+  G4HepEmHostDevice
   G4HepEmTrack*  GetTrack()  { return &fTrack; }
 
+  G4HepEmHostDevice
   double  GetCharge() const { return fTrack.GetCharge(); }
   
+  G4HepEmHostDevice
   void    SetRange(double r) { fRange = r; }
+  G4HepEmHostDevice
   double  GetRange()         { return fRange; }
   
+  G4HepEmHostDevice
   void    SetPStepLength(double psl)   { fPStepLength = psl;  }
+  G4HepEmHostDevice
   double  GetPStepLength()             { return fPStepLength; }
   
   // Reset all member values
+  G4HepEmHostDevice
   void ReSet() {
     fTrack.ReSet();
     fTrack.SetCharge(-1.0);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
@@ -2,6 +2,8 @@
 #ifndef G4HepEmTrack_HH
 #define G4HepEmTrack_HH
 
+#include "G4HepEmMacros.hh"
+
 // A simple track structure for neutral particles.
 //
 // This object stores all the basic information (e.g. position, directin, etc) 
@@ -17,8 +19,10 @@
 class G4HepEmTrack {
 
 public:
+  G4HepEmHostDevice
   G4HepEmTrack() { ReSet(); }
   
+  G4HepEmHostDevice
   G4HepEmTrack(const G4HepEmTrack& o) { 
     fPosition[0]   = o.fPosition[0];
     fPosition[1]   = o.fPosition[1];
@@ -56,44 +60,54 @@ public:
   }
   
   // Position
+  G4HepEmHostDevice
   void    SetPosition(double* posv) { 
     fPosition[0] = posv[0];
     fPosition[1] = posv[1];
     fPosition[2] = posv[2];
   }
 
+  G4HepEmHostDevice
   void    SetPosition(double x, double y, double z) { 
     fPosition[0] = x;
     fPosition[1] = y;
     fPosition[2] = z;
   }
   
+  G4HepEmHostDevice
   double* GetPosition() { return fPosition; }
   
   // Direction
+  G4HepEmHostDevice
   void    SetDirection(double* dirv) {
     fDirection[0] = dirv[0];
     fDirection[1] = dirv[1];
     fDirection[2] = dirv[2];
   }
 
+  G4HepEmHostDevice
   void    SetDirection(double x, double y, double z) {
     fDirection[0] = x;
     fDirection[1] = y;
     fDirection[2] = z;
   }
   
+  G4HepEmHostDevice
   double* GetDirection() {return fDirection; }
   
   // Kinetic energy
+  G4HepEmHostDevice
   void    SetEKin(double ekin)  { 
     fEKin    = ekin;
     fLogEKin = 100.0;
   }
   // !!! should be used only with special caution !!!
+  G4HepEmHostDevice
   void    SetLEKin(double lekin)  { fLogEKin = lekin; }
   
+  G4HepEmHostDevice
   double  GetEKin()    const { return fEKin; }
+  G4HepEmHostDevice
   double  GetLogEKin() {
     if (fLogEKin > 99.0) { 
       fLogEKin = (fEKin > 0.) ? std::log(fEKin) : -30;
@@ -102,49 +116,73 @@ public:
   }
     
   // Charge
+  G4HepEmHostDevice
   void    SetCharge(double ch) { fCharge = ch; }
   
+  G4HepEmHostDevice
   double  GetCharge() const { return fCharge; }
   
   //Energy deposit
+  G4HepEmHostDevice
   void    SetEnergyDeposit(double val) { fEDeposit  = val; }
+  G4HepEmHostDevice
   void    AddEnergyDeposit(double val) { fEDeposit += val; }
+  G4HepEmHostDevice
   double  GetEnergyDeposit()  const    { return fEDeposit; }
   
+  G4HepEmHostDevice
   void    SetGStepLength(double gsl)   { fGStepLength = gsl;  }
+  G4HepEmHostDevice
   double  GetGStepLength()    const    { return fGStepLength; }
   
   // Macroscopic cross section
+  G4HepEmHostDevice
   void    SetMFP(double val, int pindx) { fMFPs[pindx] = val; }
+  G4HepEmHostDevice
   double  GetMFP(int pindx)   const     { return fMFPs[pindx]; }
+  G4HepEmHostDevice
   double* GetMFP()                      { return fMFPs; }
   
   // Number of intercation left for the processes with mac-xsec above
+  G4HepEmHostDevice
   void    SetNumIALeft(double val, int pindx) {fNumIALeft[pindx] = val; }
+  G4HepEmHostDevice
   double  GetNumIALeft(int pindx) const       {return fNumIALeft[pindx]; }
+  G4HepEmHostDevice
   double* GetNumIALeft()                      {return fNumIALeft; }
   
   
   // ID 
+  G4HepEmHostDevice
   void    SetID(int id) { fID = id;   }
+  G4HepEmHostDevice
   int     GetID() const { return fID; }
   
   // Parent ID
+  G4HepEmHostDevice
   void    SetParentID(int id) { fIDParent = id;   }
+  G4HepEmHostDevice
   int     GetParentID() const { return fIDParent; }
   
   
+  G4HepEmHostDevice
   void    SetMCIndex(int imc) { fMCIndex = imc;  }
+  G4HepEmHostDevice
   int     GetMCIndex() const { return fMCIndex; }
   
   
+  G4HepEmHostDevice
   void    SetWinnerProcessIndex(int ip) { fPIndxWon = ip; }
+  G4HepEmHostDevice
   int     GetWinnerProcessIndex() const { return fPIndxWon; }   
   
+  G4HepEmHostDevice
   void    SetOnBoundary(bool val)  { fOnBoundary = val;  }
+  G4HepEmHostDevice
   bool    GetOnBoundary() const { return fOnBoundary; }
   
   // Reset all member values
+  G4HepEmHostDevice
   void ReSet() {
     fPosition[0]  = 0.0;
     fPosition[1]  = 0.0;


### PR DESCRIPTION
The idea is that it's possible to reuse most of the code by keeping random numbers out of the computations.