### PR TITLE
[tests] Remove kernels from header files

### DIFF
--- a/apps/tests/ElectronEnergyLoss/include/Declaration.hh
+++ b/apps/tests/ElectronEnergyLoss/include/Declaration.hh
@@ -11,20 +11,12 @@ bool TestElossData ( const struct G4HepEmData* hepEmData, bool iselectron=true )
 
 #ifdef G4HepEm_CUDA_BUILD
 
-#include <device_launch_parameters.h>
-
   // Evaluates all test cases on the device for computing the range, dE/dx and inverse
   // range values on the device for all test cases.
   void TestElossDataOnDevice ( const struct G4HepEmData* hepEmData,
                                int* tsInImc_h, double* tsInEkin_h, double* tsInLogEkin_h,
                                double* tsOutResRange_h, double* tsOutResDEDX_h, double* tsOutResInvRange_h,
                                int numTestCases, bool iselectron );
-
-  __global__
-  void TestElossDataKernel ( struct G4HepEmElectronData* theElectronData_d,
-                             int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d,
-                             double* tsOutResRange_d, double* tsOutResDEDX_d, double* tsOutResInvRange_d,
-                             int numTestCases );
 
 #endif // G4HepEm_CUDA_BUILD
 

--- a/apps/tests/ElectronEnergyLoss/src/ELossData.cu
+++ b/apps/tests/ElectronEnergyLoss/src/ELossData.cu
@@ -14,6 +14,17 @@
 #include "G4HepEmElectronManager.icc"
 #include "G4HepEmRunUtils.icc"
 
+__global__
+void TestElossDataKernel  ( struct G4HepEmElectronData* theElectronData_d, int* tsInImc_d,
+                            double* tsInEkin_d, double* tsInLogEkin_d, double* tsOutResRange_d,
+                            double* tsOutResDEDX_d, double* tsOutResInvRange_d, int numTestCases ) {
+   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
+     G4HepEmElectronManager theElectronMgr;
+     tsOutResRange_d[i]    = theElectronMgr.GetRestRange(theElectronData_d, tsInImc_d[i], tsInEkin_d[i], tsInLogEkin_d[i]);
+     tsOutResDEDX_d[i]     = theElectronMgr.GetRestDEDX (theElectronData_d, tsInImc_d[i], tsInEkin_d[i], tsInLogEkin_d[i]);
+     tsOutResInvRange_d[i] = theElectronMgr.GetInvRange (theElectronData_d, tsInImc_d[i], tsOutResRange_d[i]);
+   }
+ }
 
 void TestElossDataOnDevice ( const struct G4HepEmData* hepEmData,
      int* tsInImc_h, double* tsInEkin_h, double* tsInLogEkin_h,
@@ -64,17 +75,3 @@ void TestElossDataOnDevice ( const struct G4HepEmData* hepEmData,
   cudaFree ( tsOutResRange_d    );
   cudaFree ( tsOutResInvRange_d );
 }
-
-
-
-__global__
-void TestElossDataKernel  ( struct G4HepEmElectronData* theElectronData_d, int* tsInImc_d,
-                            double* tsInEkin_d, double* tsInLogEkin_d, double* tsOutResRange_d,
-                            double* tsOutResDEDX_d, double* tsOutResInvRange_d, int numTestCases ) {
-   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
-     G4HepEmElectronManager theElectronMgr;
-     tsOutResRange_d[i]    = theElectronMgr.GetRestRange(theElectronData_d, tsInImc_d[i], tsInEkin_d[i], tsInLogEkin_d[i]);
-     tsOutResDEDX_d[i]     = theElectronMgr.GetRestDEDX (theElectronData_d, tsInImc_d[i], tsInEkin_d[i], tsInLogEkin_d[i]);
-     tsOutResInvRange_d[i] = theElectronMgr.GetInvRange (theElectronData_d, tsInImc_d[i], tsOutResRange_d[i]);
-   }
- }

--- a/apps/tests/ElectronTargetElementSelector/include/Declaration.hh
+++ b/apps/tests/ElectronTargetElementSelector/include/Declaration.hh
@@ -13,24 +13,12 @@ bool TestElemSelectorData ( const struct G4HepEmData* hepEmData, const struct G4
 
 #ifdef G4HepEm_CUDA_BUILD
 
-#include <device_launch_parameters.h>
-
   // Evaluates all test cases on the device by sampling the index of the target element (of the
   // target material-cuts couple) on which the interaction takes place, on the device for all
   // test cases.
   void TestElemSelectorDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
                                       double* tsInEkin_h, double* tsInLogEkin_h, double* tsInRngVals_h,
                                       int* tsOutRes_h, int numTestCases, int indxModel, bool iselectron );
-
-
-  template <bool TisSBModel>
-  __global__
-  void TestElemSelectorDataBremKernel ( const struct G4HepEmElectronData* theElectronData_d,
-                                        const struct G4HepEmMatCutData* theMatCutData_d,
-                                        const struct G4HepEmMaterialData* theMaterialData_d,
-                                        int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d, double* tsInRngVals_d,
-                                        int* tsOutRes_d, int numTestCases );
-
 
 #endif // G4HepEm_CUDA_BUILD
 

--- a/apps/tests/ElectronXSections/include/Declaration.hh
+++ b/apps/tests/ElectronXSections/include/Declaration.hh
@@ -11,9 +11,6 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron=tru
 
 #ifdef G4HepEm_CUDA_BUILD
 
-#include <device_launch_parameters.h>
-
-
   // Evaluates all test cases on the device for computing the restricted macroscopic
   // cross section values for ionisation and bremsstrahlung on the device for all test cases.
   void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
@@ -21,11 +18,6 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron=tru
                                     double* tsInEkinBrem_h, double* tsInLogEkinBrem_h,
                                     double* tsOutResMXIoni_h, double* tsOutResMXBrem_h,
                                     int numTestCases, bool iselectron );
-
-  __global__
-  void TestResMacXSecDataKernel ( const struct G4HepEmElectronData* theElectronData_d,
-                                  int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d,
-                                  double* tsOutRes_d, bool isIoni, int numTestCases );
 
 #endif // G4HepEm_CUDA_BUILD
 

--- a/apps/tests/ElectronXSections/src/ResMacXSecs.cu
+++ b/apps/tests/ElectronXSections/src/ResMacXSecs.cu
@@ -15,6 +15,15 @@
 #include "G4HepEmElectronManager.icc"
 #include "G4HepEmRunUtils.icc"
 
+ __global__
+ void TestResMacXSecDataKernel ( const struct G4HepEmElectronData* theElectronData_d,
+                                 int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d,
+                                 double* tsOutRes_d, bool isIoni, int numTestCases) {
+   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
+     G4HepEmElectronManager theElectronMgr;
+     tsOutRes_d[i] = theElectronMgr.GetRestMacXSec (theElectronData_d, tsInImc_d[i], tsInEkin_d[i], tsInLogEkin_d[i], isIoni);
+   }
+ }
 
 void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
      double* tsInEkinIoni_h, double* tsInLogEkinIoni_h, double* tsInEkinBrem_h, double* tsInLogEkinBrem_h,
@@ -71,14 +80,3 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   cudaFree ( tsOutResMXIoni_d  );
   cudaFree ( tsOutResMXBrem_d  );
 }
-
-
- __global__
- void TestResMacXSecDataKernel ( const struct G4HepEmElectronData* theElectronData_d,
-                                 int* tsInImc_d, double* tsInEkin_d, double* tsInLogEkin_d,
-                                 double* tsOutRes_d, bool isIoni, int numTestCases) {
-   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
-     G4HepEmElectronManager theElectronMgr;
-     tsOutRes_d[i] = theElectronMgr.GetRestMacXSec (theElectronData_d, tsInImc_d[i], tsInEkin_d[i], tsInLogEkin_d[i], isIoni);
-   }
- }

--- a/apps/tests/MaterialAndRelated/include/Declaration.hh
+++ b/apps/tests/MaterialAndRelated/include/Declaration.hh
@@ -11,22 +11,10 @@ bool TestMatCutData    ( const struct G4HepEmData* hepEmData );
 
 #ifdef G4HepEm_CUDA_BUILD
 
-#include <device_launch_parameters.h>
-
-  __global__
-  void TestElementDataKernel    ( struct G4HepEmElementData* elemData_d, int* elemIndices_d,
-                                  double* resZet_d, double* resZet13_d, int numTestCases);
   bool TestElementDataOnDevice  ( const struct G4HepEmData* hepEmData );
 
-  __global__
-  void TestMaterialDataKernel   ( struct G4HepEmMaterialData* matData_d, int* matIndices_d, int* indxStarts_d,
-                                  double* resCompADens_d, int* resCompElems_d,  int* resNumElems_d,
-                                  double* resMassDens_d, double* resElecDens_d, double* resRadLen_d, int numTestCases );
   bool TestMaterialDataOnDevice ( const struct G4HepEmData* hepEmData );
 
-  __global__
-  void TestMatCutDataKernel     ( struct G4HepEmMatCutData* mcData_d, int* mcIndices_d,
-                                  double* resSecElCut_d, double* resSecGamCut_d, int* resMatIndx_d, int numTestCases );
   bool TestMatCutDataOnDevice   ( const struct G4HepEmData* hepEmData );
 
 #endif // G4HepEm_CUDA_BUILD

--- a/apps/tests/testElectronInteractionBrem/include/Declaration.hh
+++ b/apps/tests/testElectronInteractionBrem/include/Declaration.hh
@@ -16,13 +16,7 @@ void G4HepEmSBTest(const G4MaterialCutsCouple* g4MatCut, G4double ekin, G4double
 
 #ifdef G4HepEm_CUDA_BUILD
 
-#include <device_launch_parameters.h>
-
   bool TestSBTableData(const struct G4HepEmData* hepEmData);
-
-  __global__
-  void TestSBTableDataKernel(struct G4HepEmSBTableData* theTableData_d, int* theIData1_d, int* theIData2_d, int* theIData3_d, int* theIData4_d,
-                             double* theDData1_d, double* theDData2_d, double* theDData3_d, double* theDData4_d, double* theDData5_d);
 
 #endif // G4HepEm_CUDA_BUILD
 


### PR DESCRIPTION
They are only called in the `.cu` files they are implemented in. Move them to the top to make them declared before called. This fixes the build with CUDA + tests enabled in an environment that doesn't have `device_launch_parameters.h` in the include path, which now isn't used anymore.