### PR TITLE
Avoid using CMAKE_SOURCE_DIR

### DIFF
--- a/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/CMakeLists.txt
@@ -6,15 +6,15 @@ add_subdirectory (G4HepEmRun)
 
 
 include_directories (
- ${CMAKE_SOURCE_DIR}/G4HepEm/include
+ ${CMAKE_CURRENT_SOURCE_DIR}/include
  ${G4HEPEMDATA_INC_DIR}
  ${G4HEPEMINIT_INC_DIR}
  ${G4HEPEMRUN_INC_DIR}
 )
 
 
-file ( GLOB G4HEPEM_headers ${CMAKE_SOURCE_DIR}/G4HepEm/include/*.hh)
-file ( GLOB G4HEPEM_sources ${CMAKE_SOURCE_DIR}/G4HepEm/src/*.cc)
+file ( GLOB G4HEPEM_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
+file ( GLOB G4HEPEM_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 if (BUILD_STATIC_LIBS)
   add_library (g4HepEm STATIC ${G4HEPEM_sources})
 else ()
@@ -32,7 +32,7 @@ install (TARGETS g4HepEm DESTINATION lib)
 ## ----------------------------------------------------------------------------
 ## Create and install G4HepEm CMake Config file
 ##
-configure_file (${CMAKE_SOURCE_DIR}/cmake/G4HepEmConfig.cmake.in
+configure_file (${PROJECT_SOURCE_DIR}/cmake/G4HepEmConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/G4HepEmConfig.cmake @ONLY)
 
 install (FILES

--- a/G4HepEm/G4HepEmData/CMakeLists.txt
+++ b/G4HepEm/G4HepEmData/CMakeLists.txt
@@ -1,16 +1,16 @@
 
 
-set (G4HEPEMDATA_INC_DIR ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmData/include PARENT_SCOPE)
+set (G4HEPEMDATA_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
 
-include_directories (${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmData/include)
-file ( GLOB G4HEPEMDATA_headers ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmData/include/*.hh)
-file ( GLOB G4HEPEMDATA_CXX_sources ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmData/src/*.cc)
+include_directories (${CMAKE_CURRENT_SOURCE_DIR}/include)
+file ( GLOB G4HEPEMDATA_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
+file ( GLOB G4HEPEMDATA_CXX_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 
 #
 # CUDA
 
 if (G4HepEm_CUDA_BUILD)
-  file (GLOB G4HEPEMDATA_CUDA_sources ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmData/src/*.cu)
+  file (GLOB G4HEPEMDATA_CUDA_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cu)
   # add possible CUDA headers
   # list (APPEND G4HEPEMDATA_headers )
   #

--- a/G4HepEm/G4HepEmInit/CMakeLists.txt
+++ b/G4HepEm/G4HepEmInit/CMakeLists.txt
@@ -1,13 +1,13 @@
 
-set (G4HEPEMINIT_INC_DIR ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmInit/include PARENT_SCOPE)
+set (G4HEPEMINIT_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
 
 include_directories (
-   ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmInit/include
+   ${CMAKE_CURRENT_SOURCE_DIR}/include
    ${G4HEPEMDATA_INC_DIR}
 )
 
-file ( GLOB G4HEPEMInit_headers ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmInit/include/*.hh)
-file ( GLOB G4HEPEMInit_sources ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmInit/src/*.cc)
+file ( GLOB G4HEPEMInit_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh)
+file ( GLOB G4HEPEMInit_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc)
 if (BUILD_STATIC_LIBS)
   add_library (g4HepEmInit STATIC ${G4HEPEMInit_sources})
 else ()

--- a/G4HepEm/G4HepEmRun/CMakeLists.txt
+++ b/G4HepEm/G4HepEmRun/CMakeLists.txt
@@ -1,15 +1,15 @@
 
-set (G4HEPEMRUN_INC_DIR ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmRun/include PARENT_SCOPE)
+set (G4HEPEMRUN_INC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include PARENT_SCOPE)
 
 include_directories (
-  ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmRun/include
-  ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmData/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/include
+  ${CMAKE_CURRENT_SOURCE_DIR}/../G4HepEmData/include
   ${Geant4_INCLUDE_DIRS}  # only for CLHEP:: Random and units/constants
   )
-file ( GLOB G4HEPEmRun_headers ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmRun/include/*.hh
-                               ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmRun/include/*.icc)
-file ( GLOB G4HEPEmRun_sources ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmRun/src/*.cc
-                               ${CMAKE_SOURCE_DIR}/G4HepEm/G4HepEmRun/include/*.icc)
+file ( GLOB G4HEPEmRun_headers ${CMAKE_CURRENT_SOURCE_DIR}/include/*.hh
+                               ${CMAKE_CURRENT_SOURCE_DIR}/include/*.icc)
+file ( GLOB G4HEPEmRun_sources ${CMAKE_CURRENT_SOURCE_DIR}/src/*.cc
+                               ${CMAKE_CURRENT_SOURCE_DIR}/include/*.icc)
 set_source_files_properties(${G4HEPEmRun_sources} PROPERTIES LANGUAGE CXX)
 if (BUILD_STATIC_LIBS)
   add_library (g4HepEmRun STATIC ${G4HEPEmRun_sources})


### PR DESCRIPTION
When integrating G4HepEm into another project and invoking it via `add_subdirectory()`, `CMAKE_SOURCE_DIR` refers to the directory that CMake was started with and various files cannot be found. Move all uses to `CMAKE_CURRENT_SOURCE_DIR` or `PROJECT_SOURCE_DIR`.