### PR TITLE
Use NAME/COMMAND form of add_test

### DIFF
--- a/testing/ElectronEnergyLoss/CMakeLists.txt
+++ b/testing/ElectronEnergyLoss/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(TestEnergyLossData
   PRIVATE
   g4HepEm TestUtils ${Geant4_LIBRARIES})
 
-add_test(TestEnergyLossData TestEnergyLossData)
+add_test(NAME TestEnergyLossData COMMAND TestEnergyLossData)

--- a/testing/ElectronTargetElementSelector/CMakeLists.txt
+++ b/testing/ElectronTargetElementSelector/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(TestElemSelectorData
   PRIVATE
   g4HepEm TestUtils ${Geant4_LIBRARIES})
 
-add_test(TestElemSelectorData TestElemSelectorData)
+add_test(NAME TestElemSelectorData COMMAND TestElemSelectorData)

--- a/testing/ElectronXSections/CMakeLists.txt
+++ b/testing/ElectronXSections/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(TestXSectionData
   PRIVATE
   g4HepEm TestUtils ${Geant4_LIBRARIES})
 
-add_test(TestXSectionData TestXSectionData)
+add_test(NAME TestXSectionData COMMAND TestXSectionData)

--- a/testing/MaterialAndRelated/CMakeLists.txt
+++ b/testing/MaterialAndRelated/CMakeLists.txt
@@ -9,4 +9,4 @@ target_link_libraries(TestMaterialAndRelated
   PRIVATE
   g4HepEm TestUtils ${Geant4_LIBRARIES})
 
-add_test(TestMaterialAndRelated TestMaterialAndRelated)
+add_test(NAME TestMaterialAndRelated COMMAND TestMaterialAndRelated)


### PR DESCRIPTION
A very minor update to the CMake/CTests to use the full and recommended signature of `add_test(NAME <testname> COMMAND <command>)`. This form means that any target name (i.e. built in this project) in `<command>` will be resolved by CMake to the full path to that target's executable, and avoids any clashes with the system `PATH` and so on.