### PR TITLE
Unit/model level test for testing the interaction models for e-/e+ bremsstrahlung photon emission.

### DIFF
--- a/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cu
+++ b/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cu
@@ -24,6 +24,18 @@ void CopySBTableDataToDevice(struct G4HepEmSBTableData* onHOST, struct G4HepEmSB
   sbTablesHTo_d->fNumHepEmMatCuts   = numHepEmMatCuts;
   sbTablesHTo_d->fNumElemsInMatCuts = numElemsInMatCuts;
   sbTablesHTo_d->fNumSBTableData    = numSBTableData;
+  // copy array values
+  for (int i=0; i<121; ++i) {
+    sbTablesHTo_d->fSBTablesStartPerZ[i] = onHOST->fSBTablesStartPerZ[i];
+  }
+  for (int i=0; i<65; ++i) {
+    sbTablesHTo_d->fElEnergyVect[i]  = onHOST->fElEnergyVect[i];
+    sbTablesHTo_d->fLElEnergyVect[i] = onHOST->fLElEnergyVect[i];
+  }
+  for (int i=0; i<54; ++i) {
+    sbTablesHTo_d->fKappaVect[i]  = onHOST->fKappaVect[i];
+    sbTablesHTo_d->fLKappaVect[i] = onHOST->fKappaVect[i];
+  }
   //
   // allocate device side memory for the dynamic arrys
   gpuErrchk ( cudaMalloc ( &(sbTablesHTo_d->fGammaCutIndxStartIndexPerMC), sizeof( int )    * numHepEmMatCuts   ) );

--- a/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cu
+++ b/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cu
@@ -34,7 +34,7 @@ void CopySBTableDataToDevice(struct G4HepEmSBTableData* onHOST, struct G4HepEmSB
   }
   for (int i=0; i<54; ++i) {
     sbTablesHTo_d->fKappaVect[i]  = onHOST->fKappaVect[i];
-    sbTablesHTo_d->fLKappaVect[i] = onHOST->fKappaVect[i];
+    sbTablesHTo_d->fLKappaVect[i] = onHOST->fLKappaVect[i];
   }
   //
   // allocate device side memory for the dynamic arrys

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
@@ -23,7 +23,7 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
 // such as screening and Coulomb corrections, emission in the field of the atomic
 // electrons and LPM suppression.
 // Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
-void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData);
+void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron);
 
 
 // Sampling of the energy transferred to the emitted photon using the numerical
@@ -36,7 +36,7 @@ double SampleETransferBremSB(struct G4HepEmData* hepEmData, double thePrimEkin, 
 // DCS.
 G4HepEmHostDevice
 double SampleETransferBremRB(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
-                             int theIMCIndx, G4HepEmRandomEngine* rnge);
+                             int theIMCIndx, G4HepEmRandomEngine* rnge, bool iselectron);
 
 
 // Target atom selector for the above bremsstrahlung intercations in case of

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -92,7 +92,7 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
 // such as screening and Coulomb corrections, emission in the field of the atomic
 // electrons and LPM suppression.
 // Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
-void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData) {
+void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron) {
   //
   G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack();
@@ -110,7 +110,7 @@ void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData)
   //
   // == Sampling of the emitted photon energy
   //
-  double eGamma = SampleETransferBremRB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine());
+  double eGamma = SampleETransferBremRB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
 
   //
   // sample photon direction (modified Tsai sampling):

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -164,9 +164,9 @@ double SampleETransferBremSB(struct G4HepEmData* hepEmData, double thePrimEkin, 
   const double       theLogGamCut = theMCData.fLogSecGamCutE;
   const G4HepEmMatData& theMData = hepEmData->fTheMaterialData->fMaterialData[theMCData.fHepEmMatIndex];
   // sample target element
+  const G4HepEmElectronData* theElData = iselectron ? hepEmData->fTheElectronData : hepEmData->fThePositronData;
   const int elemIndx = (theMData.fNumOfElement > 1)
-                       ? SelectTargetAtomBrem(hepEmData->fTheElectronData, theMCIndx, thePrimEkin,
-                                              theLogEkin, rnge->flat(), true)
+                       ? SelectTargetAtomBrem(theElData, theMCIndx, thePrimEkin, theLogEkin, rnge->flat(), true)
                        : 0;
   const int     iZet = theMData.fElementVect[elemIndx];
   const double  dZet = (double)iZet;
@@ -270,17 +270,17 @@ double SampleETransferBremSB(struct G4HepEmData* hepEmData, double thePrimEkin, 
 
 G4HepEmHostDevice
 double SampleETransferBremRB(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
-                             int theMCIndx, G4HepEmRandomEngine* rnge) {
+                             int theMCIndx, G4HepEmRandomEngine* rnge, bool iselectron) {
   const G4HepEmMCCData& theMCData = hepEmData->fTheMatCutData->fMatCutData[theMCIndx];
   const double          theGamCut = theMCData.fSecGamProdCutE;
 //  const double       theLogGamCut = theMCData.fLogSecGamCutE;
 
   // get the material data
-  const G4HepEmMatData& theMData  = hepEmData->fTheMaterialData->fMaterialData[theMCData.fHepEmMatIndex];
+  const G4HepEmMatData&  theMData = hepEmData->fTheMaterialData->fMaterialData[theMCData.fHepEmMatIndex];
   // sample target element
+  const G4HepEmElectronData*  theElData = iselectron ? hepEmData->fTheElectronData : hepEmData->fThePositronData;
   const int elemIndx = (theMData.fNumOfElement > 1)
-                       ? SelectTargetAtomBrem(hepEmData->fTheElectronData, theMCIndx, thePrimEkin,
-                                              theLogEkin, rnge->flat(), false)
+                       ? SelectTargetAtomBrem(theElData, theMCIndx, thePrimEkin, theLogEkin, rnge->flat(), false)
                        : 0;
   const int     iZet = theMData.fElementVect[elemIndx];
   const double  dZet = (double)iZet;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -9,7 +9,8 @@ struct G4HepEmParameters;
 struct G4HepEmElectronData;
 
 class  G4HepEmTLData;
-
+class  G4HepEmElectronTrack;
+class  G4HepEmTrack; 
 
 /**
  * @file    G4HepEmElectronManager.hh
@@ -80,7 +81,7 @@ public:
     *   the computed physics step limit is written into its fGStepLength member.
     */
   G4HepEmHostDevice
-  void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack);
+  void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack);
 
   /** Functions that performs all continuous physics interactions for a given e-/e+ particle.
     *
@@ -96,7 +97,7 @@ public:
     * @return boolean whether the particle was stopped
     */
   G4HepEmHostDevice
-  bool PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack);
+  bool PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack);
 
   /** Function to check if a delta interaction happens instead of the discrete process.
     *
@@ -107,7 +108,7 @@ public:
     * @return boolean whether a delta interaction happens
     */
   G4HepEmHostDevice
-  bool CheckDelta(struct G4HepEmData* hepEmData, struct G4HepEmTrack* theTrack, double rand);
+  bool CheckDelta(struct G4HepEmData* hepEmData, G4HepEmTrack* theTrack, double rand);
 
   /** Functions that performs all physics interactions for a given e-/e+ particle.
     *

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -13,6 +13,7 @@
 #include "G4HepEmMath.hh"
 
 #include "G4HepEmRunUtils.hh"
+#include "G4HepEmTrack.hh"
 #include "G4HepEmElectronTrack.hh"
 #include "G4HepEmGammaTrack.hh"
 #include "G4HepEmElectronInteractionIoni.hh"
@@ -24,7 +25,7 @@
 
 // Note: pStepLength will be set here i.e. this is the first access to it that
 //       will clear the previous step value.
-void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmTLData* tlData) {
+void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
   G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack* theTrack = theElTrack->GetTrack();
   // Sample the `number-of-interaction-left`
@@ -98,7 +99,7 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
 
 // Note: energy deposit will be set here i.e. this is the first access to it that
 //       will clear the previous step value.
-bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, struct G4HepEmElectronTrack* theElTrack) {
+bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack) {
   //
   // === 1. MSC should be invoked to obtain the physics step lenght
   G4HepEmTrack*   theTrack = theElTrack->GetTrack();
@@ -158,7 +159,7 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
   return false;
 }
 
-bool G4HepEmElectronManager::CheckDelta(struct G4HepEmData* hepEmData, struct G4HepEmTrack* theTrack, double rand) {
+bool G4HepEmElectronManager::CheckDelta(struct G4HepEmData* hepEmData, G4HepEmTrack* theTrack, double rand) {
   const bool isElectron = (theTrack->GetCharge() < 0.0);
   const G4HepEmElectronData* elData = isElectron
                                       ? hepEmData->fTheElectronData

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -213,7 +213,7 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
             if (theEkin < hepEmPars->fElectronBremModelLim) {
               PerformElectronBremSB(tlData, hepEmData, isElectron);
             } else {
-              PerformElectronBremRB(tlData, hepEmData);
+              PerformElectronBremRB(tlData, hepEmData, isElectron);
             }
             break;
     case 2: // invoke annihilation (in-flight) for e+

--- a/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
@@ -6,12 +6,12 @@
 
 // A simple track structure for neutral particles.
 //
-// This object stores all the basic information (e.g. position, directin, etc) 
-// a track needs to keep and propagate between the different component of the 
-// simulation. 
-// Both the G4HepEmElectronTrack and G4HepEmGammaTrack contain an instance of 
-// this. While the G4HepEmTrack is already sufficient to store all information 
-// for gamma particle tracks the G4HepEmElectronTrack contains additional members 
+// This object stores all the basic information (e.g. position, directin, etc)
+// a track needs to keep and propagate between the different component of the
+// simulation.
+// Both the G4HepEmElectronTrack and G4HepEmGammaTrack contain an instance of
+// this. While the G4HepEmTrack is already sufficient to store all information
+// for gamma particle tracks the G4HepEmElectronTrack contains additional members
 // speacial for charged particle tracks and their simualtion.
 
 #include <cmath>
@@ -21,9 +21,9 @@ class G4HepEmTrack {
 public:
   G4HepEmHostDevice
   G4HepEmTrack() { ReSet(); }
-  
+
   G4HepEmHostDevice
-  G4HepEmTrack(const G4HepEmTrack& o) { 
+  G4HepEmTrack(const G4HepEmTrack& o) {
     fPosition[0]   = o.fPosition[0];
     fPosition[1]   = o.fPosition[1];
     fPosition[2]   = o.fPosition[2];
@@ -34,49 +34,49 @@ public:
 
     fEKin          = o.fEKin;
     fLogEKin       = o.fLogEKin;
-    
+
     fCharge        = o.fCharge;
-    
+
     fEDeposit      = o.fEDeposit;
-    
+
     fGStepLength   = o.fGStepLength;
-    
+
     fMFPs[0]       = o.fMFPs[0];
     fMFPs[1]       = o.fMFPs[1];
     fMFPs[2]       = o.fMFPs[2];
 
     fNumIALeft[0] = o.fNumIALeft[0];
     fNumIALeft[1] = o.fNumIALeft[1];
-    fNumIALeft[2] = o.fNumIALeft[2]; 
-    
+    fNumIALeft[2] = o.fNumIALeft[2];
+
     fID           = o.fID;
     fIDParent     = o.fIDParent;
-    
+
     fMCIndex      = o.fMCIndex;
-    
+
     fPIndxWon     = o.fPIndxWon;
-    
+
     fOnBoundary   = o.fOnBoundary;
   }
-  
+
   // Position
   G4HepEmHostDevice
-  void    SetPosition(double* posv) { 
+  void    SetPosition(double* posv) {
     fPosition[0] = posv[0];
     fPosition[1] = posv[1];
     fPosition[2] = posv[2];
   }
 
   G4HepEmHostDevice
-  void    SetPosition(double x, double y, double z) { 
+  void    SetPosition(double x, double y, double z) {
     fPosition[0] = x;
     fPosition[1] = y;
     fPosition[2] = z;
   }
-  
+
   G4HepEmHostDevice
   double* GetPosition() { return fPosition; }
-  
+
   // Direction
   G4HepEmHostDevice
   void    SetDirection(double* dirv) {
@@ -91,37 +91,45 @@ public:
     fDirection[1] = y;
     fDirection[2] = z;
   }
-  
+
   G4HepEmHostDevice
   double* GetDirection() {return fDirection; }
-  
+
   // Kinetic energy
   G4HepEmHostDevice
-  void    SetEKin(double ekin)  { 
+  void    SetEKin(double ekin)  {
     fEKin    = ekin;
     fLogEKin = 100.0;
   }
+
   // !!! should be used only with special caution !!!
   G4HepEmHostDevice
   void    SetLEKin(double lekin)  { fLogEKin = lekin; }
-  
+  G4HepEmHostDevice
+  void    SetEKin(double ekin, double lekin)  {
+    fEKin    = ekin;
+    fLogEKin = lekin;
+  }
+
+
+
   G4HepEmHostDevice
   double  GetEKin()    const { return fEKin; }
   G4HepEmHostDevice
   double  GetLogEKin() {
-    if (fLogEKin > 99.0) { 
+    if (fLogEKin > 99.0) {
       fLogEKin = (fEKin > 0.) ? std::log(fEKin) : -30;
     }
     return fLogEKin;
   }
-    
+
   // Charge
   G4HepEmHostDevice
   void    SetCharge(double ch) { fCharge = ch; }
-  
+
   G4HepEmHostDevice
   double  GetCharge() const { return fCharge; }
-  
+
   //Energy deposit
   G4HepEmHostDevice
   void    SetEnergyDeposit(double val) { fEDeposit  = val; }
@@ -129,12 +137,12 @@ public:
   void    AddEnergyDeposit(double val) { fEDeposit += val; }
   G4HepEmHostDevice
   double  GetEnergyDeposit()  const    { return fEDeposit; }
-  
+
   G4HepEmHostDevice
   void    SetGStepLength(double gsl)   { fGStepLength = gsl;  }
   G4HepEmHostDevice
   double  GetGStepLength()    const    { return fGStepLength; }
-  
+
   // Macroscopic cross section
   G4HepEmHostDevice
   void    SetMFP(double val, int pindx) { fMFPs[pindx] = val; }
@@ -142,7 +150,7 @@ public:
   double  GetMFP(int pindx)   const     { return fMFPs[pindx]; }
   G4HepEmHostDevice
   double* GetMFP()                      { return fMFPs; }
-  
+
   // Number of intercation left for the processes with mac-xsec above
   G4HepEmHostDevice
   void    SetNumIALeft(double val, int pindx) {fNumIALeft[pindx] = val; }
@@ -150,78 +158,78 @@ public:
   double  GetNumIALeft(int pindx) const       {return fNumIALeft[pindx]; }
   G4HepEmHostDevice
   double* GetNumIALeft()                      {return fNumIALeft; }
-  
-  
-  // ID 
+
+
+  // ID
   G4HepEmHostDevice
   void    SetID(int id) { fID = id;   }
   G4HepEmHostDevice
   int     GetID() const { return fID; }
-  
+
   // Parent ID
   G4HepEmHostDevice
   void    SetParentID(int id) { fIDParent = id;   }
   G4HepEmHostDevice
   int     GetParentID() const { return fIDParent; }
-  
-  
+
+
   G4HepEmHostDevice
   void    SetMCIndex(int imc) { fMCIndex = imc;  }
   G4HepEmHostDevice
   int     GetMCIndex() const { return fMCIndex; }
-  
-  
+
+
   G4HepEmHostDevice
   void    SetWinnerProcessIndex(int ip) { fPIndxWon = ip; }
   G4HepEmHostDevice
-  int     GetWinnerProcessIndex() const { return fPIndxWon; }   
-  
+  int     GetWinnerProcessIndex() const { return fPIndxWon; }
+
   G4HepEmHostDevice
   void    SetOnBoundary(bool val)  { fOnBoundary = val;  }
   G4HepEmHostDevice
   bool    GetOnBoundary() const { return fOnBoundary; }
-  
+
   // Reset all member values
   G4HepEmHostDevice
   void ReSet() {
     fPosition[0]  = 0.0;
     fPosition[1]  = 0.0;
     fPosition[2]  = 0.0;
-    
+
     fDirection[0] = 0.0;
     fDirection[1] = 0.0;
     fDirection[2] = 0.0;
-    
+
     fEKin         = 0.0;
     fLogEKin      = 100.0;
 
     fCharge       = 0.0;
-        
+
     fEDeposit     = 0.0;
-    
+
     // step length along the original direction
     fGStepLength  = 0.0;
-    
+
     fMFPs[0]      = -1.0;
     fMFPs[1]      = -1.0;
-    
+
     fNumIALeft[0] = -1.0;
     fNumIALeft[1] = -1.0;
-    
+
     fID           =  -1;
-    fIDParent     =  -1;    
-    
+    fIDParent     =  -1;
+
     fMCIndex      =  -1;
-    
+
     fPIndxWon     =  -1;
-    
+
     fOnBoundary   = false;
   }
-  
-  
-  
+
+
+
 private:
-    
+
   double   fPosition[3];
   double   fDirection[3];
   double   fEKin;
@@ -231,14 +239,14 @@ private:
   double   fGStepLength;   // step length along the original direction (straight line)
   double   fMFPs[3];       // pair, compton, photo-electric in case of photon
   double   fNumIALeft[3];  // ioni, brem, (e+-e- annihilation) in case of e- (e+)
-  
+
   int      fID;
   int      fIDParent;
-  
+
   int      fMCIndex;
-  
+
   int      fPIndxWon; // 0-pair, 1-compton, 2-photo-electric for photon
-                      // 0-ioni, 1-brem,  (2-annihilation) for e- (e+)   
+                      // 0-ioni, 1-brem,  (2-annihilation) for e- (e+)
   bool     fOnBoundary;
 };
 

--- a/G4HepEm/include/G4HepEmRunManager.hh
+++ b/G4HepEm/include/G4HepEmRunManager.hh
@@ -26,63 +26,63 @@ class  G4HepEmRandomEngine;
  *
  * This is the top level interface to all G4HepEm functionalities.
  *
- * A master object is responsible to construct, store and initialise all global 
- * (e.g. material, material-cut, element, configuartion parameter, etc) related 
- * data structures used by (at run-time), and shared among all other (worker) 
- * run managers. These need to be done only once for a given run: only once for 
+ * A master object is responsible to construct, store and initialise all global
+ * (e.g. material, material-cut, element, configuartion parameter, etc) related
+ * data structures used by (at run-time), and shared among all other (worker)
+ * run managers. These need to be done only once for a given run: only once for
  * all (e-/e+ and gamma) particles and only by the master.
- * Additional data structures are aslo created by the master run manager that 
- * are also shared between the workers. These are data, specific for a given 
- * particle type and needs to be crated only if it's required i.e. if the 
- * simulation of that particle needs to be done by the HepEm. These need to be 
- * created and initialised only by the master and individually for each particle 
- * when requested. 
- * All the above data objects are constructed by and stored in the master run 
- * manager and worker run managers will have only their pointer mebers to set to 
+ * Additional data structures are aslo created by the master run manager that
+ * are also shared between the workers. These are data, specific for a given
+ * particle type and needs to be crated only if it's required i.e. if the
+ * simulation of that particle needs to be done by the HepEm. These need to be
+ * created and initialised only by the master and individually for each particle
+ * when requested.
+ * All the above data objects are constructed by and stored in the master run
+ * manager and worker run managers will have only their pointer mebers to set to
  * these unique data objects (used as read-only at run time).
- * Beyond these shared data objects, each worker run-manager will have their own 
- * instance from the G4HepEmTLData that stores worker local data. 
- */  
+ * Beyond these shared data objects, each worker run-manager will have their own
+ * instance from the G4HepEmTLData that stores worker local data.
+ */
 
 
 
 class G4HepEmRunManager {
-  
+
 public:
-  
+
   G4HepEmRunManager (bool ismaster);
  ~G4HepEmRunManager ();
 
   static G4HepEmRunManager* GetMasterRunManager (); 
-  
-  /** 
+
+  /**
    * Builds or sets (data) members of run-manager.
-   * 
+   *
    * For the master-RM it initialises i.e. builds:
-   * - the `global` data structures that are shared by all run-managers i.e. 
-   *   shared by all workers, processes and particles at run-time as read-only 
+   * - the `global` data structures that are shared by all run-managers i.e.
+   *   shared by all workers, processes and particles at run-time as read-only
    *   data (configuration parameters, all the elememnt, material and material-
-   *   production-cuts related data structres). 
-   * - particle specific data that are also shared by all run-managers i.e. by 
-   *   all workers (range, dE/dx tables for e-/e+, macroscopic cross sections 
+   *   production-cuts related data structres).
+   * - particle specific data that are also shared by all run-managers i.e. by
+   *   all workers (range, dE/dx tables for e-/e+, macroscopic cross sections
    *   and target element selectors)
    * For a worker-RM:
-   * - sets all the pointer members to data that are shared among the run-managers 
+   * - sets all the pointer members to data that are shared among the run-managers
    *   to their master values.
-   * - creates and sets the worker-local data structure for each worker and sets 
-   *   its random engine pointer to the corresponding geant4, thread local random 
+   * - creates and sets the worker-local data structure for each worker and sets
+   *   its random engine pointer to the corresponding geant4, thread local random
    *   engine pointer.
    */
   void Initialize (G4HepEmRandomEngine* theRNGEngine, int hepEmParticleIndx);
 
-   
-  /** 
-   * Clears all data structures that has been created by calling the Initialize() 
+
+  /**
+   * Clears all data structures that has been created by calling the Initialize()
    * method and re-sets the correspondig pointer members to null.
    */
   void Clear ();
   void ClearAll ();
-  
+
   /** delete copy CTR and assigment operators */
   G4HepEmRunManager (const G4HepEmRunManager&) = delete;
   G4HepEmRunManager& operator= (const G4HepEmRunManager&) = delete;
@@ -92,78 +92,78 @@ public:
   struct G4HepEmData*       GetHepEmData()         const  { return fTheG4HepEmData; }
   struct G4HepEmParameters* GetHepEmParameters()   const  { return fTheG4HepEmParameters; }
   G4HepEmTLData*            GetTheTLData()         const  { return fTheG4HepEmTLData; }
-  
+
   G4HepEmElectronManager*   GetTheElectronManager() const { return fTheG4HepEmElectronManager; }
-  
+
   G4HepEmGammaManager*      GetTheGammaManager()    const { return fTheG4HepEmGammaManager; }
-  
+
 private:
-  
-  /** 
-   * Initialisation of all global data structures. 
+
+  /**
+   * Initialisation of all global data structures.
    *
-   * Extracts EM and other configuration parameters, builds all the elememnt, 
-   * matrial and material-production-cuts related data structures shared by all 
-   * workers, all processes and all particles at run-time as read-only data. In 
-   * other words, these are the `global` data structures. 
+   * Extracts EM and other configuration parameters, builds all the elememnt,
+   * matrial and material-production-cuts related data structures shared by all
+   * workers, all processes and all particles at run-time as read-only data. In
+   * other words, these are the `global` data structures.
    * This should be invoked by the master thread and only once!
    */
   void InitializeGlobal ();
-  
-   
-  
-  
-private:  
+
+
+
+
+private:
   /** Flag to indicate the master run-manager.*/
   bool                           fIsMaster;
   /** Flags to indicate if the master has been initialized for the given particle.*/
   bool                           fIsInitialisedForParticle[3];
   /** Pointer to the master run-manager.*/
-  static G4HepEmRunManager*      gTheG4HepEmRunManagerMaster;  
+  static G4HepEmRunManager*      gTheG4HepEmRunManagerMaster;
   static std::vector<G4HepEmRunManager*> gTheG4HepEmRunManagers;
-  /** 
-   * === These data are created by the Master-RM and shared among all Worker-RMs. 
+  /**
+   * === These data are created by the Master-RM and shared among all Worker-RMs.
    *
    * Collection of configuration parameters used at initialization and run time.
    */
-  struct G4HepEmParameters*      fTheG4HepEmParameters;   
+  struct G4HepEmParameters*      fTheG4HepEmParameters;
   /*
-   * The top level data structure that stores all the data used by all processes 
+   * The top level data structure that stores all the data used by all processes
    * (e.g. material or material cuts couple related data, etc.)
-   * The coresponding data structures are created and filled when calling the 
+   * The coresponding data structures are created and filled when calling the
    * Initialize() method
    */
   struct G4HepEmData*            fTheG4HepEmData;
-  
+
   /*
    * A state-less collection of methods providing answers for the simulation like:
    * - `HowFar`: how far a given e-/e+ goes till the next physics interactions i.e. sep-length
-   * - `Perform`  : performs all the interactions for e-/e+ including Ioni, Brem, MSC and 
+   * - `Perform`  : performs all the interactions for e-/e+ including Ioni, Brem, MSC and
    *             annihilation to 2 gammas in case of e+.
-   * These above methods recives (e.g. on the primary e-/e+ track) and provides 
-   * back infomation (e.g. step length, secondary tracks and updated post-interaction 
-   * primary track) through their G4HepEmTLData input argument. Such an object is 
-   * created for each workers so they are worker local. The G4HepEmElectronTrack 
+   * These above methods recives (e.g. on the primary e-/e+ track) and provides
+   * back infomation (e.g. step length, secondary tracks and updated post-interaction
+   * primary track) through their G4HepEmTLData input argument. Such an object is
+   * created for each workers so they are worker local. The G4HepEmElectronTrack
    * and G4HepEmGammaTrack stores all the state related infomation.
-   * Therefore, a single object form the G4HepEmElectronManager, created by the 
+   * Therefore, a single object form the G4HepEmElectronManager, created by the
    * master run-manager,  is shared by all worker run-mamanger.
    */
   G4HepEmElectronManager*        fTheG4HepEmElectronManager;
-  
+
   G4HepEmGammaManager*           fTheG4HepEmGammaManager;
-  
+
   /*
-   * Processes for e-/e+: this is the top level object to all e-/e+ related 
-   * interactions that can provide response to how far the particle goes till the 
+   * Processes for e-/e+: this is the top level object to all e-/e+ related
+   * interactions that can provide response to how far the particle goes till the
    * next interaction and what happens in that interaction.
    *
-   * 
+   *
    * === These data are created for each Worker-RM.
    */
-  
+
   G4HepEmTLData*                 fTheG4HepEmTLData;
-    
-  
+
+
 };
 
 #endif // G4HepEmRunManager_HH

--- a/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/src/G4HepEmProcess.cc
@@ -26,12 +26,12 @@
 #include "G4Positron.hh"
 #include "G4Gamma.hh"
 
-G4HepEmProcess::G4HepEmProcess() 
-: G4VProcess("hepEm", fElectromagnetic), 
+G4HepEmProcess::G4HepEmProcess()
+: G4VProcess("hepEm", fElectromagnetic),
   fTheG4HepEmRunManager(nullptr) {
   enableAtRestDoIt    = false;
   enablePostStepDoIt  = false;
-  
+
   fTheG4HepEmRunManager   = new G4HepEmRunManager(G4Threading::IsMasterThread());
   fTheG4HepEmRandomEngine = new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine());
   fParticleChangeForLoss  = new G4ParticleChangeForLoss();
@@ -44,60 +44,60 @@ G4HepEmProcess::~G4HepEmProcess() {
 
 
 void G4HepEmProcess::BuildPhysicsTable(const G4ParticleDefinition& partDef) {
-  G4cout << " G4HepEmProcess::BuildPhysicsTable for Particle = " << partDef.GetParticleName() << G4endl;    
+  G4cout << " G4HepEmProcess::BuildPhysicsTable for Particle = " << partDef.GetParticleName() << G4endl;
   StreamInfo(G4cout, partDef);
 
-  // The ptr-s to global data structures created and filled in InitializeGlobal() 
+  // The ptr-s to global data structures created and filled in InitializeGlobal()
   // will be copied to the workers and the TL-data structure will be created.
   //fTheG4HepEmRunManager->Initialize(G4Random::getTheEngine());
-  
-  if (partDef.GetPDGEncoding()==11) {          // e- 
+
+  if (partDef.GetPDGEncoding()==11) {          // e-
     fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 0);
-  } else if (partDef.GetPDGEncoding()==-11) {  // e+ 
+  } else if (partDef.GetPDGEncoding()==-11) {  // e+
     fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 1);
-  } else if (partDef.GetPDGEncoding()==22) {   // gamma  
+  } else if (partDef.GetPDGEncoding()==22) {   // gamma
     fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 2);
   } else {
     std::cerr << " **** ERROR in G4HepEmProcess::BuildPhysicsTable: unknown particle " << std::endl;
-    exit(-1); 
-  }       
+    exit(-1);
+  }
 }
 
 
 void     G4HepEmProcess::StartTracking(G4Track* track) {
     // reset number of interaction length left to -1
-  const G4ParticleDefinition* partDef = track->GetParticleDefinition();  
-  if (std::abs(partDef->GetPDGEncoding())==11) {          // e- and e+ 
+  const G4ParticleDefinition* partDef = track->GetParticleDefinition();
+  if (std::abs(partDef->GetPDGEncoding())==11) {          // e- and e+
     double* numInterALeft = fTheG4HepEmRunManager->GetTheTLData()->GetPrimaryElectronTrack()->GetTrack()->GetNumIALeft();
     numInterALeft[0] = -1.0;
     numInterALeft[1] = -1.0;
     numInterALeft[2] = -1.0;
-  } else if (partDef->GetPDGEncoding()==22) {   // gamma    
+  } else if (partDef->GetPDGEncoding()==22) {   // gamma
     double* numInterALeft = fTheG4HepEmRunManager->GetTheTLData()->GetPrimaryGammaTrack()->GetTrack()->GetNumIALeft();
     numInterALeft[0] = -1.0;
     numInterALeft[1] = -1.0;
     numInterALeft[2] = -1.0;
 //    numInterALeft[3] = -1.0;
-  }  
+  }
 }
 
-G4double G4HepEmProcess::AlongStepGetPhysicalInteractionLength ( 
+G4double G4HepEmProcess::AlongStepGetPhysicalInteractionLength (
                                                const G4Track& track,
                                                G4double  /*previousStepSize*/,
                                                G4double  /*currentMinimumStep*/,
                                                G4double& /*proposedSafety*/,
                                                G4GPILSelection* selection) {
-  *selection = CandidateForSelection;   
-  G4HepEmTLData*            theTLData = fTheG4HepEmRunManager->GetTheTLData();  
-  const G4ParticleDefinition* partDef = track.GetParticleDefinition();    
+  *selection = CandidateForSelection;
+  G4HepEmTLData*            theTLData = fTheG4HepEmRunManager->GetTheTLData();
+  const G4ParticleDefinition* partDef = track.GetParticleDefinition();
   const bool                 isGamma  = (partDef->GetPDGEncoding()==22);
   G4HepEmTrack*       thePrimaryTrack = isGamma
                                         ? theTLData->GetPrimaryGammaTrack()->GetTrack()
                                         : theTLData->GetPrimaryElectronTrack()->GetTrack();
   thePrimaryTrack->SetCharge(partDef->GetPDGCharge());
   const G4DynamicParticle* theG4DPart = track.GetDynamicParticle();
-  thePrimaryTrack->SetEKin(theG4DPart->GetKineticEnergy());
-  thePrimaryTrack->SetLEKin(theG4DPart->GetLogKineticEnergy());
+  thePrimaryTrack->SetEKin(theG4DPart->GetKineticEnergy(), theG4DPart->GetLogKineticEnergy());
+//  thePrimaryTrack->SetLEKin(theG4DPart->GetLogKineticEnergy());
   const int    g4IMC = track.GetMaterialCutsCouple()->GetIndex();
   const int hepEmIMC = fTheG4HepEmRunManager->GetHepEmData()->fTheMatCutData->fG4MCIndexToHepEmMCIndex[g4IMC];
   thePrimaryTrack->SetMCIndex(hepEmIMC);
@@ -119,9 +119,9 @@ G4double G4HepEmProcess::AlongStepGetPhysicalInteractionLength (
 G4VParticleChange* G4HepEmProcess::AlongStepDoIt( const G4Track& track, const G4Step& step) {
   // init particle change: it might be more special we need to see later
   fParticleChangeForLoss->InitializeForPostStep(track);
-  
+
   G4HepEmTLData*            theTLData = fTheG4HepEmRunManager->GetTheTLData();
-  const G4ParticleDefinition* partDef = track.GetParticleDefinition();    
+  const G4ParticleDefinition* partDef = track.GetParticleDefinition();
   const bool                  isGamma = (partDef->GetPDGEncoding()==22);
   G4HepEmTrack*       thePrimaryTrack = isGamma
                                         ? theTLData->GetPrimaryGammaTrack()->GetTrack()
@@ -145,26 +145,26 @@ G4VParticleChange* G4HepEmProcess::AlongStepDoIt( const G4Track& track, const G4
   const double edep = thePrimaryTrack->GetEnergyDeposit();
   fParticleChangeForLoss->SetProposedKineticEnergy(ekin);
   if (ekin<=0.0) {
-    fParticleChangeForLoss->ProposeTrackStatus(fStopAndKill);  
+    fParticleChangeForLoss->ProposeTrackStatus(fStopAndKill);
   }
   fParticleChangeForLoss->ProposeLocalEnergyDeposit(edep);
   const double* pdir = thePrimaryTrack->GetDirection();
   fParticleChangeForLoss->ProposeMomentumDirection(G4ThreeVector(pdir[0], pdir[1], pdir[2]));
-  
+
   // secondary: only possible is e- or gamma at the moemnt
   const int numSecElectron = theTLData->GetNumSecondaryElectronTrack();
   const int numSecGamma    = theTLData->GetNumSecondaryGammaTrack();
   const int numSecondaries = numSecElectron+numSecGamma;
   if (numSecondaries>0) {
-    fParticleChangeForLoss->SetNumberOfSecondaries(numSecondaries);    
+    fParticleChangeForLoss->SetNumberOfSecondaries(numSecondaries);
     const G4ThreeVector& theG4PostStepPointPosition = theG4PostStepPoint->GetPosition();
     const G4double          theG4PostStepGlobalTime = theG4PostStepPoint->GetGlobalTime();
     const G4TouchableHandle&   theG4TouchableHandle = track.GetTouchableHandle();
     for (int is=0; is<numSecElectron; ++is) {
       G4HepEmTrack* secTrack = theTLData->GetSecondaryElectronTrack(is)->GetTrack();
       const double*      dir = secTrack->GetDirection();
-      // MUST BE CHANGED WHEN e+ is added 
-      G4DynamicParticle*  dp = secTrack->GetCharge() < 0.0 
+      // MUST BE CHANGED WHEN e+ is added
+      G4DynamicParticle*  dp = secTrack->GetCharge() < 0.0
                                ? new G4DynamicParticle( G4Electron::Definition(), G4ThreeVector( dir[0], dir[1], dir[2] ), secTrack->GetEKin() )
                                : new G4DynamicParticle( G4Positron::Definition(), G4ThreeVector( dir[0], dir[1], dir[2] ), secTrack->GetEKin() );
       G4Track*     aG4Track  = new G4Track( dp, theG4PostStepGlobalTime, theG4PostStepPointPosition );
@@ -182,10 +182,10 @@ G4VParticleChange* G4HepEmProcess::AlongStepDoIt( const G4Track& track, const G4
       fParticleChangeForLoss->AddSecondary( aG4Track );
     }
     theTLData->ResetNumSecondaryGammaTrack();
-  } 
-       
+  }
+
   return fParticleChangeForLoss;
-} 
+}
 
 
 
@@ -198,6 +198,3 @@ void G4HepEmProcess::StreamInfo(std::ostream& out, const G4ParticleDefinition& p
   out << G4endl << GetProcessName()  << ": for " << part.GetParticleName();
   out << "  More later! " << G4endl;
 }
-
-
-

--- a/apps/tests/testElectronInteractionBrem/CMakeLists.txt
+++ b/apps/tests/testElectronInteractionBrem/CMakeLists.txt
@@ -1,0 +1,59 @@
+#----------------------------------------------------------------------------
+# Setup the project
+cmake_minimum_required(VERSION 2.6...3.18 FATAL_ERROR)
+project (testBrem)
+
+#-------------------------------------------------------------------------------
+# Set the CXX flags that were used when building the library
+#
+set ( CMAKE_CXX_FLAGS "${G4HepEm_CMAKE_CXX_FLAGS}" )
+
+file ( GLOB headers     ${CMAKE_SOURCE_DIR}/include/*.hh)
+file ( GLOB cxx_sources ${CMAKE_SOURCE_DIR}/src/*.cc)
+file ( GLOB cu_sources  ${CMAKE_SOURCE_DIR}/src/*.cu)
+
+#----------------------------------------------------------------------------
+# Find Geant4 package
+#
+find_package ( Geant4 REQUIRED )
+
+
+#----------------------------------------------------------------------------
+# Setup Geant4 include directories and compile definitions
+#
+include ( ${Geant4_USE_FILE} )
+
+
+#----------------------------------------------------------------------------
+# Find G4HepEm
+#
+find_package ( G4HepEm REQUIRED)
+
+
+#----------------------------------------------------------------------------
+# Locate sources and headers for this project
+#
+include_directories ( ${Geant4_INCLUDE_DIR}
+                      ${G4HepEm_INCLUDE_DIR}
+                      ${CMAKE_SOURCE_DIR}/include
+                    )
+
+#----------------------------------------------------------------------------
+# Check if G4HepEm was built with CUDA support and enable testing if any
+#
+set ( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR} )
+
+if ( G4HepEm_CUDA_BUILD )
+message(STATUS " BUILDING WITH CUDA")
+  enable_language ( CUDA )
+  add_definitions ( -DG4HepEm_CUDA_BUILD )
+  include_directories ( ${G4HepEm_CUDA_INCLUDE_DIR}
+                        ${CMAKE_SOURCE_DIR}/include
+                       )
+  add_executable ( testBrem ${CMAKE_SOURCE_DIR}/testBrem.cc ${cxx_sources} ${cu_sources})
+  target_link_libraries( testBrem ${Geant4_LIBRARIES} ${G4HepEm_LIBRARIES} )
+else ( G4HepEm_CUDA_BUILD )
+  add_executable ( testBrem ${CMAKE_SOURCE_DIR}/testBrem.cc ${cxx_sources})
+  set_target_properties (testBrem  PROPERTIES COMPILE_FLAGS ${G4HepEm_CMAKE_CXX_FLAGS})
+  target_link_libraries (testBrem  ${Geant4_LIBRARIES} ${G4HepEm_LIBRARIES})
+endif ( G4HepEm_CUDA_BUILD )

--- a/apps/tests/testElectronInteractionBrem/include/Declaration.hh
+++ b/apps/tests/testElectronInteractionBrem/include/Declaration.hh
@@ -23,5 +23,17 @@ FakeG4Setup ( G4double prodCutInLength, const G4String& nistMatName, G4int verbo
 void G4SBTest     (const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool isSBmodel, G4bool iselectron=true);
 void G4HepEmSBTest(const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool isSBmodel, G4bool iselectron=true);
 
+#ifdef G4HepEm_CUDA_BUILD
+
+#include <device_launch_parameters.h>
+
+  bool TestSBTableData(const struct G4HepEmData* hepEmData);
+
+  __global__
+  void TestSBTableDataKernel(struct G4HepEmSBTableData* theTableData_d, int* theIData1_d, int* theIData2_d, int* theIData3_d, int* theIData4_d,
+                             double* theDData1_d, double* theDData2_d, double* theDData3_d, double* theDData4_d, double* theDData5_d);
+
+#endif // G4HepEm_CUDA_BUILD
+
 
 #endif // Declaration_HH

--- a/apps/tests/testElectronInteractionBrem/include/Declaration.hh
+++ b/apps/tests/testElectronInteractionBrem/include/Declaration.hh
@@ -20,28 +20,8 @@ const G4MaterialCutsCouple*
 FakeG4Setup ( G4double prodCutInLength, const G4String& nistMatName, G4int verbose=1);
 
 
-void G4SBTest     (const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool iselectron=true);
-void G4HepEmSBTest(const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool iselectron=true);
-
-
-#ifdef G4HepEm_CUDA_BUILD
-
-#include <device_launch_parameters.h>
-
-  // Samples the emitted photon energy on the device.
-  void G4HepEmSBTestOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
-                                      double* tsInEkin_h, double* tsInLogEkin_h, double* tsInRngVals_h,
-                                      int* tsOutRes_h, int numTestCases, int indxModel, bool iselectron );
-
-  __global__
-  void G4HepEmSBTestKernel ( const struct G4HepEmElectronData* theElectronData_d,
-                                        const struct G4HepEmMatCutData* theMatCutData_d,
-                                        const struct G4HepEmMaterialData* theMaterialData_d,
-                                        int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d, double* tsInRngVals_d,
-                                        int* tsOutRes_d, int numTestCases );
-
-
-#endif // G4HepEm_CUDA_BUILD
+void G4SBTest     (const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool isSBmodel, G4bool iselectron=true);
+void G4HepEmSBTest(const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool isSBmodel, G4bool iselectron=true);
 
 
 #endif // Declaration_HH

--- a/apps/tests/testElectronInteractionBrem/include/Declaration.hh
+++ b/apps/tests/testElectronInteractionBrem/include/Declaration.hh
@@ -1,0 +1,47 @@
+
+#ifndef Declaration_HH
+#define Declaration_HH
+
+// G4 include (for types)
+#include "globals.hh"
+
+class G4MaterialCutsCouple;
+
+
+struct G4HepEmData;
+struct G4HepEmElectronData;
+
+
+// builds a fake Geant4 geometry including all G4-NIST materials
+void FakeG4Setup ( G4double prodCutInLength,  G4int verbose=1 );
+
+// builds a fake Geant4 geometry with a single G4-NIST material
+const G4MaterialCutsCouple*
+FakeG4Setup ( G4double prodCutInLength, const G4String& nistMatName, G4int verbose=1);
+
+
+void G4SBTest     (const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool iselectron=true);
+void G4HepEmSBTest(const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double numSamples, G4int numHistBins, G4bool iselectron=true);
+
+
+#ifdef G4HepEm_CUDA_BUILD
+
+#include <device_launch_parameters.h>
+
+  // Samples the emitted photon energy on the device.
+  void G4HepEmSBTestOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
+                                      double* tsInEkin_h, double* tsInLogEkin_h, double* tsInRngVals_h,
+                                      int* tsOutRes_h, int numTestCases, int indxModel, bool iselectron );
+
+  __global__
+  void G4HepEmSBTestKernel ( const struct G4HepEmElectronData* theElectronData_d,
+                                        const struct G4HepEmMatCutData* theMatCutData_d,
+                                        const struct G4HepEmMaterialData* theMaterialData_d,
+                                        int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d, double* tsInRngVals_d,
+                                        int* tsOutRes_d, int numTestCases );
+
+
+#endif // G4HepEm_CUDA_BUILD
+
+
+#endif // Declaration_HH

--- a/apps/tests/testElectronInteractionBrem/include/Hist.hh
+++ b/apps/tests/testElectronInteractionBrem/include/Hist.hh
@@ -1,0 +1,90 @@
+
+#ifndef HIST_HH
+#define HIST_HH
+
+// A simple histogram just for testing
+
+#include <iostream>
+#include <string>
+#include <cstdio>
+
+class Hist {
+public:
+  Hist(double min, double max, int numbin)
+  {
+    fMin     = min;
+    fMax     = max;
+    fNumBins = numbin;
+    fDelta   = (fMax - fMin) / (numbin);
+    fx       = new double[fNumBins];
+    fy       = new double[fNumBins];
+    for (int i = 0; i < fNumBins; ++i) {
+      fx[i] = fMin + i * fDelta;
+      fy[i] = 0.0;
+    }
+    fSum = 0.0;
+  }
+
+  Hist(double min, double max, double delta)
+  {
+    fMin     = min;
+    fMax     = max;
+    fDelta   = delta;
+    fNumBins = (int)((fMax - fMin) / (delta)) + 1.0;
+    fx       = new double[fNumBins];
+    fy       = new double[fNumBins];
+    for (int i = 0; i < fNumBins; ++i) {
+      fx[i] = fMin + i * fDelta;
+      fy[i] = 0.0;
+    }
+    fSum = 0.0;
+  }
+
+  void Fill(double x)
+  {
+    int indx = (int)((x - fMin) / fDelta);
+    if (indx < 0) {
+      std::cerr << "\n ***** ERROR in Hist::FILL  =>  x = " << x << " < fMin = " << fMin << std::endl;
+      exit(1);
+    }
+
+    fy[indx] += 1.0;
+  }
+
+  void Fill(double x, double w)
+  {
+    int indx = (int)((x - fMin) / fDelta);
+    if (indx < 0) {
+      std::cerr << "\n ***** ERROR in Hist::FILL  =>  x = " << x << " < fMin = " << fMin << std::endl;
+      exit(1);
+    }
+
+    fy[indx] += 1.0 * w;
+  }
+
+
+  void Write(const std::string& fname, double norm) {
+    FILE *f = fopen(fname.c_str(), "w");
+    for (int i = 0; i < GetNumBins(); ++i) {
+      fprintf(f, "%d\t%.8g\t%.8g\n", i, GetX()[i] + 0.5 * GetDelta(), GetY()[i] * norm);
+    }
+    fclose(f);
+  }
+
+
+  int GetNumBins() const { return fNumBins; }
+  double GetDelta() const { return fDelta; }
+  double *GetX() const { return fx; }
+  double *GetY() const { return fy; }
+
+private:
+  double *fx;
+  double *fy;
+  double fMin;
+  double fMax;
+  double fDelta;
+  double fSum;
+  int fNumBins;
+};
+
+#endif //HIST_HH

--- a/apps/tests/testElectronInteractionBrem/include/TestBremArgs.hh
+++ b/apps/tests/testElectronInteractionBrem/include/TestBremArgs.hh
@@ -1,0 +1,53 @@
+
+#ifndef TESTBREMARGS_HH
+#define TESTBREMARGS_HH
+
+#include <string>
+
+#include <getopt.h>
+
+//
+// Input argument of the `testBrem` model level test application
+//
+
+
+//
+// simple structure to store the `testBrem` input arguments
+struct BremArgs {
+  std::string fParticleName;   // primary particle is electron
+  std::string fMaterialName;   // material is lead
+  std::string fBremModelName;  // name of the bremsstrahlung model to test
+  int         fTestType;       // type of test (HepEm, G4 or GPU)
+  int         fNumHistBins;    // number of histogram bins between min/max values
+  double      fNumSamples;     // number of required final state samples
+  double      fPrimaryEnergy;  // primary particle energy in [GeV]
+  double      fProdCutValue;   // by default in length and internal units i.e. [cm]
+
+  BremArgs():
+  fParticleName("e-"),
+  fMaterialName("G4_Pb"),
+  fBremModelName("bremSB"),
+  fTestType(0),
+  fNumHistBins(100),
+  fNumSamples(1.0E+7),
+  fPrimaryEnergy(234.56),
+  fProdCutValue(0.7) {}
+};
+
+static struct option options[] = {
+    {"test-type         (G4HepEm`, `G4` or `GPU(data)`)    - default: HepEm",  required_argument, 0, 't'},
+    {"particle-name     (`e-` or `e+`)                     - default: e-",     required_argument, 0, 'p'},
+    {"material-name     (G4-NIST mat. name,`G4_` prefix)   - default: G4_Pb",  required_argument, 0, 'm'},
+    {"primary-energy    (kinetic energy in [MeV])          - default: 234.56", required_argument, 0, 'e'},
+    {"number-of-samples (number of required samples)       - default: 1.e+7",  required_argument, 0, 'f'},
+    {"number-of-bins    (number of bins in the histograms) - default: 100",    required_argument, 0, 'n'},
+    {"model-name        (`bremS` or `bremRel`)             - default: bremSB", required_argument, 0, 'b'},
+    {"cut-vale          (secondary prod. thresh. in [mm])  - default: 0.7",    required_argument, 0, 'c'},
+    {"help", no_argument, 0, 'h'},
+    {0, 0, 0, 0}};
+
+void GetBremArgs(int argc, char *argv[], struct BremArgs& args);
+void GetBremArgsHelp();
+
+
+#endif //  TESTBREMARGS_HH

--- a/apps/tests/testElectronInteractionBrem/src/SBTableData.cu
+++ b/apps/tests/testElectronInteractionBrem/src/SBTableData.cu
@@ -1,0 +1,163 @@
+#include "Declaration.hh"
+
+#include "G4HepEmData.hh"
+#include "G4HepEmSBTableData.hh"
+
+#include <cuda_runtime.h>
+#include "G4HepEmCuUtils.hh"
+
+#include <cstdio>
+
+bool TestSBTableData(const struct G4HepEmData* hepEmData) {
+  const struct G4HepEmSBTableData* theSBTables = hepEmData->fTheSBTableData;
+  // allocate arrays to store results of device side evaluation of data as:
+  // integers in theIData1: fMaxZet, fNumElEnergy, fNumKappa, fNumHepEmMatCuts, fNumElemsInMatCuts, fNumSBTableData
+  int  theIData1[6];
+  int* theIData1_d;
+  gpuErrchk ( cudaMalloc ( &theIData1_d, sizeof( int ) * 6 ) );
+  // integers in theIData2: fSBTablesStartPerZ[121]
+  int  theIData2[121];
+  int* theIData2_d;
+  gpuErrchk ( cudaMalloc ( &theIData2_d, sizeof( int ) * 121 ) );
+  // integers in theIData3: fGammaCutIndxStartIndexPerMC[fNumHepEmMatCuts]
+  int* theIData3 = new int[ theSBTables->fNumHepEmMatCuts ];
+  int* theIData3_d;
+  gpuErrchk ( cudaMalloc ( &theIData3_d, sizeof( int ) * theSBTables->fNumHepEmMatCuts ) );
+  // integers in theIData4: fGammaCutIndices[fNumElemsInMatCuts]
+  int* theIData4 = new int[ theSBTables->fNumElemsInMatCuts ];
+  int* theIData4_d;
+  gpuErrchk ( cudaMalloc ( &theIData4_d, sizeof( int ) * theSBTables->fNumElemsInMatCuts ) );
+  // doubles  in theDData1: fElEnergyVect[65]
+  double  theDData1[65];
+  double* theDData1_d;
+  gpuErrchk ( cudaMalloc ( &theDData1_d, sizeof( double ) * 65 ) );
+  // doubles  in theDData2: fLElEnergyVect[65]
+  double  theDData2[65];
+  double* theDData2_d;
+  gpuErrchk ( cudaMalloc ( &theDData2_d, sizeof( double ) * 65 ) );
+  // doubles  in theDData3: fKappaVect[54]
+  double  theDData3[54];
+  double* theDData3_d;
+  gpuErrchk ( cudaMalloc ( &theDData3_d, sizeof( double ) * 54 ) );
+  // doubles  in theDData4: fLKappaVect[54]
+  double  theDData4[54];
+  double* theDData4_d;
+  gpuErrchk ( cudaMalloc ( &theDData4_d, sizeof( double ) * 54 ) );
+  // doubles  in theDData5: fSBTableData[fNumSBTableData]
+  double* theDData5 = new double[ theSBTables->fNumSBTableData ];
+  double* theDData5_d;
+  gpuErrchk ( cudaMalloc ( &theDData5_d, sizeof( double ) * theSBTables->fNumSBTableData ) );
+  //
+  // --- Launch the kernel to obtain the data on device
+  int numThreads = 32;
+  int numBlocks  =  1;
+  TestSBTableDataKernel <<< numBlocks, numThreads >>> (hepEmData->fTheSBTableData_gpu,
+                                                       theIData1_d, theIData2_d, theIData3_d, theIData4_d,
+                                                       theDData1_d, theDData2_d, theDData3_d, theDData4_d, theDData5_d);
+  // --- Synchronize to make sure that completed on the device
+  cudaDeviceSynchronize();
+  // copy results from device to host
+  gpuErrchk ( cudaMemcpy ( theIData1, theIData1_d, sizeof( int )    *   6, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theIData2, theIData2_d, sizeof( int )    * 121, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theIData3, theIData3_d, sizeof( int )    * theSBTables->fNumHepEmMatCuts, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theIData4, theIData4_d, sizeof( int )    * theSBTables->fNumElemsInMatCuts, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theDData1, theDData1_d, sizeof( double ) *  65, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theDData2, theDData2_d, sizeof( double ) *  65, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theDData3, theDData3_d, sizeof( double ) *  54, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theDData4, theDData4_d, sizeof( double ) *  54, cudaMemcpyDeviceToHost) );
+  gpuErrchk ( cudaMemcpy ( theDData5, theDData5_d, sizeof( double ) *  theSBTables->fNumSBTableData, cudaMemcpyDeviceToHost) );
+  //
+  // --- Check results
+  bool isPassing = true;
+  int faildAt = -1;
+  while (true) {
+    isPassing = ( theIData1[0] == theSBTables->fMaxZet);
+    if ( !isPassing ) { faildAt = 0; break; }
+    isPassing = ( theIData1[1] == theSBTables->fNumElEnergy);
+    if ( !isPassing ) { faildAt = 1; break; }
+    isPassing = ( theIData1[2] == theSBTables->fNumKappa);
+    if ( !isPassing ) { faildAt = 2; break; }
+    isPassing = ( theIData1[3] == theSBTables->fNumHepEmMatCuts);
+    if ( !isPassing ) { faildAt = 3; break; }
+    isPassing = ( theIData1[4] == theSBTables->fNumElemsInMatCuts);
+    if ( !isPassing ) { faildAt = 4; break; }
+    isPassing = ( theIData1[5] == theSBTables->fNumSBTableData);
+    if ( !isPassing ) { faildAt = 5; break; }
+    for (int i=0; i<121; ++i) {
+      isPassing = ( theIData2[i] == theSBTables->fSBTablesStartPerZ[i]);
+      if ( !isPassing ) { faildAt = 6; std::cout << theIData2[i] << " <-> "<< theSBTables->fSBTablesStartPerZ[i]<< std::endl; break; }
+    }
+    if ( !isPassing ) break;
+    for (int i=0; i<theSBTables->fNumHepEmMatCuts; ++i) {
+      isPassing = ( theIData3[i] == theSBTables->fGammaCutIndxStartIndexPerMC[i]);
+      if ( !isPassing ) { faildAt = 7; break; }
+    }
+    if ( !isPassing ) break;
+    for (int i=0; i<theSBTables->fNumElemsInMatCuts; ++i) {
+      isPassing = ( theIData4[i] == theSBTables->fGammaCutIndices[i]);
+      if ( !isPassing ) { faildAt = 8; break; }
+    }
+    break;
+  }
+  if (!isPassing) {
+    std::cerr << "      .... Faild At  = " << faildAt << std::endl;
+  }
+
+  // Free all dynamically allocated mamaory
+  delete [] theIData3;
+  delete [] theIData4;
+  delete [] theDData5;
+  cudaFree ( theIData1_d );
+  cudaFree ( theIData2_d );
+  cudaFree ( theIData3_d );
+  cudaFree ( theIData4_d );
+  cudaFree ( theDData1_d );
+  cudaFree ( theDData2_d );
+  cudaFree ( theDData3_d );
+  cudaFree ( theDData4_d );
+  cudaFree ( theDData5_d );
+
+  return isPassing;
+}
+
+__global__
+void TestSBTableDataKernel(struct G4HepEmSBTableData* theSBTables_d, int* theIData1_d, int* theIData2_d, int* theIData3_d, int* theIData4_d,
+                           double* theDData1_d, double* theDData2_d, double* theDData3_d, double* theDData4_d, double* theDData5_d) {
+   // one thread will get all data
+   if (blockIdx.x * blockDim.x + threadIdx.x == 0) {
+     // fMaxZet, fNumElEnergy, fNumKappa, fNumHepEmMatCuts, fNumElemsInMatCuts, fNumSBTableData
+     theIData1_d[0] = theSBTables_d->fMaxZet;
+     theIData1_d[1] = theSBTables_d->fNumElEnergy;
+     theIData1_d[2] = theSBTables_d->fNumKappa;
+     theIData1_d[3] = theSBTables_d->fNumHepEmMatCuts;
+     theIData1_d[4] = theSBTables_d->fNumElemsInMatCuts;
+     theIData1_d[5] = theSBTables_d->fNumSBTableData;
+     //
+     for (int i=0; i<121; ++i) {
+       theIData2_d[i] = theSBTables_d->fSBTablesStartPerZ[i];
+     }
+     for (int i=0; i<theSBTables_d->fNumHepEmMatCuts; ++i) {
+       theIData3_d[i] = theSBTables_d->fGammaCutIndxStartIndexPerMC[i];
+     }
+     for (int i=0; i<theSBTables_d->fNumElemsInMatCuts; ++i) {
+       theIData4_d[i] = theSBTables_d->fGammaCutIndices[i];
+     }
+     //
+     //
+     for (int i=0; i<65; ++i) {
+       theDData1_d[i] = theSBTables_d->fElEnergyVect[i];
+     }
+     for (int i=0; i<65; ++i) {
+       theDData2_d[i] = theSBTables_d->fLElEnergyVect[i];
+     }
+     for (int i=0; i<54; ++i) {
+       theDData3_d[i] = theSBTables_d->fKappaVect[i];
+     }
+     for (int i=0; i<54; ++i) {
+       theDData4_d[i] = theSBTables_d->fKappaVect[i];
+     }
+     for (int i=0; i<theSBTables_d->fNumSBTableData; ++i) {
+       theDData5_d[i] = theSBTables_d->fSBTableData[i];
+     }
+   }
+}

--- a/apps/tests/testElectronInteractionBrem/src/TestBremArgs.cc
+++ b/apps/tests/testElectronInteractionBrem/src/TestBremArgs.cc
@@ -1,0 +1,93 @@
+
+#include "TestBremArgs.hh"
+
+#include <iostream>
+#include <iomanip>
+#include <cstdio>
+
+#include <err.h>
+
+
+// get test application input arguments
+void GetBremArgs(int argc, char *argv[], struct BremArgs& args) {
+  while (true) {
+    int c, optidx = 0;
+    c = getopt_long(argc, argv, "t:p:m:e:f:n:b:c:", options, &optidx);
+    if (c == -1) break;
+    switch (c) {
+    case 0:
+      c = options[optidx].val;
+    /* fall through */
+    case 't':
+      args.fTestType   = (int)strtof(optarg, NULL);
+      if (args.fTestType < 0 || args.fTestType > 2 ) {
+        GetBremArgsHelp();
+        errx(1, "test type -t must be 0(HepEM), 1(G4) or 2(GPU-data)");
+      }
+      break;
+    case 'p':
+      args.fParticleName = optarg;
+      if (!(args.fParticleName == "e-" || args.fParticleName == "e+")) {
+        GetBremArgsHelp();
+        errx(1, "unknown particle name");
+      }
+      break;
+    case 'm':
+      args.fMaterialName = optarg;
+      break;
+    case 'e':
+      args.fPrimaryEnergy = strtod(optarg, NULL);
+      if (args.fPrimaryEnergy <= 0) {
+        GetBremArgsHelp();
+        errx(1, "primary particle energy must be positive");
+      }
+      break;
+    case 'f':
+      args.fNumSamples = strtod(optarg, NULL);
+      if (args.fNumSamples <= 0) {
+        GetBremArgsHelp();
+        errx(1, "number of final state samples must be positive");
+      }
+      break;
+    case 'n':
+      args.fNumHistBins = (int)strtof(optarg, NULL);
+      if (args.fNumHistBins <= 0) {
+        GetBremArgsHelp();
+        errx(1, "number of histogram bins must be positive");
+      }
+      break;
+    case 'b':
+      args.fBremModelName = optarg;
+      if (!(args.fBremModelName == "bremSB" || args.fBremModelName == "bremRel")) {
+        GetBremArgsHelp();
+        errx(1, "unknown bremsstrahlung model name");
+      }
+      break;
+    case 'c':
+      args.fProdCutValue = strtod(optarg, NULL);
+      if (args.fProdCutValue <= 0) {
+        errx(1, "production cut value must be positive");
+        GetBremArgsHelp();
+      }
+      break;
+    case 'h':
+      GetBremArgsHelp();
+      return;
+    default:
+      GetBremArgsHelp();
+      errx(1, "unknown option %c", c);
+    }
+  }
+}
+
+
+void GetBremArgsHelp() {
+  std::cout << "\n " << std::setw(90) << std::setfill('=') << "" << std::setfill(' ') << std::endl;
+  std::cout << "  Model-level test for testing e-/e+ bremsstrahlung photon emission intercation models."
+            << std::endl;
+  std::cout << "\n  Usage: testBrem [OPTIONS] \n" << std::endl;
+  for (int i = 0; options[i].name != NULL; i++) {
+    printf("\t-%c  --%s\n", options[i].val, options[i].name);
+  }
+  std::cout << "\n " << std::setw(90) << std::setfill('=') << "" << std::setfill(' ') << std::endl;
+}

--- a/apps/tests/testElectronInteractionBrem/testBrem.cc
+++ b/apps/tests/testElectronInteractionBrem/testBrem.cc
@@ -98,19 +98,5 @@ int main(int argc, char *argv[]) {
 #endif // G4HepEm_CUDA_BUILD
      }
 
-
-/*
-  //
-  // --- Invoke the test for Restricted Macroscopic Cross Section structure test(s):
-  if ( !TestXSectionData ( runMgr->GetHepEmData(), g4HepEmParticleIndx==0 ) ) {
-    return 1;
-  } else if ( verbose > 0 ) {
-#ifdef G4HepEm_CUDA_BUILD
-    std::cout << " === Macroscopic Cross Section Test: PASSING (HepEm HOST v.s. DEVICE) \n" << std::endl;
-#else   // G4HepEm_CUDA_BUILD
-    std::cout << " === Macroscopic Cross Section Test: PASSING (HepEm HOST) \n" << std::endl;
-#endif  // G4HepEm_CUDA_BUILD
-  }
-*/
   return 0;
 }

--- a/apps/tests/testElectronInteractionBrem/testBrem.cc
+++ b/apps/tests/testElectronInteractionBrem/testBrem.cc
@@ -1,0 +1,79 @@
+
+#include "Declaration.hh"
+
+// G4 includes
+#include "globals.hh"
+#include "G4SystemOfUnits.hh"
+#include "Randomize.hh"
+#include "CLHEP/Random/RandomEngine.h"
+#include "G4MaterialCutsCouple.hh"
+#include "G4SeltzerBergerModel.hh"
+
+// #include "G4ProductionCutsTable.hh"
+
+#include "G4HepEmRunManager.hh"
+#include "G4HepEmData.hh"
+
+int main() {
+  int verbose = 1;
+  //
+  // --- Set up a fake G4 geometry with including all pre-defined NIST materials
+  //     to produce the G4MaterialCutsCouple objects.
+  //
+  // secondary production threshold in length
+  const G4double secProdThreshold = 0.7*mm;
+  const G4double ekin             = 245.6*MeV;
+  const G4double numSamples       = 1.0E+8;
+  const G4int    numHistBins      = 100;
+
+  // SB-brem is used below 1 GeV primary energy
+
+  const G4MaterialCutsCouple* g4MatCut = FakeG4Setup (secProdThreshold, "G4_CONCRETE", verbose);
+  // print out all material-cuts (needs the G4ProductionCutsTable.hh include)
+//  G4ProductionCutsTable* theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
+//  theCoupleTable->DumpCouples();
+
+
+  //
+  // --- Initialise the `global` data structures of G4HepEm:
+  //     - the `global`-s are the G4HepEmParameters, G4HepEmMatCutData, G4HepEmMaterialData,
+  //       and G4HepEmElementData members of the G4HepEmData, top level data structure member
+  //       of the `master` G4HepEmRunManager
+  //     - these above data structures are constructed and initialised in the G4HepEmRunManager::InitializeGlobal()
+  //       method, that is invoked when the `master` G4HepEmRunManager::Initialize() method is invoked
+  //       first time (i.e. for the first particle)
+  //     - this should be done after the Geant4 geometry is already initialized, since data will be
+  //       extracted from the already initialized Geant4 obejcts such as G4ProductionCutsTable
+  //
+  //     Therefore, here we create a `master` G4HepEmRunManager and call its Initialize()
+  //     method for e- (could be any of e-: 0; e+: 1; or gamma: 2).
+  int g4HepEmParticleIndx = 1; // e-: 0; e+: 1;
+  G4HepEmRunManager* runMgr = new G4HepEmRunManager ( true );
+  runMgr->Initialize ( G4Random::getTheEngine(), g4HepEmParticleIndx );
+
+
+  G4SBTest(g4MatCut, ekin, numSamples, numHistBins, g4HepEmParticleIndx==0);
+//  G4HepEmSBTest(g4MatCut, ekin, numSamples, numHistBins, g4HepEmParticleIndx==0);
+
+  //
+  // --- Make all G4HepEmData member available on the device (only if G4HepEm_CUDA_BUILD)
+  //
+#ifdef G4HepEm_CUDA_BUILD
+  CopyG4HepEmDataToGPU ( runMgr->GetHepEmData() );
+#endif // G4HepEm_CUDA_BUILD
+
+/*
+  //
+  // --- Invoke the test for Restricted Macroscopic Cross Section structure test(s):
+  if ( !TestXSectionData ( runMgr->GetHepEmData(), g4HepEmParticleIndx==0 ) ) {
+    return 1;
+  } else if ( verbose > 0 ) {
+#ifdef G4HepEm_CUDA_BUILD
+    std::cout << " === Macroscopic Cross Section Test: PASSING (HepEm HOST v.s. DEVICE) \n" << std::endl;
+#else   // G4HepEm_CUDA_BUILD
+    std::cout << " === Macroscopic Cross Section Test: PASSING (HepEm HOST) \n" << std::endl;
+#endif  // G4HepEm_CUDA_BUILD
+  }
+*/
+  return 0;
+}

--- a/apps/tests/testElectronInteractionBrem/testBrem.cc
+++ b/apps/tests/testElectronInteractionBrem/testBrem.cc
@@ -12,6 +12,7 @@
 
 #include "G4HepEmRunManager.hh"
 #include "G4HepEmData.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
 
 int main(int argc, char *argv[]) {
   int verbose = 1;
@@ -62,7 +63,7 @@ int main(int argc, char *argv[]) {
   if (theTestType !=1 ) {
     int theG4HepEmParticleIndx = theIsElectron ? 0 : 1; // e-: 0; e+: 1;
     runMgr = new G4HepEmRunManager ( true );
-    runMgr->Initialize ( G4Random::getTheEngine(), theG4HepEmParticleIndx );
+    runMgr->Initialize ( new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine()), theG4HepEmParticleIndx );
   }
 
   //
@@ -83,9 +84,17 @@ int main(int argc, char *argv[]) {
           break;
       default:
 #ifdef G4HepEm_CUDA_BUILD
+          std::cout << " --- Checking G4HepEmSBTableData host vs devide consistency." << std::endl;
           // make all G4HepEmData member available on the device (only if G4HepEm_CUDA_BUILD)
           CopyG4HepEmDataToGPU ( runMgr->GetHepEmData() );
           // invoke the SBTableDataTest
+          if ( !TestSBTableData( runMgr->GetHepEmData() ) ) {
+            std::cout << "     - G4HepEmSBTableData host vs device consistency test: FAILED....!!!  \n" << std::endl;
+            return 1;
+          } else if ( verbose > 0 ) {
+            std::cout << "     - G4HepEmSBTableData host vs device consistency test: PASSED  \n" << std::endl;
+          }
+
 #endif // G4HepEm_CUDA_BUILD
      }
 


### PR DESCRIPTION
The test can generate final states of **e-/e+ bremsstrahlung photon emission** both using the low (**Seltzer-Berger**) and high (**Relativistic**) energy models. The primary particle type, its kinetic energy as well as the target material can be configured by input arguments. Both the native `Geant4` models or the `G4HepEm` interaction implementations can be utilised and selected by providing the appropriate input argument. A simple host vs device consistency test of the `G4HepEmSBTableData` is also available that can also be selected by the appropriate input argument. See more by executing the application with the ``--help`` input argument or ``-h`` flag.