### PR TITLE
Abstract RNG into an object with two function pointers

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
@@ -5,6 +5,7 @@
 #include "G4HepEmMacros.hh"
 
 class  G4HepEmTLData;
+class  G4HepEmRandomEngine;
 struct G4HepEmData;
 struct G4HepEmElectronData;
 
@@ -25,6 +26,18 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
 void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData);
 
 
+// Sampling of the energy transferred to the emitted photon using the numerical
+// Seltzer-Berger DCS.
+G4HepEmHostDevice
+double SampleETransferBremSB(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
+                             int theIMCIndx, G4HepEmRandomEngine* rnge, bool iselectron);
+
+// Sampling of the energy transferred to the emitted photon using the Bethe-Heitler
+// DCS.
+G4HepEmHostDevice
+double SampleETransferBremRB(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
+                             int theIMCIndx, G4HepEmRandomEngine* rnge);
+
 
 // Target atom selector for the above bremsstrahlung intercations in case of
 // materials composed from multiple elements.
@@ -34,14 +47,17 @@ int SelectTargetAtomBrem(const struct G4HepEmElectronData* elData, const int imc
 
 // Simple linear search (with step of 3!) used in the photon energy sampling part
 // of the SB (Seltzer-Berger) brem model.
+G4HepEmHostDevice
 int LinSearch(const double* vect, const int size, const double val);
 
 
+G4HepEmHostDevice
 void EvaluateLPMFunctions(double& funcXiS, double& funcGS, double& funcPhiS, const double egamma,
                      const double etotal, const double elpm, const double z23,
                      const double ilVarS1, const double ilVarS1Cond, const double densityCor);
 
 // LPM functions G(s) and Phi(s) over an s-value grid of: ds=0.05 on [0:2.0] (2x41)
+G4HepEmHostDeviceConstant
 const double kFuncLPM[] = {
   0.0000E+00, 0.0000E+00,  6.9163E-02, 2.5747E-01,  2.0597E-01, 4.4573E-01,
   3.5098E-01, 5.8373E-01,  4.8095E-01, 6.8530E-01,  5.8926E-01, 7.6040E-01,

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -37,15 +37,136 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
   const int             theMCIndx = thePrimaryTrack->GetMCIndex();
   const G4HepEmMCCData& theMCData = hepEmData->fTheMatCutData->fMatCutData[theMCIndx];
   const double          theGamCut = theMCData.fSecGamProdCutE;
-  const double       theLogGamCut = theMCData.fLogSecGamCutE;
   // return if intercation is not possible (should not happen)
   if (thePrimEkin <= theGamCut) return;
-  // get the material data
+  //
+  // == Sampling of the emitted photon energy
+  //
+   double eGamma = SampleETransferBremSB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
+
+   //
+   // sample photon direction (modified Tsai sampling):
+   const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
+   double rndm3[3];
+   double u;
+   do {
+     tlData->GetRNGEngine()->flatArray(3, rndm3);
+     const double uu = -std::log(rndm3[0]*rndm3[1]);
+     u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
+   } while (u > uMax);
+   const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
+   const double sint = std::sqrt((1.0-cost)*(1.0+cost));
+   const double  phi = k2Pi*tlData->GetRNGEngine()->flat();
+   // create secondary photon
+   G4HepEmTrack*         secTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
+   secTrack->SetDirection(sint * std::cos(phi), sint * std::sin(phi), cost);
+   double* theSecondaryDirection = secTrack->GetDirection();
+   double* thePrimaryDirection   = thePrimaryTrack->GetDirection();
+   // rotate back to refernce frame (G4HepEmRunUtils function)
+   RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
+   secTrack->SetEKin(eGamma);
+   secTrack->SetParentID(thePrimaryTrack->GetID());
+
+   //
+   //
+   // compute post-interaction kinematics of the primary e-/e+
+   const double primETot = thePrimEkin + kElectronMassC2;
+   const double primPTot = std::sqrt(thePrimEkin * (primETot + kElectronMassC2));
+   double elDirX = primPTot * thePrimaryDirection[0] - eGamma * theSecondaryDirection[0];
+   double elDirY = primPTot * thePrimaryDirection[1] - eGamma * theSecondaryDirection[1];
+   double elDirZ = primPTot * thePrimaryDirection[2] - eGamma * theSecondaryDirection[2];
+   // normalisation
+   const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
+   // update primary track direction
+   thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
+   // update primary track kinetic energy
+   thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
+   // NOTE: the following usually set to very high energy so I don't include this.
+   // if secondary gamma energy is higher than threshold(very high by default)
+   // then stop tracking the primary particle and create new secondary e-/e+
+   // instead of the primary
+}
+
+
+// Bremsstrahlung interaction based on the Bethe-Heitler DCS with modifications
+// such as screening and Coulomb corrections, emission in the field of the atomic
+// electrons and LPM suppression.
+// Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
+void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData) {
+  //
+  G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack();
+  G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack();
+  //
+  double              thePrimEkin = thePrimaryTrack->GetEKin();
+  const double        theLogEkin  = thePrimaryTrack->GetLogEKin();
+  const int             theMCIndx = thePrimaryTrack->GetMCIndex();
+  const G4HepEmMCCData& theMCData = hepEmData->fTheMatCutData->fMatCutData[theMCIndx];
+  const double          theGamCut = theMCData.fSecGamProdCutE;
+//  const double       theLogGamCut = theMCData.fLogSecGamCutE;
+
+  // return if intercation is not possible (should not happen)
+  if (thePrimEkin <= theGamCut) return;
+
+  //
+  // == Sampling of the emitted photon energy
+  //
+  double eGamma = SampleETransferBremRB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine());
+
+  //
+  // sample photon direction (modified Tsai sampling):
+  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
+  double rndm3[3];
+  double u;
+  do {
+    tlData->GetRNGEngine()->flatArray(3, rndm3);
+    const double uu = -std::log(rndm3[0]*rndm3[1]);
+    u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
+  } while (u > uMax);
+  const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
+  const double sint = std::sqrt((1.0-cost)*(1.0+cost));
+  const double  phi = k2Pi*tlData->GetRNGEngine()->flat();
+  // create secondary photon
+  G4HepEmTrack*        secTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
+  secTrack->SetDirection(sint * std::cos(phi), sint * std::sin(phi), cost);
+  double* theSecondaryDirection = secTrack->GetDirection();
+  double* thePrimaryDirection   = thePrimaryTrack->GetDirection();
+  // rotate back to refernce frame (G4HepEmRunUtils function)
+  RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
+  secTrack->SetEKin(eGamma);
+  secTrack->SetParentID(thePrimaryTrack->GetID());
+
+  //
+  //
+  // compute post-interaction kinematics of the primary e-/e+
+  const double thePrimTotalE = thePrimEkin + kElectronMassC2;
+  const double primPTot = std::sqrt( thePrimEkin * (thePrimTotalE + kElectronMassC2) );
+  double elDirX = primPTot * thePrimaryDirection[0] - eGamma * theSecondaryDirection[0];
+  double elDirY = primPTot * thePrimaryDirection[1] - eGamma * theSecondaryDirection[1];
+  double elDirZ = primPTot * thePrimaryDirection[2] - eGamma * theSecondaryDirection[2];
+  // normalisation
+  const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
+  // update primary track direction
+  thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
+  // update primary track kinetic energy
+  thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
+  // NOTE: the following usually set to very high energy so I don't include this.
+  // if secondary gamma energy is higher than threshold(very high by default)
+  // then stop tracking the primary particle and create new secondary e-/e+
+  // instead of the primary
+}
+
+
+G4HepEmHostDevice
+double SampleETransferBremSB(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
+                             int theMCIndx, G4HepEmRandomEngine* rnge, bool iselectron) {
+  const G4HepEmMCCData& theMCData = hepEmData->fTheMatCutData->fMatCutData[theMCIndx];
+  const double          theGamCut = theMCData.fSecGamProdCutE;
+  const double       theLogGamCut = theMCData.fLogSecGamCutE;
   const G4HepEmMatData& theMData = hepEmData->fTheMaterialData->fMaterialData[theMCData.fHepEmMatIndex];
   // sample target element
   const int elemIndx = (theMData.fNumOfElement > 1)
                        ? SelectTargetAtomBrem(hepEmData->fTheElectronData, theMCIndx, thePrimEkin,
-                                              theLogEkin, tlData->GetRNGEngine()->flat(), true)
+                                              theLogEkin, rnge->flat(), true)
                        : 0;
   const int     iZet = theMData.fElementVect[elemIndx];
   const double  dZet = (double)iZet;
@@ -75,7 +196,7 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
       isCorner = true;
     }
     //
-    if (tlData->GetRNGEngine()->flat()<pIndxH) {
+    if (rnge->flat()<pIndxH) {
       ++elEnergyIndx;      // take the table at the higher e- energy bin
     } else if (isCorner) { // take the table at the lower  e- energy bin
       // special sampling need to be done if lower edge e- energy < gam-gut:
@@ -98,14 +219,13 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
   const double lKTrans = (theLogGamCut-theLogEkin)/(theLogGamCut-theSBTables->fLElEnergyVect[elEnergyIndx]);
   // dielectric (always) and e+ correction suppressions (if the primary is e+)
   const double primETot = thePrimEkin + kElectronMassC2;
-  const double primPTot = std::sqrt(thePrimEkin * (primETot + kElectronMassC2));
   const double dielSupConst = theMData.fDensityCorFactor*primETot*primETot;
   double suppression = 1.0;
   double rndm[2];
   // rejection loop starts here (rejection only for the diel-supression)
   double eGamma = 0.0;
   do {
-    tlData->GetRNGEngine()->flatArray(2, rndm);
+    rnge->flatArray(2, rndm);
     double kappa = 1.0;
     if (!isSimply) {
       const double cumRV  = rndm[0]*(1.0-minV)+minV;
@@ -145,73 +265,22 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
        suppression = (dum > -12.) ? suppression*std::exp(dum) : 0.;
      }
    } while (rndm[1] > suppression);
-   // end of rejection loop: the photon energy is `eGamma`
-   //
-   // sample photon direction (modified Tsai sampling):
-   const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
-   double rndm3[3];
-   double u;
-   do {
-     tlData->GetRNGEngine()->flatArray(3, rndm3);
-     const double uu = -std::log(rndm3[0]*rndm3[1]);
-     u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
-   } while (u > uMax);
-   const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
-   const double sint = std::sqrt((1.0-cost)*(1.0+cost));
-   const double  phi = k2Pi*tlData->GetRNGEngine()->flat();
-   // create secondary photon
-   G4HepEmTrack*         secTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
-   secTrack->SetDirection(sint * std::cos(phi), sint * std::sin(phi), cost);
-   double* theSecondaryDirection = secTrack->GetDirection();
-   double* thePrimaryDirection   = thePrimaryTrack->GetDirection();
-   // rotate back to refernce frame (G4HepEmRunUtils function)
-   RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
-   secTrack->SetEKin(eGamma);
-   secTrack->SetParentID(thePrimaryTrack->GetID());
-
-   //
-   //
-   // compute post-interaction kinematics of the primary e-/e+
-   double elDirX = primPTot * thePrimaryDirection[0] - eGamma * theSecondaryDirection[0];
-   double elDirY = primPTot * thePrimaryDirection[1] - eGamma * theSecondaryDirection[1];
-   double elDirZ = primPTot * thePrimaryDirection[2] - eGamma * theSecondaryDirection[2];
-   // normalisation
-   const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
-   // update primary track direction
-   thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
-   // update primary track kinetic energy
-   thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
-   // NOTE: the following usually set to very high energy so I don't include this.
-   // if secondary gamma energy is higher than threshold(very high by default)
-   // then stop tracking the primary particle and create new secondary e-/e+
-   // instead of the primary
+   return eGamma;
 }
 
-
-// Bremsstrahlung interaction based on the Bethe-Heitler DCS with modifications
-// such as screening and Coulomb corrections, emission in the field of the atomic
-// electrons and LPM suppression.
-// Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
-void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData) {
-  //
-  G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack();
-  G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack();
-  //
-  double              thePrimEkin = thePrimaryTrack->GetEKin();
-  const double        theLogEkin  = thePrimaryTrack->GetLogEKin();
-  const int             theMCIndx = thePrimaryTrack->GetMCIndex();
+G4HepEmHostDevice
+double SampleETransferBremRB(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
+                             int theMCIndx, G4HepEmRandomEngine* rnge) {
   const G4HepEmMCCData& theMCData = hepEmData->fTheMatCutData->fMatCutData[theMCIndx];
   const double          theGamCut = theMCData.fSecGamProdCutE;
 //  const double       theLogGamCut = theMCData.fLogSecGamCutE;
 
-  // return if intercation is not possible (should not happen)
-  if (thePrimEkin <= theGamCut) return;
   // get the material data
   const G4HepEmMatData& theMData  = hepEmData->fTheMaterialData->fMaterialData[theMCData.fHepEmMatIndex];
   // sample target element
   const int elemIndx = (theMData.fNumOfElement > 1)
                        ? SelectTargetAtomBrem(hepEmData->fTheElectronData, theMCIndx, thePrimEkin,
-                                              theLogEkin, tlData->GetRNGEngine()->flat(), false)
+                                              theLogEkin, rnge->flat(), false)
                        : 0;
   const int     iZet = theMData.fElementVect[elemIndx];
   const double  dZet = (double)iZet;
@@ -240,7 +309,7 @@ void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData)
   double rndm[2];
   double eGamma, funcVal;
   do {
-    tlData->GetRNGEngine()->flatArray(2, rndm);
+    rnge->flatArray(2, rndm);
     eGamma = std::sqrt( G4HepEmMax( std::exp( xmin + rndm[0] * xrange ) - densityCorr, 0.0 ) );
     // evaluate the DCS at this emitted gamma energy
     const double y     = eGamma / thePrimTotalE;
@@ -277,47 +346,7 @@ void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData)
     }
     funcVal = G4HepEmMax( 0.0, funcVal);
   } while ( funcVal < rejFuncMax * rndm[1] );
-  // end of rejection loop: the photon energy is `eGamma`
-  //
-  // sample photon direction (modified Tsai sampling):
-  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
-  double rndm3[3];
-  double u;
-  do {
-    tlData->GetRNGEngine()->flatArray(3, rndm3);
-    const double uu = -std::log(rndm3[0]*rndm3[1]);
-    u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
-  } while (u > uMax);
-  const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
-  const double sint = std::sqrt((1.0-cost)*(1.0+cost));
-  const double  phi = k2Pi*tlData->GetRNGEngine()->flat();
-  // create secondary photon
-  G4HepEmTrack*        secTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
-  secTrack->SetDirection(sint * std::cos(phi), sint * std::sin(phi), cost);
-  double* theSecondaryDirection = secTrack->GetDirection();
-  double* thePrimaryDirection   = thePrimaryTrack->GetDirection();
-  // rotate back to refernce frame (G4HepEmRunUtils function)
-  RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
-  secTrack->SetEKin(eGamma);
-  secTrack->SetParentID(thePrimaryTrack->GetID());
-
-  //
-  //
-  // compute post-interaction kinematics of the primary e-/e+
-  const double primPTot = std::sqrt( thePrimEkin * (thePrimTotalE + kElectronMassC2) );
-  double elDirX = primPTot * thePrimaryDirection[0] - eGamma * theSecondaryDirection[0];
-  double elDirY = primPTot * thePrimaryDirection[1] - eGamma * theSecondaryDirection[1];
-  double elDirZ = primPTot * thePrimaryDirection[2] - eGamma * theSecondaryDirection[2];
-  // normalisation
-  const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
-  // update primary track direction
-  thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
-  // update primary track kinetic energy
-  thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
-  // NOTE: the following usually set to very high energy so I don't include this.
-  // if secondary gamma energy is higher than threshold(very high by default)
-  // then stop tracking the primary particle and create new secondary e-/e+
-  // instead of the primary
+  return eGamma;
 }
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.hh
@@ -2,7 +2,10 @@
 #ifndef G4HepEmElectronInteractionIoni_HH
 #define G4HepEmElectronInteractionIoni_HH
 
+#include "G4HepEmMacros.hh"
+
 class  G4HepEmTLData;
+class  G4HepEmRandomEngine;
 struct G4HepEmData;
 
 
@@ -12,9 +15,11 @@ void PerformElectronIoni(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, b
 
 // Sampling of the energy transferred to the secondary electron in case of e- 
 // primary i.e. in case of Moller interaction.
-double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmTLData* tlData);
+G4HepEmHostDevice
+double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmRandomEngine* rnge);
 // Sampling of the energy transferred to the secondary electron in case of e+ 
 // primary i.e. in case of Bhabha interaction.
-double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmTLData* tlData);
+G4HepEmHostDevice
+double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmRandomEngine* rnge);
 
 #endif // G4HepEmElectronInteractionIoni_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.icc
@@ -2,6 +2,7 @@
 #include "G4HepEmElectronInteractionIoni.hh"
 
 #include "G4HepEmTLData.hh"
+#include "G4HepEmRandomEngine.hh"
 #include "G4HepEmData.hh"
 #include "G4HepEmMatCutData.hh"
 
@@ -29,8 +30,8 @@ void PerformElectronIoni(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, b
   const double elInitETot = thePrimEkin + kElectronMassC2;
   const double elInitPTot = std::sqrt(thePrimEkin * (elInitETot + kElectronMassC2));
   const double  deltaEkin = (iselectron) 
-                            ? SampleETransferMoller(theElCut, thePrimEkin, tlData) 
-                            : SampleETransferBhabha(theElCut, thePrimEkin, tlData);
+                            ? SampleETransferMoller(theElCut, thePrimEkin, tlData->GetRNGEngine()) 
+                            : SampleETransferBhabha(theElCut, thePrimEkin, tlData->GetRNGEngine());
   const double deltaPTot = std::sqrt(deltaEkin * (deltaEkin + 2.0 * kElectronMassC2));
   const double      cost = deltaEkin * (elInitETot + kElectronMassC2) / (deltaPTot * elInitPTot);
   // check cosTheta limit
@@ -63,7 +64,7 @@ void PerformElectronIoni(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, b
 }
 
 
-double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmTLData* tlData) {
+double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmRandomEngine* rnge) {
   const double tmin    = elCut;
   const double tmax    = 0.5*primEkin;
   const double xmin    = tmin / primEkin;
@@ -80,7 +81,7 @@ double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmT
   double rndArray[2];
   double deltaEkin  = 0.;
   do {
-    tlData->GetRNGEngine()->flatArray(2, rndArray);
+    rnge->flatArray(2, rndArray);
     deltaEkin       = xminmax / (xmin * (1.0 - rndArray[0]) + xmax * rndArray[0]);
     const double xx = 1.0 - deltaEkin;
     dum             = 1.0 - gg * deltaEkin + deltaEkin * deltaEkin * (1.0 - gg + (1.0 - gg * xx) / (xx * xx));
@@ -88,7 +89,7 @@ double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmT
   return deltaEkin * primEkin;
 }
 
-double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmTLData* tlData) {
+double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmRandomEngine* rnge) {
   const double tmin    = elCut;
   const double tmax    = primEkin;
   const double xmin    = tmin / primEkin;
@@ -113,7 +114,7 @@ double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmT
   double rndArray[2];
   double deltaEkin  = 0.;
   do {
-    tlData->GetRNGEngine()->flatArray(2, rndArray);
+    rnge->flatArray(2, rndArray);
     deltaEkin       = xminmax / (xmin * (1.0 - rndArray[0]) + xmax * rndArray[0]);
     const double xx = deltaEkin * deltaEkin;
     dum             = 1.0 + (xx * xx * b4 - deltaEkin * xx * b3 + xx * b2 - deltaEkin * b1) * beta2;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmMacros.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmMacros.hh
@@ -9,4 +9,11 @@
 #define G4HepEmHostDevice
 #endif
 
+#ifdef __CUDA_ARCH__
+// If compiling for the device, make the constant available.
+#define G4HepEmHostDeviceConstant __device__
+#else
+#define G4HepEmHostDeviceConstant
+#endif
+
 #endif // G4HepEmMacros_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
@@ -1,0 +1,40 @@
+
+#ifndef G4HepEmRandomEngine_HH
+#define G4HepEmRandomEngine_HH
+
+#include "G4HepEmMacros.hh"
+
+/**
+ * @file    G4HepEmRandomEngine.hh
+ * @class   G4HepEmRandomEngine
+ * @author  J. Hahnfeld
+ * @date    2021
+ *
+ * A simple abstraction for a random number engine.
+ *
+ * Holds a reference to the real engine and two function pointers to generate
+ * one random number or fill an array with a given size, respectively.
+ */
+class G4HepEmRandomEngine {
+public:
+  typedef double (*FlatFn)(void *object);
+  typedef void (*FlatArrayFn)(void *object, const int size, double* vect);
+
+  G4HepEmHostDevice
+  G4HepEmRandomEngine(void *object, FlatFn flatFn, FlatArrayFn flatArrayFn)
+    : fObject(object), fFlatFn(flatFn), fFlatArrayFn(flatArrayFn) { }
+
+  G4HepEmHostDevice
+  double flat() { return fFlatFn(fObject); }
+  G4HepEmHostDevice
+  void flatArray(const int size, double* vect) {
+    fFlatArrayFn(fObject, size, vect);
+  }
+
+private:
+  void *fObject;
+  FlatFn fFlatFn;
+  FlatArrayFn fFlatArrayFn;
+};
+
+#endif // G4HepEmRandomEngine_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmTLData.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmTLData.hh
@@ -5,10 +5,9 @@
 
 #include "G4HepEmElectronTrack.hh"
 #include "G4HepEmGammaTrack.hh"
+#include "G4HepEmRandomEngine.hh"
 
-// g4: CLHEP include
-#include "CLHEP/Random/RandomEngine.h"
-
+#include <vector>
 
 /**
  * @file    G4HepEmTLData.hh
@@ -42,8 +41,8 @@ public:
   
  ~G4HepEmTLData();
   
-  void SetRandomEngine(CLHEP::HepRandomEngine* rnge) {fRNGEngine = rnge; }
-  CLHEP::HepRandomEngine* GetRNGEngine() { return fRNGEngine; }
+  void SetRandomEngine(G4HepEmRandomEngine* rnge) { fRNGEngine = rnge; }
+  G4HepEmRandomEngine* GetRNGEngine() { return fRNGEngine; }
   
   G4HepEmElectronTrack* GetPrimaryElectronTrack()   { return &fElectronTrack; }
   G4HepEmElectronTrack* AddSecondaryElectronTrack() { 
@@ -73,7 +72,7 @@ public:
 private:  
   
   // needs to set to point to the RNG engine of the thread
-  CLHEP::HepRandomEngine*            fRNGEngine;
+  G4HepEmRandomEngine*               fRNGEngine;
   
   std::size_t                        fNumSecondaryElectronTracks;
   G4HepEmElectronTrack               fElectronTrack;

--- a/G4HepEm/include/G4HepEmCLHEPRandomEngine.hh
+++ b/G4HepEm/include/G4HepEmCLHEPRandomEngine.hh
@@ -1,0 +1,33 @@
+
+#ifndef G4HepEmCLHEPRandomEngine_HH
+#define G4HepEmCLHEPRandomEngine_HH
+
+#include "G4HepEmRandomEngine.hh"
+
+#include "CLHEP/Random/RandomEngine.h"
+
+/**
+ * @file    G4HepEmCLHEPRandomEngine.hh
+ * @class   G4HepEmCLHEPRandomEngine
+ * @author  J. Hahnfeld
+ * @date    2021
+ *
+ * A wrapper around CLHEP::HepRandomEngine.
+ *
+ * Dispatches to the virtual functions defined in the derived class.
+ */
+class G4HepEmCLHEPRandomEngine : public G4HepEmRandomEngine {
+  // Wrapper functions to call into CLHEP::HepRandomEngine.
+  static double flatWrapper(void *object) {
+    return ((CLHEP::HepRandomEngine*)object)->flat();
+  }
+  static void flatArrayWrapper(void *object, const int size, double* vect) {
+    ((CLHEP::HepRandomEngine*)object)->flatArray(size, vect);
+  }
+
+public:
+  G4HepEmCLHEPRandomEngine(CLHEP::HepRandomEngine* engine)
+    : G4HepEmRandomEngine(/*object=*/engine, &flatWrapper, &flatArrayWrapper) {}
+};
+
+#endif // G4HepEmCLHEPRandomEngine_HH

--- a/G4HepEm/include/G4HepEmProcess.hh
+++ b/G4HepEm/include/G4HepEmProcess.hh
@@ -6,6 +6,7 @@
 #include "G4VProcess.hh"
 
 class  G4HepEmRunManager;  
+class  G4HepEmRandomEngine;
 
 class  G4ParticleChangeForLoss;
 
@@ -103,6 +104,7 @@ public:
 private:
   // the top level interface to the G4HepEm functionalities  
   G4HepEmRunManager*       fTheG4HepEmRunManager;
+  G4HepEmRandomEngine*     fTheG4HepEmRandomEngine;
 
   G4ParticleChangeForLoss* fParticleChangeForLoss;
 

--- a/G4HepEm/include/G4HepEmRunManager.hh
+++ b/G4HepEm/include/G4HepEmRunManager.hh
@@ -13,11 +13,7 @@ class  G4HepEmTLData;
 class  G4HepEmElectronManager;
 class  G4HepEmGammaManager;
 
-// Geant4 CLHEP::HepRandomEngine
-namespace CLHEP {
-  class HepRandomEngine;
-}
-
+class  G4HepEmRandomEngine;
 
 #include <vector>
 
@@ -77,7 +73,7 @@ public:
    *   its random engine pointer to the corresponding geant4, thread local random 
    *   engine pointer.
    */
-  void Initialize (CLHEP::HepRandomEngine* theRNGEngine, int hepEmParticleIndx);
+  void Initialize (G4HepEmRandomEngine* theRNGEngine, int hepEmParticleIndx);
 
    
   /** 

--- a/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/src/G4HepEmProcess.cc
@@ -7,6 +7,7 @@
 #include "G4HepEmMatCutData.hh"
 #include "G4HepEmTLData.hh"
 #include "G4HepEmRunManager.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
 
 #include "G4HepEmElectronTrack.hh"
 #include "G4HepEmGammaTrack.hh"
@@ -25,19 +26,20 @@
 #include "G4Positron.hh"
 #include "G4Gamma.hh"
 
-
 G4HepEmProcess::G4HepEmProcess() 
 : G4VProcess("hepEm", fElectromagnetic), 
   fTheG4HepEmRunManager(nullptr) {
   enableAtRestDoIt    = false;
   enablePostStepDoIt  = false;
   
-  fTheG4HepEmRunManager  = new G4HepEmRunManager(G4Threading::IsMasterThread());  
-  fParticleChangeForLoss = new G4ParticleChangeForLoss();
+  fTheG4HepEmRunManager   = new G4HepEmRunManager(G4Threading::IsMasterThread());
+  fTheG4HepEmRandomEngine = new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine());
+  fParticleChangeForLoss  = new G4ParticleChangeForLoss();
 }
 
 G4HepEmProcess::~G4HepEmProcess() {
   delete fTheG4HepEmRunManager;
+  delete fTheG4HepEmRandomEngine;
 }
 
 
@@ -50,11 +52,11 @@ void G4HepEmProcess::BuildPhysicsTable(const G4ParticleDefinition& partDef) {
   //fTheG4HepEmRunManager->Initialize(G4Random::getTheEngine());
   
   if (partDef.GetPDGEncoding()==11) {          // e- 
-    fTheG4HepEmRunManager->Initialize(G4Random::getTheEngine(), 0);
+    fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 0);
   } else if (partDef.GetPDGEncoding()==-11) {  // e+ 
-    fTheG4HepEmRunManager->Initialize(G4Random::getTheEngine(), 1);
+    fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 1);
   } else if (partDef.GetPDGEncoding()==22) {   // gamma  
-    fTheG4HepEmRunManager->Initialize(G4Random::getTheEngine(), 2);
+    fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 2);
   } else {
     std::cerr << " **** ERROR in G4HepEmProcess::BuildPhysicsTable: unknown particle " << std::endl;
     exit(-1); 

--- a/G4HepEm/src/G4HepEmRunManager.cc
+++ b/G4HepEm/src/G4HepEmRunManager.cc
@@ -13,9 +13,7 @@
 #include "G4HepEmElectronInit.hh"
 #include "G4HepEmElectronManager.hh"
 
-// g4 includes
-#include "Randomize.hh"
-#include "CLHEP/Random/RandomEngine.h"
+#include "G4HepEmRandomEngine.hh"
 
 
 #include <iostream>
@@ -88,7 +86,7 @@ void G4HepEmRunManager::InitializeGlobal() {
   }
 }
 
-void G4HepEmRunManager::Initialize(CLHEP::HepRandomEngine* theRNGEngine, int hepEmParticleIndx) {
+void G4HepEmRunManager::Initialize(G4HepEmRandomEngine* theRNGEngine, int hepEmParticleIndx) {
   if (fIsMaster) {
     //
     // Build the global data structures (material-cuts, material, element data and

--- a/apps/tests/ElectronEnergyLoss/TestEnergyLossData.cc
+++ b/apps/tests/ElectronEnergyLoss/TestEnergyLossData.cc
@@ -5,11 +5,11 @@
 #include "globals.hh"
 #include "G4SystemOfUnits.hh"
 #include "Randomize.hh"
-#include "CLHEP/Random/RandomEngine.h"
 
 
 #include "G4HepEmRunManager.hh"
 #include "G4HepEmData.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
 
 int main() {
   int verbose = 1;
@@ -39,7 +39,8 @@ int main() {
   //     method for e- (could be any of e-: 0; e+: 1; or gamma: 2).
   int g4HepEmParticleIndx = 0; // e-
   G4HepEmRunManager* runMgr = new G4HepEmRunManager ( true );
-  runMgr->Initialize ( G4Random::getTheEngine(), g4HepEmParticleIndx );
+  G4HepEmCLHEPRandomEngine* rng = new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine());
+  runMgr->Initialize ( rng, g4HepEmParticleIndx );
   
   
   //

--- a/apps/tests/ElectronTargetElementSelector/TestElemSelectorData.cc
+++ b/apps/tests/ElectronTargetElementSelector/TestElemSelectorData.cc
@@ -5,11 +5,11 @@
 #include "globals.hh"
 #include "G4SystemOfUnits.hh"
 #include "Randomize.hh"
-#include "CLHEP/Random/RandomEngine.h"
 
 
 #include "G4HepEmRunManager.hh"
 #include "G4HepEmData.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
 
 
 int main() {
@@ -40,7 +40,8 @@ int main() {
   //     method for e- (could be any of e-: 0; e+: 1; or gamma: 2).
   int g4HepEmParticleIndx = 1; // e-: 0; e+: 1;  
   G4HepEmRunManager* runMgr = new G4HepEmRunManager ( true );
-  runMgr->Initialize ( G4Random::getTheEngine(), g4HepEmParticleIndx );
+  G4HepEmCLHEPRandomEngine* rng = new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine());
+  runMgr->Initialize ( rng, g4HepEmParticleIndx );
   
   //
   // --- Make all G4HepEmData member available on the device (only if G4HepEm_CUDA_BUILD)

--- a/apps/tests/ElectronXSections/TestXSectionData.cc
+++ b/apps/tests/ElectronXSections/TestXSectionData.cc
@@ -5,11 +5,11 @@
 #include "globals.hh"
 #include "G4SystemOfUnits.hh"
 #include "Randomize.hh"
-#include "CLHEP/Random/RandomEngine.h"
 
 
 #include "G4HepEmRunManager.hh"
 #include "G4HepEmData.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
 
 int main() {
   int verbose = 1;
@@ -39,7 +39,8 @@ int main() {
   //     method for e- (could be any of e-: 0; e+: 1; or gamma: 2).
   int g4HepEmParticleIndx = 0; // e-: 0; e+: 1;  
   G4HepEmRunManager* runMgr = new G4HepEmRunManager ( true );
-  runMgr->Initialize ( G4Random::getTheEngine(), g4HepEmParticleIndx );
+  G4HepEmCLHEPRandomEngine* rng = new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine());
+  runMgr->Initialize ( rng, g4HepEmParticleIndx );
   
   
   //

--- a/apps/tests/MaterialAndRelated/TestMaterialAndRelated.cc
+++ b/apps/tests/MaterialAndRelated/TestMaterialAndRelated.cc
@@ -4,11 +4,11 @@
 #include "globals.hh"
 #include "G4SystemOfUnits.hh"
 #include "Randomize.hh"
-#include "CLHEP/Random/RandomEngine.h"
 
 
 #include "G4HepEmRunManager.hh"
 #include "G4HepEmData.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
 
 int main() {
   int verbose = 1;
@@ -37,7 +37,8 @@ int main() {
   //     Therefore, here we create a `master` G4HepEmRunManager and call its Initialize() 
   //     method for e- (could be any of e-, e+ or gamma).
   G4HepEmRunManager* runMgr = new G4HepEmRunManager ( true );
-  runMgr->Initialize ( G4Random::getTheEngine(), 0 );
+  G4HepEmCLHEPRandomEngine* rng = new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine());
+  runMgr->Initialize ( rng, 0 );
   
   //
   // --- Make all G4HepEmData member available on the device (only if G4HepEm_CUDA_BUILD)


### PR DESCRIPTION
`G4HepEmRandomEngine` holds a reference to the real engine and two function pointers to generate one random number or fill an array with a given size, respectively. `G4HepEmCLHEPRandomEngine` is a wrapper around `CLHEP::HepRandomEngine` and dispatches to the virtual functions defined in the derived class.

The goal of this abstraction is to decouple the `G4HepEmRun` library from `CLHEP` and pave the way for passing in custom RNG implementations to the final state sampling. This enables further changes to reuse more code on the GPU.

---

Building on this abstraction, make the energy transfer sampling for ionisation and Bremsstrahlung reusable.