### PR TITLE
Further increase of host side code reusability on the device by modifying the interaction model implementations 

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
@@ -43,8 +43,8 @@ int SelectTargetAtomBrem(const struct G4HepEmElectronData* elData, const int imc
                          const double lekin, const double urndn, const bool isbremSB);
 
 
-void SampleDirections(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir,
-                      double* thePrimElecDir, G4HepEmRandomEngine* rnge);
+void SampleDirectionsBrem(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir,
+                          double* thePrimElecDir, G4HepEmRandomEngine* rnge);
 
 
 // Simple linear search (with step of 3!) used in the photon energy sampling part

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
@@ -45,6 +45,11 @@ G4HepEmHostDevice
 int SelectTargetAtomBrem(const struct G4HepEmElectronData* elData, const int imc, const double ekin,
                          const double lekin, const double urndn, const bool isbremSB);
 
+
+void SampleDirections(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir,
+                      double* thePrimElecDir, G4HepEmRandomEngine* rnge);
+
+
 // Simple linear search (with step of 3!) used in the photon energy sampling part
 // of the SB (Seltzer-Berger) brem model.
 G4HepEmHostDevice

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
@@ -10,20 +10,17 @@ struct G4HepEmData;
 struct G4HepEmElectronData;
 
 
-// Bremsstrahlung interaction based on the numerical Seltzer-Berger DCS for the
-// emitted photon energy.
-// Used between 100 eV - 1 GeV primary e-/e+ kinetic energies.
-// NOTE: the core part i.e. sampling the emitted photon energy is different than
-//       that in the G4SeltzerBergerModel. I implemented here my rejection free,
-//       memory effcicient (tables only per Z and not per mat-cuts) sampling.
-//       Rejection is used only to account dielectric supression and e+ correction.
-void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron);
-
-// Bremsstrahlung interaction based on the Bethe-Heitler DCS with modifications
-// such as screening and Coulomb corrections, emission in the field of the atomic
-// electrons and LPM suppression.
-// Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
-void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron);
+// Bremsstrahlung interaction based on:
+// 1. SB: - the numerical Seltzer-Berger DCS for the emitted photon energy.
+//        - used between 1 keV - 1 GeV primary e-/e+ kinetic energies.
+//        NOTE: the core part i.e. sampling the emitted photon energy is different than
+//          that in the G4SeltzerBergerModel. I implemented here my rejection free,
+//          memory effcicient (tables only per Z and not per mat-cuts) sampling.
+//          Rejection is used only to account dielectric supression and e+ correction.
+// 2. RB: - the Bethe-Heitler DCS with modifications such as screening and Coulomb
+//          corrections, emission in the field of the atomic electrons and LPM suppression.
+//          Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
+void PerformElectronBrem(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron, bool isSBmodel);
 
 
 // Sampling of the energy transferred to the emitted photon using the numerical

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -20,14 +20,17 @@
 //#include <iostream>
 
 
-// Bremsstrahlung interaction based on the numerical Seltzer-Berger DCS for the
-// emitted photon energy.
-// Used between 1 keV - 1 GeV primary e-/e+ kinetic energies.
-// NOTE: the core part i.e. sampling the emitted photon energy is different than
-//       that in the G4SeltzerBergerModel. I implemented here my rejection free,
-//       memory effcicient (tables only per Z and not per mat-cuts) sampling.
-//       Rejection is used only to account dielectric supression and e+ correction.
-void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron) {
+// Bremsstrahlung interaction based on:
+// 1. SB: - the numerical Seltzer-Berger DCS for the emitted photon energy.
+//        - used between 1 keV - 1 GeV primary e-/e+ kinetic energies.
+//        NOTE: the core part i.e. sampling the emitted photon energy is different than
+//          that in the G4SeltzerBergerModel. I implemented here my rejection free,
+//          memory effcicient (tables only per Z and not per mat-cuts) sampling.
+//          Rejection is used only to account dielectric supression and e+ correction.
+// 2. RB: - the Bethe-Heitler DCS with modifications such as screening and Coulomb
+//          corrections, emission in the field of the atomic electrons and LPM suppression.
+//          Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
+void PerformElectronBrem(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron, bool isSBmodel) {
   //
   G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack();
@@ -41,48 +44,9 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
   if (thePrimEkin <= theGamCut) return;
   //
   // == Sampling of the emitted photon energy
-  const double eGamma = SampleETransferBremSB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
-  // get a secondary photon track and sample directions (all will be already in lab. frame)
-  G4HepEmTrack* theSecTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
-  double*    theSecGammaDir = theSecTrack->GetDirection();
-  double*    thePrimElecDir = thePrimaryTrack->GetDirection();
-  //
-  // == Sampling of the emitted photon and post interaction e-/e+ directions
-  SampleDirections(thePrimEkin, eGamma, theSecGammaDir, thePrimElecDir, tlData->GetRNGEngine());
-  //
-  // == Update primary and set secondary gamma track properties
-  //    note: the directions are already set in SampleDirections
-  thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
-  theSecTrack->SetEKin(eGamma);
-  theSecTrack->SetParentID(thePrimaryTrack->GetID());
-  // NOTE: the following usually set to very high energy so I don't include this.
-  // if secondary gamma energy is higher than threshold(very high by default)
-  // then stop tracking the primary particle and create new secondary e-/e+
-  // instead of the primary
-}
-
-
-// Bremsstrahlung interaction based on the Bethe-Heitler DCS with modifications
-// such as screening and Coulomb corrections, emission in the field of the atomic
-// electrons and LPM suppression.
-// Used between 1 GeV - 100 TeV primary e-/e+ kinetic energies.
-void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron) {
-  //
-  G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack();
-  G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack();
-  //
-  double              thePrimEkin = thePrimaryTrack->GetEKin();
-  const double        theLogEkin  = thePrimaryTrack->GetLogEKin();
-  const int             theMCIndx = thePrimaryTrack->GetMCIndex();
-  const G4HepEmMCCData& theMCData = hepEmData->fTheMatCutData->fMatCutData[theMCIndx];
-  const double          theGamCut = theMCData.fSecGamProdCutE;
-//  const double       theLogGamCut = theMCData.fLogSecGamCutE;
-
-  // return if intercation is not possible (should not happen)
-  if (thePrimEkin <= theGamCut) return;
-  //
-  // == Sampling of the emitted photon energy
-  double eGamma = SampleETransferBremRB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
+  const double eGamma = isSBmodel
+                        ? SampleETransferBremSB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron)
+                        : SampleETransferBremRB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
   // get a secondary photon track and sample directions (all will be already in lab. frame)
   G4HepEmTrack* theSecTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
   double*    theSecGammaDir = theSecTrack->GetDirection();

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -53,7 +53,7 @@ void PerformElectronBrem(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, b
   double*    thePrimElecDir = thePrimaryTrack->GetDirection();
   //
   // == Sampling of the emitted photon and post interaction e-/e+ directions
-  SampleDirections(thePrimEkin, eGamma, theSecGammaDir, thePrimElecDir, tlData->GetRNGEngine());
+  SampleDirectionsBrem(thePrimEkin, eGamma, theSecGammaDir, thePrimElecDir, tlData->GetRNGEngine());
   //
   // == Update primary and set secondary gamma track properties
   //    note: the directions are already set in SampleDirections
@@ -291,7 +291,7 @@ int SelectTargetAtomBrem(const struct G4HepEmElectronData* elData, const int imc
 }
 
 
-void SampleDirections(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir, double* thePrimElecDir, G4HepEmRandomEngine* rnge) {
+void SampleDirectionsBrem(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir, double* thePrimElecDir, G4HepEmRandomEngine* rnge) {
   // sample photon direction (modified Tsai sampling):
   const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
   double rndm3[3];

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -41,50 +41,24 @@ void PerformElectronBremSB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
   if (thePrimEkin <= theGamCut) return;
   //
   // == Sampling of the emitted photon energy
+  const double eGamma = SampleETransferBremSB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
+  // get a secondary photon track and sample directions (all will be already in lab. frame)
+  G4HepEmTrack* theSecTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
+  double*    theSecGammaDir = theSecTrack->GetDirection();
+  double*    thePrimElecDir = thePrimaryTrack->GetDirection();
   //
-   double eGamma = SampleETransferBremSB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
-
-   //
-   // sample photon direction (modified Tsai sampling):
-   const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
-   double rndm3[3];
-   double u;
-   do {
-     tlData->GetRNGEngine()->flatArray(3, rndm3);
-     const double uu = -std::log(rndm3[0]*rndm3[1]);
-     u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
-   } while (u > uMax);
-   const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
-   const double sint = std::sqrt((1.0-cost)*(1.0+cost));
-   const double  phi = k2Pi*tlData->GetRNGEngine()->flat();
-   // create secondary photon
-   G4HepEmTrack*         secTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
-   secTrack->SetDirection(sint * std::cos(phi), sint * std::sin(phi), cost);
-   double* theSecondaryDirection = secTrack->GetDirection();
-   double* thePrimaryDirection   = thePrimaryTrack->GetDirection();
-   // rotate back to refernce frame (G4HepEmRunUtils function)
-   RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
-   secTrack->SetEKin(eGamma);
-   secTrack->SetParentID(thePrimaryTrack->GetID());
-
-   //
-   //
-   // compute post-interaction kinematics of the primary e-/e+
-   const double primETot = thePrimEkin + kElectronMassC2;
-   const double primPTot = std::sqrt(thePrimEkin * (primETot + kElectronMassC2));
-   double elDirX = primPTot * thePrimaryDirection[0] - eGamma * theSecondaryDirection[0];
-   double elDirY = primPTot * thePrimaryDirection[1] - eGamma * theSecondaryDirection[1];
-   double elDirZ = primPTot * thePrimaryDirection[2] - eGamma * theSecondaryDirection[2];
-   // normalisation
-   const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
-   // update primary track direction
-   thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
-   // update primary track kinetic energy
-   thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
-   // NOTE: the following usually set to very high energy so I don't include this.
-   // if secondary gamma energy is higher than threshold(very high by default)
-   // then stop tracking the primary particle and create new secondary e-/e+
-   // instead of the primary
+  // == Sampling of the emitted photon and post interaction e-/e+ directions
+  SampleDirections(thePrimEkin, eGamma, theSecGammaDir, thePrimElecDir, tlData->GetRNGEngine());
+  //
+  // == Update primary and set secondary gamma track properties
+  //    note: the directions are already set in SampleDirections
+  thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
+  theSecTrack->SetEKin(eGamma);
+  theSecTrack->SetParentID(thePrimaryTrack->GetID());
+  // NOTE: the following usually set to very high energy so I don't include this.
+  // if secondary gamma energy is higher than threshold(very high by default)
+  // then stop tracking the primary particle and create new secondary e-/e+
+  // instead of the primary
 }
 
 
@@ -106,49 +80,22 @@ void PerformElectronBremRB(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData,
 
   // return if intercation is not possible (should not happen)
   if (thePrimEkin <= theGamCut) return;
-
   //
   // == Sampling of the emitted photon energy
-  //
   double eGamma = SampleETransferBremRB(hepEmData, thePrimEkin, theLogEkin, theMCIndx, tlData->GetRNGEngine(), iselectron);
-
+  // get a secondary photon track and sample directions (all will be already in lab. frame)
+  G4HepEmTrack* theSecTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
+  double*    theSecGammaDir = theSecTrack->GetDirection();
+  double*    thePrimElecDir = thePrimaryTrack->GetDirection();
   //
-  // sample photon direction (modified Tsai sampling):
-  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
-  double rndm3[3];
-  double u;
-  do {
-    tlData->GetRNGEngine()->flatArray(3, rndm3);
-    const double uu = -std::log(rndm3[0]*rndm3[1]);
-    u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
-  } while (u > uMax);
-  const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
-  const double sint = std::sqrt((1.0-cost)*(1.0+cost));
-  const double  phi = k2Pi*tlData->GetRNGEngine()->flat();
-  // create secondary photon
-  G4HepEmTrack*        secTrack = tlData->AddSecondaryGammaTrack()->GetTrack();
-  secTrack->SetDirection(sint * std::cos(phi), sint * std::sin(phi), cost);
-  double* theSecondaryDirection = secTrack->GetDirection();
-  double* thePrimaryDirection   = thePrimaryTrack->GetDirection();
-  // rotate back to refernce frame (G4HepEmRunUtils function)
-  RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
-  secTrack->SetEKin(eGamma);
-  secTrack->SetParentID(thePrimaryTrack->GetID());
-
+  // == Sampling of the emitted photon and post interaction e-/e+ directions
+  SampleDirections(thePrimEkin, eGamma, theSecGammaDir, thePrimElecDir, tlData->GetRNGEngine());
   //
-  //
-  // compute post-interaction kinematics of the primary e-/e+
-  const double thePrimTotalE = thePrimEkin + kElectronMassC2;
-  const double primPTot = std::sqrt( thePrimEkin * (thePrimTotalE + kElectronMassC2) );
-  double elDirX = primPTot * thePrimaryDirection[0] - eGamma * theSecondaryDirection[0];
-  double elDirY = primPTot * thePrimaryDirection[1] - eGamma * theSecondaryDirection[1];
-  double elDirZ = primPTot * thePrimaryDirection[2] - eGamma * theSecondaryDirection[2];
-  // normalisation
-  const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
-  // update primary track direction
-  thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
-  // update primary track kinetic energy
+  // == Update primary and set secondary gamma track properties
+  //    note: the directions are already set in SampleDirections
   thePrimaryTrack->SetEKin(thePrimEkin - eGamma);
+  theSecTrack->SetEKin(eGamma);
+  theSecTrack->SetParentID(thePrimaryTrack->GetID());
   // NOTE: the following usually set to very high energy so I don't include this.
   // if secondary gamma energy is higher than threshold(very high by default)
   // then stop tracking the primary particle and create new secondary e-/e+
@@ -172,7 +119,6 @@ double SampleETransferBremSB(struct G4HepEmData* hepEmData, double thePrimEkin, 
   const double  dZet = (double)iZet;
   //
   // == Sampling of the emitted photon energy
-  //
   // get the G4HepEmSBTableData structure
   const G4HepEmSBTableData* theSBTables = hepEmData->fTheSBTableData;
   // get the start index of sampling tables for this Z
@@ -287,7 +233,6 @@ double SampleETransferBremRB(struct G4HepEmData* hepEmData, double thePrimEkin, 
   const G4HepEmElemData& theElemData = hepEmData->fTheElementData->fElementData[G4HepEmMin(iZet, hepEmData->fTheElementData->fMaxZet)];
   //
   // == Sampling of the emitted photon energy
-  //
   // - compute lpm energy
   const double densityFactor = kMigdalConst * theMData.fElectronDensity;
   const double     lpmEnergy = kLPMconstant * theMData.fRadiationLength;
@@ -379,6 +324,38 @@ int SelectTargetAtomBrem(const struct G4HepEmElectronData* elData, const int imc
   int theElemIndex = 0;
   while (theElemIndex<numElem-1 && urndn > xdata[indx0+theElemIndex]+b*(xdata[indx1+theElemIndex]-xdata[indx0+theElemIndex])) { ++theElemIndex; }
   return theElemIndex;
+}
+
+
+void SampleDirections(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir, double* thePrimElecDir, G4HepEmRandomEngine* rnge) {
+  // sample photon direction (modified Tsai sampling):
+  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
+  double rndm3[3];
+  double u;
+  do {
+    rnge->flatArray(3, rndm3);
+    const double uu = -std::log(rndm3[0]*rndm3[1]);
+    u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
+  } while (u > uMax);
+  const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
+  const double sint = std::sqrt((1.0-cost)*(1.0+cost));
+  const double  phi = k2Pi*rnge->flat();
+  theSecGammaDir[0] = sint * std::cos(phi);
+  theSecGammaDir[1] = sint * std::sin(phi);
+  theSecGammaDir[2] = cost;
+  // rotate to refernce frame (G4HepEmRunUtils function) to get it in lab. frame
+  RotateToReferenceFrame(theSecGammaDir, thePrimElecDir);
+  // go for the post-interaction primary electron/positiorn direction in lab. farme
+  const double primETot = thePrimEkin + kElectronMassC2;
+  const double primPTot = std::sqrt(thePrimEkin * (primETot + kElectronMassC2));
+  thePrimElecDir[0] = primPTot * thePrimElecDir[0] - theSecGammaEkin * theSecGammaDir[0];
+  thePrimElecDir[1] = primPTot * thePrimElecDir[1] - theSecGammaEkin * theSecGammaDir[1];
+  thePrimElecDir[2] = primPTot * thePrimElecDir[2] - theSecGammaEkin * theSecGammaDir[2];
+  // normalisation
+  const double  norm = 1.0 / std::sqrt(thePrimElecDir[0] * thePrimElecDir[0] + thePrimElecDir[1] * thePrimElecDir[1] + thePrimElecDir[2] * thePrimElecDir[2]);
+  thePrimElecDir[0] *= norm;
+  thePrimElecDir[1] *= norm;
+  thePrimElecDir[2] *= norm;
 }
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.hh
@@ -13,13 +13,15 @@ struct G4HepEmData;
 // Used between 100 eV - 100 TeV primary e-/e+ kinetic energies.
 void PerformElectronIoni(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron);
 
-// Sampling of the energy transferred to the secondary electron in case of e- 
+// Sampling of the energy transferred to the secondary electron in case of e-
 // primary i.e. in case of Moller interaction.
 G4HepEmHostDevice
 double SampleETransferMoller(const double elCut, const double primEkin, G4HepEmRandomEngine* rnge);
-// Sampling of the energy transferred to the secondary electron in case of e+ 
+// Sampling of the energy transferred to the secondary electron in case of e+
 // primary i.e. in case of Bhabha interaction.
 G4HepEmHostDevice
 double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmRandomEngine* rnge);
+
+void SampleDirectionsIoni(const double thePrimEkin, const double deltaEkin, double* theSecElecDir, double* thePrimElecDir, G4HepEmRandomEngine* rnge);
 
 #endif // G4HepEmElectronInteractionIoni_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.icc
@@ -9,58 +9,41 @@
 #include "G4HepEmElectronTrack.hh"
 #include "G4HepEmConstants.hh"
 #include "G4HepEmRunUtils.hh"
+#include "G4HepEmMath.hh"
 
 
 
 #include <iostream>
 
 
-void PerformElectronIoni(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron) {  
-  G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack(); 
-  G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack(); 
+void PerformElectronIoni(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData, bool iselectron) {
+  G4HepEmElectronTrack* thePrimaryElTrack = tlData->GetPrimaryElectronTrack();
+  G4HepEmTrack* thePrimaryTrack = thePrimaryElTrack->GetTrack();
   double    thePrimEkin = thePrimaryTrack->GetEKin();
   const int   theMCIndx = thePrimaryTrack->GetMCIndex();
   const double theElCut = hepEmData->fTheMatCutData->fMatCutData[theMCIndx].fSecElProdCutE;
-  
+
   const double maxETransfer = (iselectron) ? 0.5*thePrimEkin : thePrimEkin;
   if (maxETransfer <= theElCut) return;
-  
+
   //
   // sample energy transfer and compute direction
-  const double elInitETot = thePrimEkin + kElectronMassC2;
-  const double elInitPTot = std::sqrt(thePrimEkin * (elInitETot + kElectronMassC2));
-  const double  deltaEkin = (iselectron) 
-                            ? SampleETransferMoller(theElCut, thePrimEkin, tlData->GetRNGEngine()) 
+  const double  deltaEkin = (iselectron)
+                            ? SampleETransferMoller(theElCut, thePrimEkin, tlData->GetRNGEngine())
                             : SampleETransferBhabha(theElCut, thePrimEkin, tlData->GetRNGEngine());
-  const double deltaPTot = std::sqrt(deltaEkin * (deltaEkin + 2.0 * kElectronMassC2));
-  const double      cost = deltaEkin * (elInitETot + kElectronMassC2) / (deltaPTot * elInitPTot);
-  // check cosTheta limit
-  const double  cosTheta = std::max(-1.0, std::min(cost, 1.0));
-  const double  sinTheta = std::sqrt((1.0 - cosTheta) * (1.0 + cosTheta));
-  // spherical symmetry
-  const double  phi      = k2Pi * tlData->GetRNGEngine()->flat();
-  // create the secondary partcile i.e. the delta e-
-  G4HepEmElectronTrack* secElTrack = tlData->AddSecondaryElectronTrack();
-  G4HepEmTrack*           secTrack = secElTrack->GetTrack();
-  secTrack->SetDirection(sinTheta * std::cos(phi), sinTheta * std::sin(phi), cosTheta);
-  double* theSecondaryDirection  = secTrack->GetDirection();
-  double* thePrimaryDirection    = thePrimaryTrack->GetDirection();
-  // rotate back to refernce frame (G4HepEmRunUtils function)
-  RotateToReferenceFrame(theSecondaryDirection, thePrimaryDirection);
-  secTrack->SetEKin(deltaEkin);
-  secTrack->SetParentID(thePrimaryTrack->GetID()); 
+  // get a secondary e- track and sample/compute directions (all will be already in lab. frame)
+  G4HepEmTrack* theSecTrack = tlData->AddSecondaryElectronTrack()->GetTrack();
+  double*     theSecElecDir = theSecTrack->GetDirection();
+  double*    thePrimElecDir = thePrimaryTrack->GetDirection();
   //
-  // compute the primary e-/e+ post interaction kinetic energy and direction: from momentum vector conservation
-  // final momentum of the primary e-/e+ in the lab frame
-  double elDirX = elInitPTot * thePrimaryDirection[0] - deltaPTot * theSecondaryDirection[0];
-  double elDirY = elInitPTot * thePrimaryDirection[1] - deltaPTot * theSecondaryDirection[1];
-  double elDirZ = elInitPTot * thePrimaryDirection[2] - deltaPTot * theSecondaryDirection[2];
-  // normalisation
-  const double norm = 1.0 / std::sqrt(elDirX * elDirX + elDirY * elDirY + elDirZ * elDirZ);
-  // update primary track direction
-  thePrimaryTrack->SetDirection(elDirX * norm, elDirY * norm, elDirZ * norm);
-  // update primary track kinetic energy
+  // == Sample/copute the emitted secondary e- and post interaction primary e-/e+ directions
+  SampleDirectionsIoni(thePrimEkin, deltaEkin, theSecElecDir, thePrimElecDir, tlData->GetRNGEngine());
+  //
+  // == Update primary e-/e+ and the secondary e- track properties
+  //    note: the directions are already set in SampleDirections
   thePrimaryTrack->SetEKin(thePrimEkin - deltaEkin);
+  theSecTrack->SetEKin(deltaEkin);
+  theSecTrack->SetParentID(thePrimaryTrack->GetID());
 }
 
 
@@ -119,6 +102,33 @@ double SampleETransferBhabha(const double elCut, const double primEkin, G4HepEmR
     const double xx = deltaEkin * deltaEkin;
     dum             = 1.0 + (xx * xx * b4 - deltaEkin * xx * b3 + xx * b2 - deltaEkin * b1) * beta2;
   } while (gf * rndArray[1] > dum);
-  return deltaEkin * primEkin;  
+  return deltaEkin * primEkin;
 }
 
+
+void SampleDirectionsIoni(const double thePrimEkin, const double deltaEkin, double* theSecElecDir, double* thePrimElecDir, G4HepEmRandomEngine* rnge) {
+    const double elInitETot = thePrimEkin + kElectronMassC2;
+    const double elInitPTot = std::sqrt(thePrimEkin * (elInitETot + kElectronMassC2));
+    const double  deltaPTot = std::sqrt(deltaEkin * (deltaEkin + 2.0 * kElectronMassC2));
+    const double       cost = deltaEkin * (elInitETot + kElectronMassC2) / (deltaPTot * elInitPTot);
+    // check cosTheta limit
+    const double   cosTheta = G4HepEmMax(-1.0, G4HepEmMin(cost, 1.0));
+    const double   sinTheta = std::sqrt((1.0 - cosTheta) * (1.0 + cosTheta));
+    const double        phi = k2Pi * rnge->flat();     // spherical symmetry
+    //
+    theSecElecDir[0]  = sinTheta * std::cos(phi);
+    theSecElecDir[1]  = sinTheta * std::sin(phi);
+    theSecElecDir[2]  = cosTheta;
+    // rotate to refernce frame (G4HepEmRunUtils function) to get it in lab. frame
+    RotateToReferenceFrame(theSecElecDir, thePrimElecDir);
+    // go for the post-interaction primary electron/positiorn direction in lab. farme
+    // (compute from momentum vector conservation)
+    thePrimElecDir[0] = elInitPTot * thePrimElecDir[0] - deltaPTot * theSecElecDir[0];
+    thePrimElecDir[1] = elInitPTot * thePrimElecDir[1] - deltaPTot * theSecElecDir[1];
+    thePrimElecDir[2] = elInitPTot * thePrimElecDir[2] - deltaPTot * theSecElecDir[2];
+    // normalisation
+    const double  norm = 1.0 / std::sqrt(thePrimElecDir[0] * thePrimElecDir[0] + thePrimElecDir[1] * thePrimElecDir[1] + thePrimElecDir[2] * thePrimElecDir[2]);
+    thePrimElecDir[0] *= norm;
+    thePrimElecDir[1] *= norm;
+    thePrimElecDir[2] *= norm;
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -211,11 +211,7 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
             PerformElectronIoni(tlData, hepEmData, isElectron);
             break;
     case 1: // invoke brem (for e-/e+): either SB- or Rel-Brem
-            if (theEkin < hepEmPars->fElectronBremModelLim) {
-              PerformElectronBremSB(tlData, hepEmData, isElectron);
-            } else {
-              PerformElectronBremRB(tlData, hepEmData, isElectron);
-            }
+            PerformElectronBrem(tlData, hepEmData, isElectron, theEkin < hepEmPars->fElectronBremModelLim);
             break;
     case 2: // invoke annihilation (in-flight) for e+
             PerformPositronAnnihilation(tlData, false);

--- a/apps/tests/testElectronInteractionBrem/src/Implementation.cc
+++ b/apps/tests/testElectronInteractionBrem/src/Implementation.cc
@@ -269,11 +269,7 @@ void G4HepEmSBTest(const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double
     thePrimaryTrack->SetEKin(ekin, lekin);
     thePrimaryTrack->SetDirection(0.0, 0.0, 1.0);
     // invoke SB brem intercation from G4HepEmElectronInteractionBrem.hh
-    if (isSBmodel) {
-      PerformElectronBremSB(theTLData, theHepEmData, iselectron);
-    } else {
-      PerformElectronBremRB(theTLData, theHepEmData, iselectron);
-    }
+    PerformElectronBremSB(theTLData, theHepEmData, iselectron, isSBmodel);
     // get secondary related results (energy, direction) if any
     const int numSecGamma = theTLData->GetNumSecondaryGammaTrack();
     if (numSecGamma > 0) {


### PR DESCRIPTION
Computations of the post interaction primary and secondary particle directions have been separated out from the main interaction functions (similarly to the energy transfer part) such that they depend only on primitive types (plus the already resolved random-engine). Therefore, even this part of the interaction computations of e-/e+ Ionisation and Bremsstrahlung   
can be now re-used on the device (after marking them and the related functions properly).  A high fraction (>95%) of the interaction computation can now be re-used on the device and only couple of lines, that depend on the actual track representation, need to be implemented.  

Furthermore, the earlier 2 interaction model (SB and RB) for bremsstrahlung have been merged into a single function, reducing further the amount of duplicated codes. 

These modifications resulted final state computation implementations (`PerformElectronIoni` and `PerformElectronBrem`)
that follows the same patter.