### PR TITLE
Add gamma interactions

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmData.hh
@@ -7,11 +7,9 @@ struct G4HepEmElementData;
 
 struct G4HepEmElectronData;
 
-#ifdef G4HepEm_CUDA_BUILD
- struct G4HepEmElectronDataOnDevice;
-#endif  // G4HepEm_CUDA_BUILD
-
 struct G4HepEmSBTableData;
+
+struct G4HepEmGammaData;
 
 /**
  * @file    G4HepEmData.hh
@@ -57,6 +55,9 @@ struct G4HepEmData {
   struct G4HepEmSBTableData*           fTheSBTableData      = nullptr;
 
 
+  struct G4HepEmGammaData*             fTheGammaData        = nullptr;
+
+
 #ifdef G4HepEm_CUDA_BUILD
   struct G4HepEmMatCutData*            fTheMatCutData_gpu   = nullptr;
   struct G4HepEmMaterialData*          fTheMaterialData_gpu = nullptr;
@@ -66,6 +67,8 @@ struct G4HepEmData {
   struct G4HepEmElectronData*          fThePositronData_gpu = nullptr;
 
   struct G4HepEmSBTableData*           fTheSBTableData_gpu  = nullptr;
+
+  struct G4HepEmGammaData*             fTheGammaData_gpu    = nullptr;
 #endif  // G4HepEm_CUDA_BUILD
 
 };

--- a/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
@@ -39,12 +39,12 @@ struct G4HepEmElemData {
   double  fZet;
 
   /** \f$Z^{1/3}\f$ */
-  double  fZet13;  
+  double  fZet13;
 
   /** \f$Z^{2/3}\f$ */
-  double  fZet23;  
+  double  fZet23;
 
-  /** Coulomb correction */
+  /** Coulomb correction \f$ f_C \f$ */
   double  fCoulomb;
 
   /** \f$ \ln(Z) \f$  */
@@ -52,6 +52,12 @@ struct G4HepEmElemData {
 
   /** \f$ F_{\text{e}l}-f_c+F_{\text{inel}}/Z \f$  */
   double  fZFactor1;
+
+  /** \f$ \exp\[ \frac{42.038-F_{Z-low}}{8.29} \] -0.958 \f$ with \f$ Z-low = \frac{8}{3}\log(Z)\f$ */
+  double  fDeltaMaxLow;
+
+  /** \f$ \exp\[ \frac{42.038-F_{Z-high}}{8.29} \] -0.958 \f$ with \f$ Z-high = 8[\log(Z)/3 + f_C \f$ */
+  double  fDeltaMaxHigh;
 
   /** LPM variable \f$ 1/ln [ \sqrt{2}s1 ] \f$ */
   double  fILVarS1;
@@ -63,7 +69,7 @@ struct G4HepEmElemData {
 
 // Data for all elements that are used by G4HepEm.
 struct G4HepEmElementData {
-  /** Maximum capacity of the below G4HepEmElemData structure container (max Z that can be stored).*/ 
+  /** Maximum capacity of the below G4HepEmElemData structure container (max Z that can be stored).*/
   int     fMaxZet;
   /** Collection of G4HepEmElemData structures indexed by the atomic number Z. */
   struct G4HepEmElemData* fElementData;  // [fMaxZet]
@@ -72,30 +78,30 @@ struct G4HepEmElementData {
 /**
   * Allocates and pre-initialises the G4HepEmMaterialData structure.
   *
-  * This method is invoked from the InitMaterialAndCoupleData() function declared 
-  * in the G4HepEmMaterialInit header file. The input argument address of the 
-  * G4HepEmElementData structure pointer is the one stored in the G4HepEmData  
-  * member of the `master` G4HepEmRunManager and the initialisation should be 
+  * This method is invoked from the InitMaterialAndCoupleData() function declared
+  * in the G4HepEmMaterialInit header file. The input argument address of the
+  * G4HepEmElementData structure pointer is the one stored in the G4HepEmData
+  * member of the `master` G4HepEmRunManager and the initialisation should be
   * done by the master G4HepEmRunManager.
   *
   * @param theElementData address of a G4HepEmElementData structure pointer. At termination,
   *   the correspondig pointer will be set to a memory location with a freshly allocated
   *   G4HepEmElementData structure. If the pointer was not null at input, the pointed
-  *   memory is freed before the new allocation.  
+  *   memory is freed before the new allocation.
   */
 void AllocateElementData(struct G4HepEmElementData** theElementData);
 
-/** 
-  * Frees a G4HepEmElementData structure. 
+/**
+  * Frees a G4HepEmElementData structure.
   *
-  * This function deallocates all dynamically allocated memory stored in the 
-  * input argument related G4HepEmElementData structure, deallocates the structure 
-  * itself and sets the input address to store a pointer to null. This makes the 
-  * corresponding input stucture cleared, freed and ready to be re-initialised. 
-  * The input argument is supposed to be the address of the corresponding pointer 
+  * This function deallocates all dynamically allocated memory stored in the
+  * input argument related G4HepEmElementData structure, deallocates the structure
+  * itself and sets the input address to store a pointer to null. This makes the
+  * corresponding input stucture cleared, freed and ready to be re-initialised.
+  * The input argument is supposed to be the address of the corresponding pointer
   * member of the G4HepEmData member of the `master` G4HepEmRunManager.
   *
-  * @param theElementData memory address that stores pointer to a G4HepEmElementData  
+  * @param theElementData memory address that stores pointer to a G4HepEmElementData
   *  structure. The memory is freed and the input address will store a null pointer
   *  at termination.
   */
@@ -107,18 +113,18 @@ void FreeElementData (struct G4HepEmElementData** theElementData);
   * Allocates memory for and copies the G4HepEmElementData structure from the
   * host to the device.
   *
-  * The input arguments are supposed to be the corresponding members of the 
+  * The input arguments are supposed to be the corresponding members of the
   * G4HepEmData, top level data structure, stored in the `master` G4HepEmRunManager.
   *
   * @param onHost    pointer to the host side, already initialised G4HepEmElementData structure.
-  * @param onDevice  host side address of a G4HepEmElementData structure memory pointer. The pointed 
-  *   memory is cleaned (if not null at input) and points to the device side memory at termination 
+  * @param onDevice  host side address of a G4HepEmElementData structure memory pointer. The pointed
+  *   memory is cleaned (if not null at input) and points to the device side memory at termination
   *   that stores the copied G4HepEmElementData structure.
-  */  
+  */
   void CopyElementDataToGPU(struct G4HepEmElementData* onHost, struct G4HepEmElementData** onDevice);
-  
+
   /**
-    * Frees all memory related to the device side G4HepEmElementData structure referred 
+    * Frees all memory related to the device side G4HepEmElementData structure referred
     * by the pointer stored on the host side input argument address.
     *
     * @param onDevice host side address of a G4HepEmElementData structure located on the device side memory.

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -1,0 +1,109 @@
+#ifndef G4HepEmGammaData_HH
+#define G4HepEmGammaData_HH
+
+/**
+ * @file    G4HepEmGammaData.hh
+ * @struct  G4HepEmGammaData
+ * @author  M. Novak
+ * @date    2021
+ *
+ * @brief All energy loss process related data used for \f$e^-/e+\f$ simulations by `G4HepEm`.
+ *
+ * Covers Gamma conversion itno e-/e+ pairs and Compton scattering at the moment.
+ */
+
+struct G4HepEmGammaData {
+  /** Number of G4HepEm materials: number of G4HepEmMatData structures stored in the G4HepEmMaterialData::fMaterialData array. */
+  int           fNumMaterials;
+
+//// === conversion related data. Grid: 146 bins form 2mc^2 - 100 TeV
+  const int     fConvEnergyGridSize = 147;
+  double        fConvLogMinEkin;    // = 0.021759358706830;  // log(2mc^2)
+  double        fConvEILDelta;      // = 7.935247775833226;  // 1./[log(emax/emin)/146]
+  double*       fConvEnergyGrid;    // the enrgy grid
+
+//// === compton related data. 84 bins (7 per decades) from 100 eV - 100 TeV
+  const int     fCompEnergyGridSize = 85;
+  double        fCompLogMinEkin;     // = -9.210340371976182; // log(0.0001) i.e. log(100 eV)
+  double        fCompEILDelta;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
+  double*       fCompEnergyGrid;     // the enrgy grid
+
+  // the macroscopic cross sections for all materials and for [conversion,compton]
+  // at each material
+  double*       fConvCompMacXsecData;   // [#materials*(fConvEnergyGridSize+fCompEnergyGridSize)]
+
+//// === element selector for conversion (note: KN compton interaction do not know anything about Z)
+  int           fElemSelectorConvEgridSize;
+  int           fElemSelectorConvNumData;          // total number of data i.e. lenght of fElemSelectorConvData
+  double        fElemSelectorConvLogMinEkin;
+  double        fElemSelectorConvEILDelta;         //
+  int*          fElemSelectorConvStartIndexPerMat; // [#materials]
+  double*       fElemSelectorConvEgrid;            // common energy grid for all element selectors
+
+  /** Element selector data for all materials */
+  double*       fElemSelectorConvData;             // [fElemSelectorConvEGridSize]
+};
+
+/**
+  * Allocates and pre-initialises the G4HepEmGammaData structure.
+  *
+  * This method is invoked from the InitGammaData() function declared
+  * in the G4HepEmGammaInit header file. The input argument address of the
+  * G4HepEmGammaData structure pointer is the one stored in the G4HepEmData
+  * member of the `master` G4HepEmRunManager and the initialisation should be
+  * done by the master G4HepEmRunManager by invoking the InitGammaData() function
+  * for \f$\gamma\f$ particles.
+  *
+  * @param theGammaData address of a G4HepEmGammaData structure pointer. At termination,
+  *   the correspondig pointer will be set to a memory location with a freshly allocated
+  *   G4HepEmGammaData structure with all its pointer members set to nullprt.
+  *   If the input pointer was not null at input, the pointed memory, including all
+  *   dynamic memory members, is freed before the new allocation.
+  */
+void AllocateGammaData (struct G4HepEmGammaData** theGammaData);
+
+/**
+  * Frees a G4HepEmGammaData structure.
+  *
+  * This function deallocates all dynamically allocated memory stored in the
+  * input argument related G4HepEmGammaData structure, deallocates the structure
+  * itself and sets the input address to store a pointer to null. This makes the
+  * corresponding input stucture cleared, freed and ready to be re-initialised.
+  * The input argument is supposed to be the address of the corresponding pointer
+  * member of the G4HepEmData member of the `master` G4HepEmRunManager.
+  *
+  * @param theGammaData memory address that stores pointer to a G4HepEmGammaData
+  *  structure. The memory is freed and the input address will store a null pointer
+  *  at termination.
+  */
+void FreeGammaData (struct G4HepEmGammaData** theGammaData);
+
+
+
+#ifdef G4HepEm_CUDA_BUILD
+  /**
+    * Allocates memory for and copies the G4HepEmGammaData structure from the
+    * host to the device.
+    *
+    * The input arguments are supposed to be the corresponding members of the
+    * G4HepEmData, top level data structure, stored in the `master` G4HepEmRunManager.
+    *
+    * @param onHOST    pointer to the host side, already initialised G4HepEmGammaData structure.
+    * @param onDEVICE  host side address of a pointer to a device side G4HepEmGammaData
+    *   structure. The pointed device side memory is cleaned (if not null at input) and
+    *   points to the device side memory at termination containing all the copied
+    *   G4HepEmGammaData structure members.
+    */
+  void CopyGammaDataToDevice(struct G4HepEmGammaData* onHOST, struct G4HepEmGammaData** onDEVICE);
+
+  /**
+    * Frees all memory related to the device side G4HepEmGammaData structure referred
+    * by the pointer stored on the host side input argument address.
+    *
+    * @param onDEVICE host side address of a G4HepEmGammaDataOnDevice structure located on the device side memory.
+    *   The correspondig device memory will be freed and the input argument address will be set to null.
+    */
+  void FreeGammaDataOnDevice(struct G4HepEmGammaData** onDEVICE);
+#endif // DG4HepEm_CUDA_BUILD
+
+#endif // G4HepEmGammaData_HH

--- a/G4HepEm/G4HepEmData/src/G4HepEmData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmData.cc
@@ -9,6 +9,8 @@
 #include "G4HepEmElectronData.hh"
 #include "G4HepEmSBTableData.hh"
 
+#include "G4HepEmGammaData.hh"
+
 void InitG4HepEmData (struct G4HepEmData* theHepEmData) {
   // free all previous (if any)
   FreeG4HepEmData (theHepEmData);
@@ -22,6 +24,8 @@ void InitG4HepEmData (struct G4HepEmData* theHepEmData) {
 
   theHepEmData->fTheSBTableData      = nullptr;
 
+  theHepEmData->fTheGammaData        = nullptr;
+
 #ifdef G4HepEm_CUDA_BUILD
   theHepEmData->fTheMatCutData_gpu   = nullptr;
   theHepEmData->fTheMaterialData_gpu = nullptr;
@@ -31,6 +35,8 @@ void InitG4HepEmData (struct G4HepEmData* theHepEmData) {
   theHepEmData->fThePositronData_gpu = nullptr;
 
   theHepEmData->fTheSBTableData_gpu  = nullptr;
+
+  theHepEmData->fTheGammaData_gpu    = nullptr;
 #endif // G4HepEm_CUDA_BUILD
 }
 
@@ -45,6 +51,8 @@ void FreeG4HepEmData (struct G4HepEmData* theHepEmData) {
 
   FreeSBTableData  ( &(theHepEmData->fTheSBTableData)  );
 
+  FreeGammaData    ( &(theHepEmData->fTheGammaData)  );
+
 #ifdef G4HepEm_CUDA_BUILD
   FreeMatCutDataOnGPU      ( &(theHepEmData->fTheMatCutData_gpu)   );
   FreeMaterialDataOnGPU    ( &(theHepEmData->fTheMaterialData_gpu) );
@@ -54,6 +62,8 @@ void FreeG4HepEmData (struct G4HepEmData* theHepEmData) {
   FreeElectronDataOnDevice ( &(theHepEmData->fThePositronData_gpu) );
 
   FreeSBTableDataOnDevice  ( &(theHepEmData->fTheSBTableData_gpu)  );
+
+  FreeGammaDataOnDevice    ( &(theHepEmData->fTheGammaData_gpu)  );
 #endif // G4HepEm_CUDA_BUILD
 }
 
@@ -65,13 +75,13 @@ void CopyG4HepEmDataToGPU (struct G4HepEmData* onCPU) {
   // Deep copy each members represented by their pointers.
 
   // 1. Copy the G4HepEmMatCutData member and set the device ptr.
-  CopyMatCutDataToGPU ( onCPU->fTheMatCutData, &(onCPU->fTheMatCutData_gpu) );
+  CopyMatCutDataToGPU ( onCPU->fTheMatCutData,      &(onCPU->fTheMatCutData_gpu) );
 
   // 2. Copy the G4HepEmMaterialData member and set the device ptr.
-  CopyMaterialDataToGPU ( onCPU->fTheMaterialData, &(onCPU->fTheMaterialData_gpu) );
+  CopyMaterialDataToGPU ( onCPU->fTheMaterialData,  &(onCPU->fTheMaterialData_gpu) );
 
   // 3. Copy the G4HepEmElementData member and set the device ptr.
-  CopyElementDataToGPU ( onCPU->fTheElementData, &(onCPU->fTheElementData_gpu) );
+  CopyElementDataToGPU ( onCPU->fTheElementData,    &(onCPU->fTheElementData_gpu) );
 
   // 4. Copy electron data to the GPU
   CopyElectronDataToDevice( onCPU->fTheElectronData, &(onCPU->fTheElectronData_gpu));
@@ -81,5 +91,9 @@ void CopyG4HepEmDataToGPU (struct G4HepEmData* onCPU) {
 
   // 6. Copy SB-brem sampling tables to the GPU
   CopySBTableDataToDevice( onCPU->fTheSBTableData,   &(onCPU->fTheSBTableData_gpu));
+
+  // 7. Copy gamma related data to the GPU
+  CopyGammaDataToDevice( onCPU->fTheGammaData,     &(onCPU->fTheGammaData_gpu));
+
 }
 #endif

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -1,0 +1,58 @@
+#include "G4HepEmGammaData.hh"
+
+// NOTE: allocates only the main data structure but not the dynamic members
+void AllocateGammaData (struct G4HepEmGammaData** theGammaData) {
+  // clean away previous (if any)
+  FreeGammaData(theGammaData);
+  *theGammaData   = new G4HepEmGammaData;
+  // energy grids for conversion and compton
+  (*theGammaData)->fConvEnergyGrid                      = nullptr;
+  (*theGammaData)->fCompEnergyGrid                      = nullptr;
+  // macroscopic cross sections, for conversina and compton, per materials
+  (*theGammaData)->fConvCompMacXsecData                 = nullptr;  // mac-xsec
+  // element selector for conversion (no need for the dummy KN compton)
+  (*theGammaData)->fElemSelectorConvStartIndexPerMat    = nullptr;
+  (*theGammaData)->fElemSelectorConvEgrid               = nullptr;
+  (*theGammaData)->fElemSelectorConvData                = nullptr;
+
+}
+
+
+void FreeGammaData (struct G4HepEmGammaData** theGammaData)  {
+  if (*theGammaData) {
+    // energy grids for conversion and compton
+    if ((*theGammaData)->fConvEnergyGrid ) {
+      delete[] (*theGammaData)->fConvEnergyGrid ;
+    }
+    if ((*theGammaData)->fCompEnergyGrid) {
+      delete[] (*theGammaData)->fCompEnergyGrid;
+    }
+    // mac-xsec for conversion and compton
+    if ((*theGammaData)->fConvCompMacXsecData) {
+      delete[] (*theGammaData)->fConvCompMacXsecData;
+    }
+    // element selector for conversion
+    if ((*theGammaData)->fElemSelectorConvStartIndexPerMat) {
+      delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
+    }
+    if ((*theGammaData)->fElemSelectorConvEgrid) {
+      delete[] (*theGammaData)->fElemSelectorConvEgrid;
+    }
+    if ((*theGammaData)->fElemSelectorConvData) {
+      delete[] (*theGammaData)->fElemSelectorConvData;
+    }
+
+    delete *theGammaData;
+    *theGammaData = nullptr;
+  }
+}
+
+
+#ifdef G4HepEm_CUDA_BUILD
+#include <cuda_runtime.h>
+#include "G4HepEmCuUtils.hh"
+
+void CopyGammaDataToDevice(struct G4HepEmGammaData* onHOST, struct G4HepEmGammaData** onDEVICE) {/*TO BE IMPLEMENTED*/}
+void FreeGammaDataOnDevice(struct G4HepEmGammaData** onDEVICE) {/*TO BE IMPLEMENTED*/}
+
+#endif

--- a/G4HepEm/G4HepEmInit/include/G4HepEmGammaInit.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmGammaInit.hh
@@ -1,0 +1,17 @@
+
+// Initialisation of all gamma related data (macroscopic cross sections
+// and target element selectors for each model) and interaction models.
+
+// NOTE: only Conversion and Compton is active at the moment
+
+#ifndef G4HepEmGammaInit_HH
+#define G4HepEmGammaInit_HH
+
+struct G4HepEmData;
+struct G4HepEmParameters;
+
+void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars);
+
+
+
+#endif // G4HepEmGammaInit_HH

--- a/G4HepEm/G4HepEmInit/include/G4HepEmGammaTableBuilder.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmGammaTableBuilder.hh
@@ -1,0 +1,23 @@
+#ifndef G4HepEmGammaTableBuilder_HH
+#define G4HepEmGammaTableBuilder_HH
+
+// computes the macroscopic cross sections for Conversion and Compton for all
+// materials
+
+//class G4VEmModel;
+//class G4ParticleDefinition;
+class G4PairProductionRelModel;
+class G4KleinNishinaCompton;
+
+struct G4HepEmData;
+struct G4HepEmParameters;
+//struct G4HepEmMatData;
+
+
+// Should receive pointers to G4 models that are already initialised
+void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton* knModel,
+                     struct G4HepEmData* hepEmData);
+
+void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepEmData* hepEmData);
+
+#endif // G4HepEmGammaTableBuilder_HH

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronInit.cc
@@ -21,8 +21,6 @@
 #include "G4SeltzerBergerModel.hh"
 #include "G4eBremsstrahlungRelModel.hh"
 
-#include "G4HepEmElectronTableBuilder.hh"
-
 #include "G4HepEmMatCutData.hh"
 #include "G4HepEmMaterialData.hh"
 #include "G4HepEmElementData.hh"
@@ -30,34 +28,34 @@
 #include <iostream>
 
 
-void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, 
+void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars,
                       bool iselectron) {
   // clean previous G4HepEmElectronData (if any)
-  // 
+  //
   // create G4Models for e- or for e+
   G4ParticleDefinition* g4PartDef = G4Positron::Positron();
   if (iselectron) {
-    g4PartDef = G4Electron::Electron(); 
+    g4PartDef = G4Electron::Electron();
   }
-  std::cout << "     ---  InitElectronData ... " << std::endl;  
+  std::cout << "     ---  InitElectronData ... " << std::endl;
   // Min/Max energies of the EM model (same as for the loss-tables)
   G4double emModelEMin = G4EmParameters::Instance()->MinKinEnergy();
-  G4double emModelEMax = G4EmParameters::Instance()->MaxKinEnergy();  
+  G4double emModelEMax = G4EmParameters::Instance()->MaxKinEnergy();
   // we will need the couple table to get the cuts
   G4ProductionCutsTable* theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
   //
-  // 1. Moller-Bhabha model for ionisation: 
-  // --- used on [E_min : E_max] 
+  // 1. Moller-Bhabha model for ionisation:
+  // --- used on [E_min : E_max]
   G4MollerBhabhaModel*  modelMB = new G4MollerBhabhaModel();
   modelMB->SetLowEnergyLimit(emModelEMin);
-  modelMB->SetHighEnergyLimit(emModelEMin);
+  modelMB->SetHighEnergyLimit(emModelEMax);
   // get cuts for secondary e-
   const G4DataVector* theElCuts = static_cast<const G4DataVector*>(theCoupleTable->GetEnergyCutsVector(1));
   modelMB->Initialise(g4PartDef, *theElCuts);
   //
   //
   // 2. Seltzer-Berger numerical DCS based model for brem. photon emission:
-  // --- used on [E_min : 1 GeV] note: data are available from 1 keV to 1 GeV 
+  // --- used on [E_min : 1 GeV] note: data are available from 1 keV to 1 GeV
   G4SeltzerBergerModel* modelSB = new G4SeltzerBergerModel();
   modelSB->SetLowEnergyLimit(emModelEMin);
   G4double energyLimit = std::min(modelSB->HighEnergyLimit(), hepEmPars->fElectronBremModelLim);
@@ -78,11 +76,11 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
   modelRB->SetLPMFlag(true);
   modelRB->Initialise(g4PartDef, *theGamCuts);
   //
-  // === Use the G4HepEmElectronTableBuilder to build all data tables used at 
-  //     run time: e-loss, macroscopic cross section tables and target element 
+  // === Use the G4HepEmElectronTableBuilder to build all data tables used at
+  //     run time: e-loss, macroscopic cross section tables and target element
   //     selectors for each models.
   //
-  // allocate (the ELossData part of) the ElectronData (NOTE: shallow only, 
+  // allocate (the ELossData part of) the ElectronData (NOTE: shallow only,
   // BuildELossTables will complete the allocation) but cleans the memory of the
   // hepEmData->fTheElectronData
   if (iselectron) {
@@ -93,10 +91,10 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
   // build energy loss data
   std::cout << "     ---  BuildELossTables ..." << std::endl;
   BuildELossTables(modelMB, modelSB, modelRB, hepEmData, hepEmPars, iselectron);
-  // build macroscopic cross section data 
+  // build macroscopic cross section data
   std::cout << "     ---  BuildLambdaTables ... " << std::endl;
   BuildLambdaTables(modelMB, modelSB, modelRB, hepEmData, hepEmPars, iselectron);
-  // build element selectors 
+  // build element selectors
   std::cout << "     ---  BuildElementSelectorTables ... " << std::endl;
   BuildElementSelectorTables(modelMB, modelSB, modelRB, hepEmData, hepEmPars, iselectron);
   //
@@ -104,7 +102,7 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
   //
   // init sampling for MB, SB and RB models:
   // - nothing to init for MB
-  // - SB: create a SB-table builder, build the S-tables and read them to produce 
+  // - SB: create a SB-table builder, build the S-tables and read them to produce
   //       the G4HepEmSBTables data structure (SB-table are the same fo -e and e+
   //       so we should build them only once)
   if (!hepEmData->fTheSBTableData) {
@@ -117,4 +115,3 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
   delete modelSB;
   delete modelRB;
 }
-

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -35,10 +35,10 @@
 
 
 void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbModel,
-                      G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData, 
-                      struct G4HepEmParameters* hepEmParams, bool iselectron) {                        
-  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData                                                
-  struct G4HepEmElectronData* elData = iselectron 
+                      G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData,
+                      struct G4HepEmParameters* hepEmParams, bool iselectron) {
+  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData
+  struct G4HepEmElectronData* elData = iselectron
                                        ? hepEmData->fTheElectronData
                                        : hepEmData->fThePositronData;
   //
@@ -68,21 +68,21 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
     g4PartDef = G4Electron::Electron();
   }
   // get the HepEm Material-cut couple data
-  const struct G4HepEmMatCutData*    hepEmMCData = hepEmData->fTheMatCutData; 
-  // we will need to obtain the correspondig G4MaterialCutsCouple object pointers 
+  const struct G4HepEmMatCutData*    hepEmMCData = hepEmData->fTheMatCutData;
+  // we will need to obtain the correspondig G4MaterialCutsCouple object pointers
   G4ProductionCutsTable* theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
   // loop over the HepEm material-cuts couples:
   //  - get the corresponding G4Material pointer
-  //  - loop over the eloss-energy grid and compute the sum of the electronic and 
+  //  - loop over the eloss-energy grid and compute the sum of the electronic and
   //    radiative (restricted) stopping powers for each material-cuts couple
-  //  - apply smoothing in case of the radiative (i.e. brem.) part between the 
-  //    two models connected at bermModelLimitEnergy = 1 GeV = 1000 MeV 
-  //  - store the dE/dx in an intermediate array, compute the range array and 
+  //  - apply smoothing in case of the radiative (i.e. brem.) part between the
+  //    two models connected at bermModelLimitEnergy = 1 GeV = 1000 MeV
+  //  - store the dE/dx in an intermediate array, compute the range array and
   //    their second derivative for a spline interpolation
   //  - fill these 4 later data into the elData structure for this mat-cut
   //
   double* theDEDXArray       = new double[numELoss];
-  double* theRangeArray      = new double[numELoss]; 
+  double* theRangeArray      = new double[numELoss];
   double* theDEDXSDArray     = new double[numELoss];  // second derivatives for dedx
   double* theRangeSDArray    = new double[numELoss];  // second derivatives for range
   double* theInvRangeSDArray = new double[numELoss];  // second derivatives for inverse range
@@ -92,11 +92,11 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
   //
   // allocate array to store the [range, sec-deriv, dedx, sec-deriv, in-range-sec-deriv]
   // (numELoss values each) for all matrial-cuts couple
-//  
+//
 //  std::out << " ==== Allocating " << 5.0*numELoss*numHepEmMCCData*sizeof(double)/1024/1024
-//            << " [MB] memory in G4HepEmELossTableBuilder::BuildELossTables \n" 
-//            << " for Range, dE/dx and inv-Range for the " << numHepEmMCCData 
-//            << "\n material-cuts couples used in the geometry. ( 5x " << numELoss  
+//            << " [MB] memory in G4HepEmELossTableBuilder::BuildELossTables \n"
+//            << " for Range, dE/dx and inv-Range for the " << numHepEmMCCData
+//            << "\n material-cuts couples used in the geometry. ( 5x " << numELoss
 //            << " `double` value for each)." << std::endl;
   elData->fELossData = new double[5*numELoss*numHepEmMCCData];
   //
@@ -104,12 +104,12 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
   for (int imc=0; imc<numHepEmMCCData; ++imc) {
     const struct G4HepEmMCCData& mccData = hepEmMCData->fMatCutData[imc];
     const G4MaterialCutsCouple* g4MatCut = theCoupleTable->GetMaterialCutsCouple(mccData.fG4MatCutIndex);
-    const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut   
+    const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut
     const double    gamCutE = mccData.fSecGamProdCutE;
-    // loop over the eloss-energy grid 
+    // loop over the eloss-energy grid
     for (int ie=0; ie<numELoss; ++ie) {
       double ekin = elData->fELossEnergyGrid[ie];
-      // compute the electronic dE/dx 
+      // compute the electronic dE/dx
       double dedxIoni = std::max(0.0, mbModel->ComputeDEDX(g4MatCut, g4PartDef, ekin, elCutE));
       // compute the radiative dE/dx: smoothing of the high energy model value
       double dlta = 0.0;
@@ -119,7 +119,7 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
         dlta = dedx2 > 0.0 ? (dedx1/dedx2-1.0)*hepEmParams->fElectronBremModelLim : 0.0;
       }
       //sbModel->SetupForMaterial(g4PartDef, g4MatCut->GetMaterial(), ekin);
-      double dedxBrem = ekin > hepEmParams->fElectronBremModelLim 
+      double dedxBrem = ekin > hepEmParams->fElectronBremModelLim
                         ? rbModel->ComputeDEDX(g4MatCut, g4PartDef, ekin, gamCutE)
                         : sbModel->ComputeDEDX(g4MatCut, g4PartDef, ekin, gamCutE);
       dedxBrem *= (1.0+dlta/ekin);
@@ -129,7 +129,7 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
     // set up a spline on the DEDX array for interpolation
     G4HepEmInitUtils::Instance().PrepareSpline(numELoss, elData->fELossEnergyGrid, theDEDXArray, theDEDXSDArray);
     // integrate the restricted dedx to get the corresponding restricted range:
-    // - first set the very first range value i.e. approximate the integral of 
+    // - first set the very first range value i.e. approximate the integral of
     //   the dE/dx on [0, E_0] by assuming that the dE/dx is proportional to $\beta$
     theRangeArray[0] = 2.0*elData->fELossEnergyGrid[0]/theDEDXArray[0];
     // - integrate the dE/dx by using a 16 point GL integral on [0,1] at each bin
@@ -152,14 +152,14 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
       }
       res *= del;
       theRangeArray[i+1] = res+theRangeArray[i];
-    }    
-    // clean auxilary arrays    
+    }
+    // clean auxilary arrays
     delete[] glX;
     delete[] glW;
-    
-    
+
+
     //
-    // prepare final form of the Range, dE/dx, inverse range and their second 
+    // prepare final form of the Range, dE/dx, inverse range and their second
     // derivatives for this macc and fill in to the G4HepEmElemData elData struct
     // - set up a spline on the range array for spline interpolation
     G4HepEmInitUtils::Instance().PrepareSpline(numELoss, elData->fELossEnergyGrid, theRangeArray, theRangeSDArray);
@@ -176,7 +176,7 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
       elData->fELossData[indxStart+4*(numELoss)+i]   = theInvRangeSDArray[i];
     }
   }
-  // free auxilary arrays 
+  // free auxilary arrays
   delete[] theDEDXArray;
   delete[] theRangeArray;
   delete[] theDEDXSDArray;
@@ -187,13 +187,13 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
 
 // G4ElectroNuclearCrossSection::GetElementCrossSection
 // G4PhotoNuclearCrossSection::GetElementCrossSection
-  
+
 
 void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbModel,
-                       G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData, 
-                       struct G4HepEmParameters* hepEmParams, bool iselectron) {                        
-  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData                                                
-  struct G4HepEmElectronData* elData = iselectron 
+                       G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData,
+                       struct G4HepEmParameters* hepEmParams, bool iselectron) {
+  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData
+  struct G4HepEmElectronData* elData = iselectron
                                        ? hepEmData->fTheElectronData
                                        : hepEmData->fThePositronData;
   //
@@ -202,60 +202,60 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
   if  (iselectron) {
     g4PartDef = G4Electron::Electron();
   }
-  // we will need to obtain the correspondig G4MaterialCutsCouple object pointers 
+  // we will need to obtain the correspondig G4MaterialCutsCouple object pointers
   G4ProductionCutsTable* theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
   //
   // Loop over the HepEm material-cuts couple:s
-  // - get the secondary e- and gamma production thresholds 
+  // - get the secondary e- and gamma production thresholds
   // - determine the minimum primary energy at which the ioni/brem can happen
-  // - generate the energy grid (for ioni/brem) and compute the resctricted 
-  //   macroscopic cross sections 
+  // - generate the energy grid (for ioni/brem) and compute the resctricted
+  //   macroscopic cross sections
   // - keep track of the maximum value and its energy position
   // - store the data in th efollowing format for a given material-cuts couple
-  //   === Ioni then Brem: 
-  //   === for each first 4 values: energyOfMaxValue, maxValue, logE_0, invLodEDelta 
-  //   === then the values: energy, value, second-derivative order i.e. 
+  //   === Ioni then Brem:
+  //   === for each first 4 values: energyOfMaxValue, maxValue, logE_0, invLodEDelta
+  //   === then the values: energy, value, second-derivative order i.e.
   //       [...,E_i,Sigma_i,SD_i, E_{i+1}, Sigma_{i}, SD_{i},...]
-  //   === then the same for Brem, etc.   
-  // - record the start index of the data for each material-cuts couple in a separate array 
+  //   === then the same for Brem, etc.
+  // - record the start index of the data for each material-cuts couple in a separate array
   // - record the start index of the brem data relative to the ioni (i.e. number of ioni entires)
-  //   in a separate array 
+  //   in a separate array
   //
-  // With these, we can find easily where the ioni and brem data starts in the flatten array 
+  // With these, we can find easily where the ioni and brem data starts in the flatten array
   //
-  // ON GPU, first the ioni energy grid, ioni sigmas, their sec-derive, then for brem 
-  
+  // ON GPU, first the ioni energy grid, ioni sigmas, their sec-derive, then for brem
+
   // prepare some space (for sure enough) to store an energy grid and mac-xsec
   double*  energyGrid = new double[hepEmParams->fNumLossTableBins+2];
-  double*  macXSec    = new double[hepEmParams->fNumLossTableBins+2];  
-  double*  secDerivs  = new double[hepEmParams->fNumLossTableBins+2];  
-  // also prepare a maximal size array: 2 x 3 x (N+2) for each mat-cuts where 
-  // the 2 is for ioni + brem, the 3 is for E,Sig,SD and N+2 is the max number 
-  // of possible such entires and the + 5 is the #data, max value and energy grid related 
+  double*  macXSec    = new double[hepEmParams->fNumLossTableBins+2];
+  double*  secDerivs  = new double[hepEmParams->fNumLossTableBins+2];
+  // also prepare a maximal size array: 2 x 3 x (N+2) for each mat-cuts where
+  // the 2 is for ioni + brem, the 3 is for E,Sig,SD and N+2 is the max number
+  // of possible such entires and the + 5 is the #data, max value and energy grid related
   // 4 first entires.
   //
   // get the HepEm Material-cut couple data
-  const struct G4HepEmMatCutData*  hepEmMCData = hepEmData->fTheMatCutData;   
+  const struct G4HepEmMatCutData*  hepEmMCData = hepEmData->fTheMatCutData;
   int numHepEmMCCData = hepEmMCData->fNumMatCutData;
   double*    xsecData = new double[2*3*(hepEmParams->fNumLossTableBins+2+5)*numHepEmMCCData];
-  // 
+  //
   // allocate the arrays to store start indices per matrial-cuts couples
-  elData->fResMacXSecStartIndexPerMatCut = new int[numHepEmMCCData]; 
-  // a continuous index 
-  int indxCont = 0; 
+  elData->fResMacXSecStartIndexPerMatCut = new int[numHepEmMCCData];
+  // a continuous index
+  int indxCont = 0;
   for (int imc=0; imc<numHepEmMCCData; ++imc) {
     const struct G4HepEmMCCData& mccData = hepEmMCData->fMatCutData[imc];
     const G4MaterialCutsCouple* g4MatCut = theCoupleTable->GetMaterialCutsCouple(mccData.fG4MatCutIndex);
-    const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut   
+    const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut
     const double    gamCutE = mccData.fSecGamProdCutE;
     //
     // ===== Ionisation
-    //  
+    //
     // find out the lowest energy of the ioni Ekin grid and the number of entries
     const double       emax = hepEmParams->fMaxLossTableEnergy;
     const double   eminIoni = iselectron ? 2*elCutE : elCutE;
     const int    numDefEkin = hepEmParams->fNumLossTableBins+1;
-    const double      scale = std::log(hepEmParams->fMaxLossTableEnergy/hepEmParams->fMinLossTableEnergy); 
+    const double      scale = std::log(hepEmParams->fMaxLossTableEnergy/hepEmParams->fMinLossTableEnergy);
     const double  scaleIoni = std::log(emax/eminIoni);
     const int      numEIoni = std::max(4, (int)std::lrint(numDefEkin*scaleIoni/scale)+1);
     // generate the energy grid for Ioni
@@ -268,14 +268,14 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
     energyGrid[numEIoni-1]  = emax;
     for (int ie=1; ie<numEIoni-1; ++ie) {
       energyGrid[ie] = std::exp(logEmin+ie*delta);
-    } 
+    }
     for (int ie=0; ie<numEIoni; ++ie) {
       const double theEKin  = energyGrid[ie];
-      const double theXSec  = std::max(0.0, mbModel->CrossSection(g4MatCut, g4PartDef, theEKin, elCutE, theEKin)); 
+      const double theXSec  = std::max(0.0, mbModel->CrossSection(g4MatCut, g4PartDef, theEKin, elCutE, theEKin));
       // keep track of macroscopic cross section max and its energy
       if (theXSec>macXSecMax) {
         macXSecMax     = theXSec;
-        macXSecMaxEner = theEKin; 
+        macXSecMaxEner = theEKin;
       }
       macXSec[ie] = theXSec;
     }
@@ -296,7 +296,7 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
       xsecData[indxCont++] = secDerivs[ie];
     }
     //
-    // ===== Bremsstrahlung 
+    // ===== Bremsstrahlung
     //
     const double   eminBrem = gamCutE;
     const double  scaleBrem = std::log(emax/eminBrem);
@@ -306,29 +306,29 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
     delta                   = scaleBrem/(numEBrem-1);
     invLEDel                =  1.0/delta;
     macXSecMax              = -1.0;
-    macXSecMaxEner          = -1.0;    
+    macXSecMaxEner          = -1.0;
     energyGrid[0]           = eminBrem;
     energyGrid[numEBrem-1]  = emax;
     for (int ie=1; ie<numEBrem-1; ++ie) {
       energyGrid[ie] = std::exp(logEmin+ie*delta);
-    } 
+    }
     // compute macroscopic cross section for Brem: smooth the xsection values between the 2 models
     for (int ie=0; ie<numEBrem; ++ie) {
       const double theEKin  = energyGrid[ie];
       double dlta = 0.0;
       if ( theEKin > hepEmParams->fElectronBremModelLim ) {
-        double xsec1  = std::max(0.0, sbModel->CrossSection(g4MatCut, g4PartDef, hepEmParams->fElectronBremModelLim, gamCutE, hepEmParams->fElectronBremModelLim)); 
-        double xsec2  = std::max(0.0, rbModel->CrossSection(g4MatCut, g4PartDef, hepEmParams->fElectronBremModelLim, gamCutE, hepEmParams->fElectronBremModelLim));         
+        double xsec1  = std::max(0.0, sbModel->CrossSection(g4MatCut, g4PartDef, hepEmParams->fElectronBremModelLim, gamCutE, hepEmParams->fElectronBremModelLim));
+        double xsec2  = std::max(0.0, rbModel->CrossSection(g4MatCut, g4PartDef, hepEmParams->fElectronBremModelLim, gamCutE, hepEmParams->fElectronBremModelLim));
         dlta = xsec2 > 0.0 ? (xsec1/xsec2-1.0)*hepEmParams->fElectronBremModelLim : 0.0;
       }
-      double theXSec = theEKin > hepEmParams->fElectronBremModelLim 
+      double theXSec = theEKin > hepEmParams->fElectronBremModelLim
                         ? std::max(0.0, rbModel->CrossSection(g4MatCut, g4PartDef, theEKin, gamCutE, theEKin))
                         : std::max(0.0, sbModel->CrossSection(g4MatCut, g4PartDef, theEKin, gamCutE, theEKin));
       theXSec *= (1.0+dlta/theEKin);
       // keep track of macroscopic cross section max and its energy
       if (theXSec>macXSecMax) {
         macXSecMax     = theXSec;
-        macXSecMaxEner = theEKin; 
+        macXSecMaxEner = theEKin;
       }
       macXSec[ie] = theXSec;
     }
@@ -344,21 +344,21 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
       xsecData[indxCont++] = energyGrid[ie];
       xsecData[indxCont++] = macXSec[ie];
       xsecData[indxCont++] = secDerivs[ie];
-    }    
+    }
   }
-  // allocate data, in the fTheElectronData member of the top level data structure, 
+  // allocate data, in the fTheElectronData member of the top level data structure,
   // for all the macroscopic-scross section data for all mat-cuts and store them
   if (elData->fResMacXSecData) {
     delete[] elData->fResMacXSecData;
-  } 
+  }
 //  std::cerr << " ==== Allocating " << indxCont*sizeof(double)/1024./1024.
-//            << " [MB] memory in G4HepEmELossTableBuilder::BuildLambdaTables \n" 
-//            << " for Ioni and Brem macroscopic scross secion for the " << numHepEmMCCData 
-//            << "\n material-cuts couples used in the geometry. " 
-//            << std::endl;  
+//            << " [MB] memory in G4HepEmELossTableBuilder::BuildLambdaTables \n"
+//            << " for Ioni and Brem macroscopic scross secion for the " << numHepEmMCCData
+//            << "\n material-cuts couples used in the geometry. "
+//            << std::endl;
   elData->fResMacXSecNumData = indxCont;
   elData->fResMacXSecData = new double[indxCont];
-  for (int i=0; i<indxCont; ++i) {    
+  for (int i=0; i<indxCont; ++i) {
     elData->fResMacXSecData[i] = xsecData[i];
   }
   //
@@ -367,14 +367,14 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
   delete[] macXSec;
   delete[] secDerivs;
   delete[] xsecData;
-}  
+}
 
 
 void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbModel,
-                       G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData, 
-                       struct G4HepEmParameters* hepEmParams, bool iselectron) {                        
-  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData                                                
-  struct G4HepEmElectronData* elData = iselectron 
+                       G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData,
+                       struct G4HepEmParameters* hepEmParams, bool iselectron) {
+  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData
+  struct G4HepEmElectronData* elData = iselectron
                                        ? hepEmData->fTheElectronData
                                        : hepEmData->fThePositronData;
   //
@@ -385,10 +385,10 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
   }
   // get the HepEm Material-cut couple data
   const struct G4HepEmMatCutData*    hepEmMCData = hepEmData->fTheMatCutData;
-  const struct G4HepEmMaterialData* hepEmMatData = hepEmData->fTheMaterialData; 
+  const struct G4HepEmMaterialData* hepEmMatData = hepEmData->fTheMaterialData;
   // number of HepEm material-cuts couples
   int numHepEmMCCData = hepEmMCData->fNumMatCutData;
-  // estimate buffer size by counting #element and energy grids 
+  // estimate buffer size by counting #element and energy grids
   int num = 0;
   for (int imc=0; imc<numHepEmMCCData; ++imc) {
     const struct G4HepEmMCCData& mccData = hepEmMCData->fMatCutData[imc];
@@ -402,17 +402,17 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
   double* ioniData   = new double[(hepEmParams->fNumLossTableBins+4)*num];
   double* bremSBData = new double[(hepEmParams->fNumLossTableBins+4)*num];
   double* bremRBData = new double[(hepEmParams->fNumLossTableBins+4)*num];
-  // 
+  //
   // allocate the arrays to store start indices per matrial-cuts couples
-  elData->fElemSelectorIoniStartIndexPerMatCut   = new int[numHepEmMCCData]; 
-  elData->fElemSelectorBremSBStartIndexPerMatCut = new int[numHepEmMCCData]; 
-  elData->fElemSelectorBremRBStartIndexPerMatCut = new int[numHepEmMCCData]; 
+  elData->fElemSelectorIoniStartIndexPerMatCut   = new int[numHepEmMCCData];
+  elData->fElemSelectorBremSBStartIndexPerMatCut = new int[numHepEmMCCData];
+  elData->fElemSelectorBremRBStartIndexPerMatCut = new int[numHepEmMCCData];
   //
   int numBinsPerDecade = G4EmParameters::Instance()->NumberOfBinsPerDecade();
-  // a continuous index 
-  int indxContIoni   = 0; 
-  int indxContBremSB = 0; 
-  int indxContBremRB = 0; 
+  // a continuous index
+  int indxContIoni   = 0;
+  int indxContBremSB = 0;
+  int indxContBremRB = 0;
   for (int imc=0; imc<numHepEmMCCData; ++imc) {
     // get the hepEm mat-cut and material structures
     const struct G4HepEmMCCData& mccData  = hepEmMCData->fMatCutData[imc];
@@ -427,11 +427,11 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
     }
 
     // get the the secondary e- and gamma production energy thresholds
-    const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut   
+    const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut
     const double    gamCutE = mccData.fSecGamProdCutE;
     //
     // ===== Ionisation
-    //  
+    //
     // generate the kinetic energy grid for this material-cut for ioni
     double    minEKin = iselectron ? 2*elCutE : elCutE;
     double    maxEKin = hepEmParams->fMaxLossTableEnergy;
@@ -439,12 +439,12 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
       elData->fElemSelectorIoniStartIndexPerMatCut[imc] = -1;
     } else {
       // fill in the first values as #data
-      elData->fElemSelectorIoniStartIndexPerMatCut[imc] = indxContIoni; 
+      elData->fElemSelectorIoniStartIndexPerMatCut[imc] = indxContIoni;
       BuildElementSelector(minEKin, maxEKin, numBinsPerDecade, ioniData, indxContIoni, matData, mbModel, elCutE, g4PartDef);
     }
     //
     // ===== Brem: Seltzer-Berger
-    //  
+    //
     // generate the kinetic energy grid for this material-cut for sb-brem
     minEKin = gamCutE;
     maxEKin = hepEmParams->fElectronBremModelLim;
@@ -452,12 +452,12 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
       // no element selector for this mat-cut in case of SB-brem since the interaction cannot happen
       elData->fElemSelectorBremSBStartIndexPerMatCut[imc] = -1;
     } else  {
-      elData->fElemSelectorBremSBStartIndexPerMatCut[imc] = indxContBremSB; 
+      elData->fElemSelectorBremSBStartIndexPerMatCut[imc] = indxContBremSB;
       BuildElementSelector(minEKin, maxEKin, numBinsPerDecade, bremSBData, indxContBremSB, matData, sbModel, gamCutE, g4PartDef);
     }
     //
     // ===== Brem: Relativistic
-    //  
+    //
     // generate the kinetic energy grid for this material-cut for rel-brem
     minEKin = std::max(gamCutE, hepEmParams->fElectronBremModelLim);
     maxEKin = hepEmParams->fMaxLossTableEnergy;
@@ -465,7 +465,7 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
       // no element selector for this mat-cut in case of SB-brem since the interaction cannot happen
       elData->fElemSelectorBremRBStartIndexPerMatCut[imc] = -1;
     } else  {
-      elData->fElemSelectorBremRBStartIndexPerMatCut[imc] = indxContBremRB; 
+      elData->fElemSelectorBremRBStartIndexPerMatCut[imc] = indxContBremRB;
       BuildElementSelector(minEKin, maxEKin, numBinsPerDecade, bremRBData, indxContBremRB, matData, rbModel, gamCutE, g4PartDef);
 
     }
@@ -495,13 +495,13 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
 }
 
 
-void BuildElementSelector(double minEKin, double maxEKin, int numBinsPerDecade, double *data, int& indxCont, const struct G4HepEmMatData& matData, G4VEmModel* emModel, double cut, const G4ParticleDefinition* g4PartDef) {  
+void BuildElementSelector(double minEKin, double maxEKin, int numBinsPerDecade, double *data, int& indxCont, const struct G4HepEmMatData& matData, G4VEmModel* emModel, double cut, const G4ParticleDefinition* g4PartDef) {
   int     numElem    = matData.fNumOfElement;
   double  logMinEKin = 0.0;
   double  invLEDelta = 0.0;
   double egridData[500];
   int       numEKins = InitElementSelectorEnergyGrid(numBinsPerDecade, egridData, minEKin, maxEKin, logMinEKin, invLEDelta);
-  // fill in the first 3 values as #data, logMinEKin, and invLodEDelta 
+  // fill in the first 3 values as #data, logMinEKin, and invLodEDelta
   data[indxCont++]   = numEKins;
   data[indxCont++]   = numElem;
   data[indxCont++]   = logMinEKin;
@@ -513,16 +513,16 @@ void BuildElementSelector(double minEKin, double maxEKin, int numBinsPerDecade, 
     int          ist = indxCont;
     double       sum = 0.0;
     for (int iz=0; iz<numElem; ++iz) {
-      // compute atomic cross section x number of atoms per volume      
+      // compute atomic cross section x number of atoms per volume
       int      izet = matData.fElementVect[iz];
       double natoms = matData.fNumOfAtomsPerVolumeVect[iz];
-      const G4Element* g4Elem  = G4NistManager::Instance()->FindOrBuildElement(izet);    
+      const G4Element* g4Elem  = G4NistManager::Instance()->FindOrBuildElement(izet);
       double   xsec = std::max(0.0, emModel->ComputeCrossSectionPerAtom(g4PartDef, g4Elem, ekin, cut, ekin));
       sum += natoms*xsec;
       if (iz<numElem-1) {
         data[indxCont++] = sum;
       }
-    } 
+    }
     // normalise
     for (int i=0; i<numElem-1; ++i) {
       if (sum>0.0) {
@@ -554,13 +554,13 @@ int InitElementSelectorEnergyGrid(int binsperdecade, double* egrid, double mine,
 void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4SeltzerBergerModel* sbModel) {
   G4HepEmSBBremTableBuilder* sbTables = new G4HepEmSBBremTableBuilder();
   sbTables->Initialize( std::max(hepEmPars->fElectronTrackingCut, sbModel->LowEnergyLimit()), sbModel->HighEnergyLimit());
-    
+
   // we need the HepEm-MatCut data to convert G4-mc indices to hepEm-mc indices
   // we need the HepEm-element data to loop over the required Z values
   const G4HepEmMatCutData*   theMCData   = hepEmData->fTheMatCutData;
   const G4HepEmMaterialData* theMatData  = hepEmData->fTheMaterialData;
   const G4HepEmElementData*  theElemData = hepEmData->fTheElementData;
-  
+
   // count: #hepEM-mc, sum-#elements-in-mcs, #unique-elements
   int numHepEmMatCuts = theMCData->fNumMatCutData;
   int numElemsInMC    = 0;
@@ -574,8 +574,8 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
       ++numElemsUnique;
     }
   }
-  
-  // loop over the elements used in the geometry 
+
+  // loop over the elements used in the geometry
   int numSBData = 0;
   for (int iz=1; iz<theElemData->fMaxZet; ++iz) {
     const int izet = (int)(theElemData->fElementData[iz].fZet);
@@ -584,19 +584,19 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     }
     int izST = std::min(iz, sbTables->fMaxZet);
     // and construct the HepEm-SB-sampling tables for each
-    const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);  
+    const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);
     if (!stPerZ) {
       std::cout << " *** No SB-STable for iz = " << iz << ": gcut probably above max-model-energy of 1 GeV " << std::endl;
       continue;
     }
     // #sampling tables i.e. energy grid = stPerZ->fMaxElEnergyIndx - stPerZ->fMinElEnergyIndx + 1
-    // 54 + #gamma-cuts for this Z elememnts at each energy grid 
+    // 54 + #gamma-cuts for this Z elememnts at each energy grid
     // + 4 values: [0] #data; [1] min-; [2] max-energy grid index; [3] #mat-cuts this Z appears (with g-cut below 1 geV)
     int num = (stPerZ->fMaxElEnergyIndx - stPerZ->fMinElEnergyIndx + 1)*(stPerZ->fNumGammaCuts + 3*sbTables->fNumKappa) + 4;
     numSBData += num;
 /*
     std::cout << " ======= SB Table for Z = " << iz << std::endl;
-    std::cout << "  - # gamm-cuts      = " << stPerZ->fNumGammaCuts    << std::endl; 
+    std::cout << "  - # gamm-cuts      = " << stPerZ->fNumGammaCuts    << std::endl;
     std::cout << "  - fMinElEnergyIndx = " << stPerZ->fMinElEnergyIndx << "  E[x] = " << sbTables->fElEnergyVect[stPerZ->fMinElEnergyIndx]<< std::endl;
     std::cout << "  - fMaxElEnergyIndx = " << stPerZ->fMaxElEnergyIndx << "  E[x] = " << sbTables->fElEnergyVect[stPerZ->fMaxElEnergyIndx]<< std::endl;
     std::cout << "  size of 'fTablesPerEnergy' = " << stPerZ->fTablesPerEnergy.size() << std::endl;
@@ -610,9 +610,9 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
 
   // allocate G4HepEmSBTables data structure
   AllocateSBTableData(&(hepEmData->fTheSBTableData), numHepEmMatCuts, numElemsInMC, numSBData);
-  G4HepEmSBTableData *sbData = hepEmData->fTheSBTableData; 
-  
-  
+  G4HepEmSBTableData *sbData = hepEmData->fTheSBTableData;
+
+
   // check and allert !
 //  std::cout << "  == max-Z  = " << sbData->fMaxZet      << " v.s. " << sbTables->fMaxZet << std::endl;
 //  std::cout << "  == #E     = " << sbData->fNumElEnergy << " v.s. " << sbTables->fNumElEnergy << std::endl;
@@ -630,7 +630,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     sbData->fLKappaVect[ik] = sbTables->fLKappaVect[ik];
   }
   //
-  
+
   //int indxCumKappaVals    = 0;
   int indxCumSBTableData  = 0;
   // loop over the elements used in the geometry and construct HepEM SB-tables
@@ -641,7 +641,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     }
     int izST = std::min(iz,sbTables->fMaxZet);
     // and construct the HepEm-SB-sampling tables for each
-    const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);  
+    const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);
     if (!stPerZ) {
       continue;
     }
@@ -651,12 +651,12 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     // 2. fill in the first 4 values:
     int minEindex      = stPerZ->fMinElEnergyIndx;
     int maxEindex      = stPerZ->fMaxElEnergyIndx;
-    int numGammaCuts   = stPerZ->fNumGammaCuts; 
+    int numGammaCuts   = stPerZ->fNumGammaCuts;
     int numData        = (maxEindex - minEindex + 1)*(numGammaCuts + 3*sbTables->fNumKappa)+4;
     sbData->fSBTableData[indxCumSBTableData++] = numData;
     sbData->fSBTableData[indxCumSBTableData++] = minEindex;
     sbData->fSBTableData[indxCumSBTableData++] = maxEindex;
-    sbData->fSBTableData[indxCumSBTableData++] = numGammaCuts;    
+    sbData->fSBTableData[indxCumSBTableData++] = numGammaCuts;
     for (int ist=minEindex; ist<=maxEindex; ++ist) {
       const G4HepEmSBBremTableBuilder::STable* stPerE = stPerZ->fTablesPerEnergy[ist];
       for (int igc=0; igc<numGammaCuts; ++igc) {
@@ -671,7 +671,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
   }
   sbData->fNumSBTableData = indxCumSBTableData;
   // 3. fill the HepEm-mc index to gamma-cut index (in a given Zet data) translation
-  // loop over the HepEm mat-cuts, get the corresponding g4 mat-cut index and 
+  // loop over the HepEm mat-cuts, get the corresponding g4 mat-cut index and
   // loop over the elements of the HepEm mat-cut material and get the gamma-cut index
   // for each element
   int indxCumKappaCut = 0;
@@ -684,7 +684,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     bool isfirst = true;
     for (int ie=0; ie<numElems; ++ie) {
       int izST = std::min(elemVect[ie], sbTables->fMaxZet);
-      const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);  
+      const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);
       if (!stPerZ) {
         continue;
       }
@@ -699,7 +699,5 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
 //        std::cout << " ==> imc = "<< imc<< " g-cut index for Z = " << izST << " ==>" << sbData->fGammaCutIndices[indxCumKappaCut-1] << std::endl;
       }
     }
-  }  
+  }
 }
-
- 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -1,0 +1,73 @@
+
+#include "G4HepEmGammaInit.hh"
+
+#include "G4HepEmData.hh"
+#include "G4HepEmParameters.hh"
+#include "G4HepEmGammaData.hh"
+
+#include "G4HepEmGammaTableBuilder.hh"
+
+// g4 includes
+#include "G4EmParameters.hh"
+#include "G4ProductionCutsTable.hh"
+
+#include "G4ParticleDefinition.hh"
+#include "G4Gamma.hh"
+#include "G4SystemOfUnits.hh"
+
+#include "G4DataVector.hh"
+#include "G4PairProductionRelModel.hh"
+#include "G4KleinNishinaCompton.hh"
+
+#include "G4HepEmMaterialData.hh"
+#include "G4HepEmElementData.hh"
+
+#include <iostream>
+
+
+void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/) {
+  // clean previous G4HepEmElectronData (if any)
+  //
+  // create G4Models for gamma
+  G4ParticleDefinition* g4PartDef = G4Gamma::Gamma();
+  std::cout << "     ---  InitGammaData ... " << std::endl;
+  // Min/Max energies of the EM model (same as for the loss-tables)
+  G4double emModelEMin = G4EmParameters::Instance()->MinKinEnergy();
+  G4double emModelEMax = G4EmParameters::Instance()->MaxKinEnergy();
+  //
+  // 1. Bethe-Heitler model with Coulomb, screening and LPM correction:
+  // --- used on [2mc^2 : E_max]
+  G4PairProductionRelModel*  modelPP = new G4PairProductionRelModel();
+  modelPP->SetLowEnergyLimit(std::max(emModelEMin, 2.0*CLHEP::electron_mass_c2));
+  modelPP->SetHighEnergyLimit(emModelEMax);
+  // get cuts for secondary e- (not relevant for gamma models, needed only for the model init)
+  const G4DataVector* theElCuts = static_cast<const G4DataVector*>(G4ProductionCutsTable::GetProductionCutsTable()->GetEnergyCutsVector(1));
+  modelPP->Initialise(g4PartDef, *theElCuts);
+  //
+  //
+  // 2. The simple Klein-Nishina model for Compton scattering:
+  // --- used on [E_min : E_max]
+  G4KleinNishinaCompton* modelKN = new G4KleinNishinaCompton();
+  modelKN->SetLowEnergyLimit(emModelEMin);
+  modelKN->SetHighEnergyLimit(emModelEMax);
+  modelKN->Initialise(g4PartDef, *theElCuts);
+  //
+  // === Use the G4HepEmGammaTableBuilder to build all data tables used at
+  //     run time: macroscopic cross section tables and target element
+  //     selectors for each models.
+  //
+  // allocate the GammaData (NOTE: shallow only, BuildLambdaTables will complete
+  // the allocation) but cleans the memory of the hepEmData->fTheGammaData
+  AllocateGammaData(&(hepEmData->fTheGammaData));
+  // build macroscopic cross section data for Conversion and Compton
+  std::cout << "     ---  BuildLambdaTables ... " << std::endl;
+  BuildLambdaTables(modelPP, modelKN, hepEmData);
+  // build element selectors
+  std::cout << "     ---  BuildElementSelectorTables ... " << std::endl;
+  BuildElementSelectorTables(modelPP, hepEmData);
+  //
+  // delete all g4 models
+  // NOTE: I don't delete this because something is crashing in G4
+//  delete modelPP;
+  delete modelKN;
+}

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -1,0 +1,226 @@
+#include "G4HepEmGammaTableBuilder.hh"
+
+#include "G4HepEmData.hh"
+#include "G4HepEmMatCutData.hh"
+#include "G4HepEmMaterialData.hh"
+#include "G4HepEmElementData.hh"
+#include "G4HepEmGammaData.hh"
+
+#include "G4HepEmParameters.hh"
+
+#include "G4HepEmInitUtils.hh"
+
+
+// g4 includes
+#include "G4PairProductionRelModel.hh"
+#include "G4KleinNishinaCompton.hh"
+
+#include "G4ParticleDefinition.hh"
+#include "G4Gamma.hh"
+#include "G4ProductionCutsTable.hh"
+#include "G4Material.hh"
+#include "G4Element.hh"
+#include "G4NistManager.hh"
+#include "G4EmParameters.hh"
+
+#include <cmath>
+
+void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton* knModel,
+                     struct G4HepEmData* hepEmData) {
+  // get the pointer to the already allocated G4HepEmGammaData from the HepEmData
+  struct G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+  //
+  // == Generate the enegry grid for Conversion
+  int numConvEkin = gmData->fConvEnergyGridSize;
+  // allocate array for the kinetic energy grid
+  if (gmData->fConvEnergyGrid) {
+    delete[] gmData->fConvEnergyGrid;
+  }
+  double emin = 2.0*CLHEP::electron_mass_c2;
+  double emax = 100.0*CLHEP::TeV;
+  gmData->fConvEnergyGrid = new double[numConvEkin];
+  gmData->fConvLogMinEkin = std::log(emin);
+  double delta = std::log(emax/emin)/(numConvEkin-1.0);
+  gmData->fConvEILDelta   = 1.0/delta;
+  // fill in
+  gmData->fConvEnergyGrid[0]             = emin;
+  gmData->fConvEnergyGrid[numConvEkin-1] = emax;
+  for (int i=1; i<numConvEkin-1; ++i) {
+    gmData->fConvEnergyGrid[i] = std::exp(gmData->fConvLogMinEkin+i*delta);
+  }
+  //
+  // == Generate the enegry grid for Compton
+  int numCompEkin = gmData->fCompEnergyGridSize;
+  // allocate array for the kinetic energy grid
+  if (gmData->fCompEnergyGrid) {
+    delete[] gmData->fCompEnergyGrid;
+  }
+  emin = 100.0* CLHEP::eV;
+  emax = 100.0*CLHEP::TeV;
+  gmData->fCompEnergyGrid = new double[numCompEkin];
+  gmData->fCompLogMinEkin = std::log(emin);
+  delta = std::log(emax/emin)/(numCompEkin-1.0);
+  gmData->fCompEILDelta   = 1.0/delta;
+  // fill in
+  gmData->fCompEnergyGrid[0]             = emin;
+  gmData->fCompEnergyGrid[numCompEkin-1] = emax;
+  for (int i=1; i<numCompEkin-1; ++i) {
+    gmData->fCompEnergyGrid[i] = std::exp(gmData->fCompLogMinEkin+i*delta);
+  }
+  //
+  // == Compute the macroscopic cross sections: for Conversion and Compton over
+  //    all materials
+  //
+  // get the G4HepEm material-cuts and material data: allocate memory for the
+  // max-xsec data
+  const struct G4HepEmMatCutData*   hepEmMCData  = hepEmData->fTheMatCutData;
+  const struct G4HepEmMaterialData* hepEmMatData = hepEmData->fTheMaterialData;
+  int numHepEmMCCData   = hepEmMCData->fNumMatCutData;
+  int numHepEmMatData   = hepEmMatData->fNumMaterialData;
+  gmData->fNumMaterials = numHepEmMatData;
+  gmData->fConvCompMacXsecData    = new double[numHepEmMatData*2*(numConvEkin + numCompEkin)];
+  std::vector<bool> isThisMatDone = std::vector<bool>(numHepEmMatData,false);
+  //
+  // copute the macroscopic cross sections
+  // get the g4 particle-definition
+  G4ParticleDefinition* g4PartDef = G4Gamma::Gamma();
+  // we will need to obtain the correspondig G4MaterialCutsCouple object pointers
+  G4ProductionCutsTable* theCoupleTable = G4ProductionCutsTable::GetProductionCutsTable();
+  // a temporary container for the mxsec data and for their second deriv
+  double* macXSec   = new double[std::max(numConvEkin,numCompEkin)];
+  double* secDerivs = new double[std::max(numConvEkin,numCompEkin)];
+  for (int imc=0; imc<numHepEmMCCData; ++imc) {
+    const struct G4HepEmMCCData& mccData = hepEmMCData->fMatCutData[imc];
+    int hepEmMatIndx = mccData.fHepEmMatIndex;
+    // mac-xsecs has already been computed for this material
+    if (isThisMatDone[hepEmMatIndx])
+      continue;
+    // mac-xsecs needs to be computed for this material
+    const G4MaterialCutsCouple* g4MatCut = theCoupleTable->GetMaterialCutsCouple(mccData.fG4MatCutIndex);
+    // == Conversion
+    for (int ie=0; ie<numConvEkin; ++ie) {
+      const double theEKin = gmData->fConvEnergyGrid[ie];
+      macXSec[ie] = std::max(0.0, ppModel->CrossSection(g4MatCut, g4PartDef, theEKin));
+    }
+    // prepare for sline by computing the second derivatives
+    G4HepEmInitUtils::Instance().PrepareSpline(numConvEkin, gmData->fConvEnergyGrid, macXSec, secDerivs);
+    // fill in into the continuous array: index where data for this material starts from
+    int mxStartIndx = hepEmMatIndx*2*(numConvEkin + numCompEkin);
+    int indxCont    = mxStartIndx;
+    for (int i=0; i<numConvEkin; ++i) {
+      gmData->fConvCompMacXsecData[indxCont++] = macXSec[i];
+      gmData->fConvCompMacXsecData[indxCont++] = secDerivs[i];
+    }
+    // == Compton
+//    std::cout << " ===== Material = " << g4MatCut->GetMaterial()->GetName() << std::endl;
+    for (int ie=0; ie<numCompEkin; ++ie) {
+      const double theEKin = gmData->fCompEnergyGrid[ie];
+      macXSec[ie] = std::max(0.0, knModel->CrossSection(g4MatCut, g4PartDef, theEKin));
+//      std::cout << " E = " << theEKin << " [MeV] Sigam-Compton(E) = " << macXSec[ie] << std::endl;
+    }
+    // prepare for sline by computing the second derivatives
+    G4HepEmInitUtils::Instance().PrepareSpline(numCompEkin, gmData->fCompEnergyGrid, macXSec, secDerivs);
+    // fill in into the continuous array: the continuous index is used further here
+    for (int i=0; i<numCompEkin; ++i) {
+      gmData->fConvCompMacXsecData[indxCont++] = macXSec[i];
+      gmData->fConvCompMacXsecData[indxCont++] = secDerivs[i];
+    }
+    //
+    // set this material index to be done
+    isThisMatDone[hepEmMatIndx] = true;
+  }
+  //
+  // free all dynamically allocated auxilary memory
+  delete[] macXSec;
+  delete[] secDerivs;
+}
+
+
+// element selectro only for Conversion (compton model is too dummy to care)
+void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepEmData* hepEmData) {
+  // get the pointer to the already allocated G4HepEmGammaData from the HepEmData
+  struct G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+  //
+  // == Generate the enegry grid for Conversion-element selectors
+  const double emin      = gmData->fConvEnergyGrid[0];
+  const double emax      = gmData->fConvEnergyGrid[gmData->fConvEnergyGridSize-1];
+  const double invlog106 = 1.0/(6.0*std::log(10.0));
+  int numConvEkin = (int)(G4EmParameters::Instance()->NumberOfBinsPerDecade()*std::log(emax/emin)*invlog106);
+  gmData->fElemSelectorConvEgridSize = numConvEkin;
+  // allocate array for the kinetic energy grid
+  if (gmData->fElemSelectorConvEgrid) {
+    delete[] gmData->fElemSelectorConvEgrid;
+  }
+  gmData->fElemSelectorConvEgrid = new double[numConvEkin];
+  double lemin = std::log(emin);
+  double delta = std::log(emax/emin)/(numConvEkin-1.0);
+  gmData->fElemSelectorConvLogMinEkin = lemin;
+  gmData->fElemSelectorConvEILDelta   = 1.0/delta;
+  // fill in
+  gmData->fElemSelectorConvEgrid[0]             = emin;
+  gmData->fElemSelectorConvEgrid[numConvEkin-1] = emax;
+  for (int i=1; i<numConvEkin-1; ++i) {
+    gmData->fElemSelectorConvEgrid[i] = std::exp(lemin+i*delta);
+  }
+  //
+  // fill in with the element selectors (only for materials with #elemnt > 1)
+  // get the G4HepEm material-cuts and material data: allocate memory for the
+  // max-xsec data
+//  const struct G4HepEmMatCutData*   hepEmMCData  = hepEmData->fTheMatCutData;
+  const struct G4HepEmMaterialData* hepEmMatData = hepEmData->fTheMaterialData;
+//  int numHepEmMCCData   = hepEmMCData->fNumMatCutData;
+  int numHepEmMatData   = hepEmMatData->fNumMaterialData;
+  gmData->fElemSelectorConvStartIndexPerMat = new int[numHepEmMatData];
+  // count size of containers: #elements(in mat. with #eleme>1) * (#elem-1)*numConvEkin
+  int num = 0;
+  for (int im=0; im<numHepEmMatData; ++im) {
+    const struct G4HepEmMatData& matData = hepEmMatData->fMaterialData[im];
+    int numElem = matData.fNumOfElement;
+    if (numElem>1) {
+      // should be numElem-1 but for each material 1 extra is #elements that is the first elem
+      num += numElem;
+    }
+  }
+  // allocate memory:
+  int size = num*numConvEkin;
+  if (gmData->fElemSelectorConvData) {
+    delete gmData->fElemSelectorConvData;
+  }
+  gmData->fElemSelectorConvData = new double[size];
+  G4VEmModel* emModel = ppModel;
+  int indxCont = 0;
+  for (int im=0; im<numHepEmMatData; ++im) {
+    const struct G4HepEmMatData& matData = hepEmMatData->fMaterialData[im];
+    int numElem = matData.fNumOfElement;
+    if (numElem<2) {
+      gmData->fElemSelectorConvStartIndexPerMat[im] = -1;
+    }
+    gmData->fElemSelectorConvStartIndexPerMat[im] = indxCont;
+    gmData->fElemSelectorConvData[indxCont++]     = numElem;
+    // build element selector for this material starting the data from indxCont:
+    // loop over the kinetic energy grid
+    for (int ie=0; ie<numConvEkin; ++ie) {
+      double      ekin = gmData->fElemSelectorConvEgrid[ie];
+      double       sum = 0.0;
+      int          ist = indxCont;
+      for (int iz=0; iz<numElem; ++iz) {
+        // compute atomic cross section x number of atoms per volume
+        int      izet = matData.fElementVect[iz];
+        double natoms = matData.fNumOfAtomsPerVolumeVect[iz];
+        const G4Element* g4Elem  = G4NistManager::Instance()->FindOrBuildElement(izet);
+        double   xsec = std::max(0.0, emModel->ComputeCrossSectionPerAtom(G4Gamma::Gamma(), g4Elem, ekin));
+        sum += natoms*xsec;
+        if (iz<numElem-1) {
+          gmData->fElemSelectorConvData[indxCont++] = sum;
+        }
+      }
+      // normalise
+      if (sum>0.0) {
+        sum = 1.0/sum;
+        for (int i=0; i<numElem-1; ++i) {
+            gmData->fElemSelectorConvData[ist+i] *= sum;
+        }
+      }
+    }
+  }
+}

--- a/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
@@ -6,7 +6,7 @@
 
 #include "G4HepEmMatCutData.hh"
 #include "G4HepEmMaterialData.hh"
-#include "G4HepEmElementData.hh" 
+#include "G4HepEmElementData.hh"
 
 // g4 includes
 #include "G4ProductionCutsTable.hh"
@@ -19,9 +19,9 @@
 #include <iostream>
 
 
-// - translates all G4MaterialCutsCouple, used in the current geometry, to a 
+// - translates all G4MaterialCutsCouple, used in the current geometry, to a
 //   G4HepEmMatCutData structure element used by G4HepEm
-// - generates a G4HepEmMaterialData structure that stores material information 
+// - generates a G4HepEmMaterialData structure that stores material information
 //   for all unique materials, used in the current geometry
 // - builds the G4HepEmElementData structure
 void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars) {
@@ -33,16 +33,16 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
   //  theCoupleTable->DumpCouples();
   //  G4cout << *theMaterialTable;
   //
-  // 0. count G4MaterialCutsCouple and unique G4Material objects that are used in 
+  // 0. count G4MaterialCutsCouple and unique G4Material objects that are used in
   //    the courrent geometry. Record the indices of the used, unique materials.
   G4int  numUsedG4MatCuts = 0;
   G4int  numUsedG4Mat     = 0;
   std::vector<G4int> theUsedG4MatIndices(numG4Mat, -2);
   for (size_t imc=0; imc<numG4MatCuts; ++imc) {
     const G4MaterialCutsCouple* matCut = theCoupleTable->GetMaterialCutsCouple(imc);
-    if (!matCut->IsUsed()) { 
+    if (!matCut->IsUsed()) {
       continue;
-    }   
+    }
     ++numUsedG4MatCuts;
     size_t matIndx = matCut->GetMaterial()->GetIndex();
     if (theUsedG4MatIndices[matIndx]>-2) {
@@ -51,9 +51,9 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
     // mark to be used in the geometry (but only once: numUsedG4Mat = unique used mats)
     theUsedG4MatIndices[matIndx] = -1;
     ++numUsedG4Mat;
-  }  
+  }
 
-  // 1. Allocate the MatCutData and MaterialData sub-structure of the global G4HepEmData 
+  // 1. Allocate the MatCutData and MaterialData sub-structure of the global G4HepEmData
   AllocateMatCutData   (&(hepEmData->fTheMatCutData), numG4MatCuts, numUsedG4MatCuts);
   AllocateMaterialData (&(hepEmData->fTheMaterialData), numG4Mat, numUsedG4Mat);
   AllocateElementData  (&(hepEmData->fTheElementData));
@@ -66,9 +66,9 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
   numUsedG4Mat     = 0;
   for (size_t imc=0; imc<numG4MatCuts; ++imc) {
     const G4MaterialCutsCouple* matCut = theCoupleTable->GetMaterialCutsCouple(imc);
-    if (!matCut->IsUsed()) { 
+    if (!matCut->IsUsed()) {
       continue;
-    }    
+    }
     G4int mcIndx          = matCut->GetIndex();
     G4double gammaCutE    = (*(theCoupleTable->GetEnergyCutsVector(0)))[mcIndx];
     G4double electronCutE = (*(theCoupleTable->GetEnergyCutsVector(1)))[mcIndx];
@@ -84,10 +84,10 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
     mccData.fSecGamProdCutE = gammaCutE;
     mccData.fLogSecGamCutE  = std::log(gammaCutE);
     ++numUsedG4MatCuts;
-    
+
     // check if the corresponding G4HepEm material struct has already been created
     if (theUsedG4MatIndices[matIndx]>-1) {
-      // already created: 
+      // already created:
       mccData.fHepEmMatIndex = theUsedG4MatIndices[matIndx];
     } else {
       // material structure has not been created so do it
@@ -111,24 +111,28 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
       for (size_t ie=0; ie<numOfElement; ++ie) {
         G4int izet = ((*elmVec)[ie])->GetZasInt();
         matData.fElementVect[ie] = izet;
-        matData.fNumOfAtomsPerVolumeVect[ie] = nAtomPerVolVec[ie];      
+        matData.fNumOfAtomsPerVolumeVect[ie] = nAtomPerVolVec[ie];
         // fill element data as well if haven't done yet
         izet = std::min ( izet, (G4int)hepEmData->fTheElementData->fMaxZet );
         struct G4HepEmElemData& elData = hepEmData->fTheElementData->fElementData[izet];
         if (elData.fZet<0) {
-          double dZet         = (double)izet;
-          elData.fZet         = dZet;
-          elData.fZet13       = std::pow(dZet, 1.0/3.0); 
-          elData.fZet23       = std::pow(dZet, 2.0/3.0); 
-          elData.fCoulomb     = ((*elmVec)[ie])->GetfCoulomb();
-          elData.fLogZ        = std::log(dZet);           
-          double Fel          = (izet<5) ? kFelLowZet[izet]   : std::log(184.15) -     elData.fLogZ/3.0;         
-          double Finel        = (izet<5) ? kFinelLowZet[izet] : std::log(1194.0) - 2.0*elData.fLogZ/3.0;                
-          elData.fZFactor1    = (Fel-elData.fCoulomb) + Finel/dZet;
-          double varS1        = elData.fZet23/(184.15*184.15);
-          elData.fILVarS1Cond = 1./(std::log(std::sqrt(2.0)*varS1));
-          elData.fILVarS1     = 1./std::log(varS1);
-        }        
+          double dZet          = (double)izet;
+          elData.fZet          = dZet;
+          elData.fZet13        = std::pow(dZet, 1.0/3.0);
+          elData.fZet23        = std::pow(dZet, 2.0/3.0);
+          elData.fCoulomb      = ((*elmVec)[ie])->GetfCoulomb();
+          elData.fLogZ         = std::log(dZet);
+          double Fel           = (izet<5) ? kFelLowZet[izet]   : std::log(184.15) -     elData.fLogZ/3.0;
+          double Finel         = (izet<5) ? kFinelLowZet[izet] : std::log(1194.0) - 2.0*elData.fLogZ/3.0;
+          elData.fZFactor1     = (Fel-elData.fCoulomb) + Finel/dZet;
+          const double FZLow   = 8.0*elData.fLogZ/3.0;
+          const double FZHigh  = 8.0*(elData.fLogZ/3.0 + elData.fCoulomb);
+          elData.fDeltaMaxLow  = std::exp((42.038 - FZLow)/8.29) - 0.958;
+          elData.fDeltaMaxHigh = std::exp((42.038 - FZHigh)/8.29) - 0.958;
+          double varS1         = elData.fZet23/(184.15*184.15);
+          elData.fILVarS1Cond  = 1./(std::log(std::sqrt(2.0)*varS1));
+          elData.fILVarS1      = 1./std::log(varS1);
+        }
       }
       //
       theUsedG4MatIndices[matIndx] = numUsedG4Mat;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.hh
@@ -54,29 +54,4 @@ G4HepEmHostDevice
 int LinSearch(const double* vect, const int size, const double val);
 
 
-G4HepEmHostDevice
-void EvaluateLPMFunctions(double& funcXiS, double& funcGS, double& funcPhiS, const double egamma,
-                     const double etotal, const double elpm, const double z23,
-                     const double ilVarS1, const double ilVarS1Cond, const double densityCor);
-
-// LPM functions G(s) and Phi(s) over an s-value grid of: ds=0.05 on [0:2.0] (2x41)
-G4HepEmHostDeviceConstant
-const double kFuncLPM[] = {
-  0.0000E+00, 0.0000E+00,  6.9163E-02, 2.5747E-01,  2.0597E-01, 4.4573E-01,
-  3.5098E-01, 5.8373E-01,  4.8095E-01, 6.8530E-01,  5.8926E-01, 7.6040E-01,
-  6.7626E-01, 8.1626E-01,  7.4479E-01, 8.5805E-01,  7.9826E-01, 8.8952E-01,
-  8.4003E-01, 9.1338E-01,  8.7258E-01, 9.3159E-01,  8.9794E-01, 9.4558E-01,
-  9.1776E-01, 9.5640E-01,  9.3332E-01, 9.6483E-01,  9.4560E-01, 9.7143E-01,
-  9.5535E-01, 9.7664E-01,  9.6313E-01, 9.8078E-01,  9.6939E-01, 9.8408E-01,
-  9.7444E-01, 9.8673E-01,  9.7855E-01, 9.8888E-01,  9.8191E-01, 9.9062E-01,
-  9.8467E-01, 9.9204E-01,  9.8695E-01, 9.9321E-01,  9.8884E-01, 9.9417E-01,
-  9.9042E-01, 9.9497E-01,  9.9174E-01, 9.9564E-01,  9.9285E-01, 9.9619E-01,
-  9.9379E-01, 9.9666E-01,  9.9458E-01, 9.9706E-01,  9.9526E-01, 9.9739E-01,
-  9.9583E-01, 9.9768E-01,  9.9632E-01, 9.9794E-01,  9.9674E-01, 9.9818E-01,
-  9.9710E-01, 9.9839E-01,  9.9741E-01, 9.9857E-01,  9.9767E-01, 9.9873E-01,
-  9.9790E-01, 9.9887E-01,  9.9809E-01, 9.9898E-01,  9.9826E-01, 9.9909E-01,
-  9.9840E-01, 9.9918E-01,  9.9856E-01, 9.9926E-01
-};
-
-
 #endif // G4HepEmElectronInteractionBrem_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionBrem.icc
@@ -14,6 +14,8 @@
 #include "G4HepEmConstants.hh"
 #include "G4HepEmRunUtils.hh"
 
+#include "G4HepEmInteractionUtils.hh"
+
 #include "G4HepEmMath.hh"
 
 #include <cmath>
@@ -227,7 +229,7 @@ double SampleETransferBremRB(struct G4HepEmData* hepEmData, double thePrimEkin, 
     if ( isLPMActive ) { // DCS: Bethe-Heitler in complete screening and LPM suppression
       // evaluate LPM functions (combined with the Ter-Mikaelian effect)
       double funcGS, funcPhiS, funcXiS;
-      EvaluateLPMFunctions(funcXiS, funcGS, funcPhiS, eGamma, thePrimTotalE, lpmEnergy, theElemData.fZet23, theElemData.fILVarS1, theElemData.fILVarS1Cond, densityCorr);
+      EvaluateLPMFunctions(funcXiS, funcGS, funcPhiS, eGamma, thePrimTotalE, lpmEnergy, theElemData.fZet23, theElemData.fILVarS1, theElemData.fILVarS1Cond, densityCorr, 1.0);
       const double term1 = funcXiS * ( dum0 * funcGS + (onemy+2.0*dum0) * funcPhiS );
       funcVal = term1*zFactor1 + onemy*zFactor2;
     } else {  // DCS: Bethe-Heitler without LPM suppression and complete screening only if Z<5 (becaue TF screening is not vaild for low Z)
@@ -293,15 +295,7 @@ int SelectTargetAtomBrem(const struct G4HepEmElectronData* elData, const int imc
 
 void SampleDirectionsBrem(const double thePrimEkin, const double theSecGammaEkin, double* theSecGammaDir, double* thePrimElecDir, G4HepEmRandomEngine* rnge) {
   // sample photon direction (modified Tsai sampling):
-  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
-  double rndm3[3];
-  double u;
-  do {
-    rnge->flatArray(3, rndm3);
-    const double uu = -std::log(rndm3[0]*rndm3[1]);
-    u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
-  } while (u > uMax);
-  const double cost = 1.0 - 2.0*u*u/(uMax*uMax);
+  const double cost = SampleCostModifiedTsai(thePrimEkin, rnge);
   const double sint = std::sqrt((1.0-cost)*(1.0+cost));
   const double  phi = k2Pi*rnge->flat();
   theSecGammaDir[0] = sint * std::cos(phi);
@@ -342,51 +336,4 @@ int LinSearch(const double* vect, const int size, const double val) {
     i += 3;
   }
   return i;
-}
-
-
-void EvaluateLPMFunctions(double& funcXiS, double& funcGS, double& funcPhiS, const double egamma,
-     const double etotal, const double elpm, const double z23, const double ilVarS1,
-     const double ilVarS1Cond, const double densityCor) {
-  const double     sqrt2 = 1.414213562373095;
-  const double redegamma = egamma / etotal;
-  const double varSprime = std::sqrt( 0.125 * redegamma * elpm / ( ( 1.0 - redegamma ) * etotal ) );
-  const double     varS1 = z23 / ( 184.15 * 184.15 );
-  const double condition = sqrt2*varS1;
-  double funcXiSprime = 2.0;
-  if (varSprime > 1.0) {
-    funcXiSprime = 1.0;
-  } else if (varSprime > condition) {
-    const double funcHSprime = std::log(varSprime)*ilVarS1Cond;
-    funcXiSprime = 1.0 + funcHSprime - 0.08*(1.0-funcHSprime)*funcHSprime*(2.0-funcHSprime)*ilVarS1Cond;
-  }
-  const double    varS = varSprime / std::sqrt( funcXiSprime );
-  // - include dielectric suppression effect into s according to Migdal
-  const double varShat = varS * ( 1.0 + densityCor / (egamma*egamma) );
-  funcXiS = 2.0;
-  if (varShat > 1.0) {
-    funcXiS = 1.0;
-  } else if (varShat > varS1) {
-    funcXiS = 1.0 + std::log ( varShat ) * ilVarS1;
-  }
-  // avluate the LPM G(s) and Phi(s) function (approximations) at s = s-hat
-  const double lpmSLimit =  2.0;
-  const double lpmISDelt = 20.0;
-  if (varShat < lpmSLimit) {
-    double  val = varShat*lpmISDelt;
-    int    ilow = (int)val;
-    val        -= ilow;
-    ilow       *= 2;
-    funcGS      = ( kFuncLPM[ilow+2] - kFuncLPM[ilow]   ) * val + kFuncLPM[ilow];
-    funcPhiS    = ( kFuncLPM[ilow+3] - kFuncLPM[ilow+1] ) * val + kFuncLPM[ilow+1];
-  } else {
-    double ss = 1.0/(varShat*varShat);
-    ss *= ss;
-    funcGS   = 1.0-0.0230655*ss;
-    funcPhiS = 1.0-0.01190476*ss;
-  }
-  //MAKE SURE SUPPRESSION IS SMALLER THAN 1: due to Migdal's approximation on xi
-  if (funcXiS*funcPhiS > 1.0 || varShat > 0.57) {
-    funcXiS = 1.0/funcPhiS;
-  }
 }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionCompton.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionCompton.hh
@@ -1,0 +1,20 @@
+#ifndef G4HepEmGammaInteractionCompton_HH
+#define G4HepEmGammaInteractionCompton_HH
+
+#include "G4HepEmMacros.hh"
+
+class  G4HepEmTLData;
+class  G4HepEmRandomEngine;
+struct G4HepEmData;
+
+
+// Compton scattering for gamma described by the simple Klein-Nishina model.
+// Used between 100 eV - 100 TeV primary gamma kinetic energies.
+void PerformComptonScattering(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData);
+
+// Sampling of the post interaction photon energy and direction (already in the lab. frame)
+G4HepEmHostDevice
+double SamplePhotonEnergyAndDirection(const double primEkin, double* primDir, const double* theOrgPrimGmDir, G4HepEmRandomEngine* rnge);
+
+
+#endif  // G4HepEmGammaInteractionCompton_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionCompton.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionCompton.icc
@@ -1,0 +1,103 @@
+#include "G4HepEmGammaInteractionCompton.hh"
+
+#include "G4HepEmTLData.hh"
+#include "G4HepEmRandomEngine.hh"
+#include "G4HepEmData.hh"
+//#include "G4HepEmMatCutData.hh"
+
+#include "G4HepEmElectronTrack.hh"
+#include "G4HepEmGammaTrack.hh"
+#include "G4HepEmConstants.hh"
+#include "G4HepEmRunUtils.hh"
+
+#include "G4HepEmMath.hh"
+
+#include <iostream>
+
+void PerformComptonScattering(G4HepEmTLData* tlData, struct G4HepEmData* /*hepEmData*/) {
+  G4HepEmTrack* thePrimaryTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
+  const double       thePrimGmE = thePrimaryTrack->GetEKin();
+  // low energy limit: both for the primary gamma and secondary e-
+  const double theLowEnergyThreshold = 0.0001; // 100 eV
+  if (thePrimGmE<theLowEnergyThreshold) {
+    return;
+  }
+  // sample the post interaction photon energy and direction (already in lab frame)
+  // note: we might need the original photon direction so we keep it here
+  double*        thePrimGmDir = thePrimaryTrack->GetDirection();
+  const double theOrgGmDir[3] = {thePrimGmDir[0], thePrimGmDir[1], thePrimGmDir[2]};
+  // the 'thePrimGmDir' will be updated
+  const double     thePostGmE = SamplePhotonEnergyAndDirection(thePrimGmE, thePrimGmDir, theOrgGmDir, tlData->GetRNGEngine());
+  // compute the secondary e- energy and check aganints the threshold:
+  //  - if below threshold: simple deposit the corresponding energy
+  //  - compute the secondary e- direction otherwise and create the secondary track
+  const double  theSecElE = thePrimGmE-thePostGmE;
+  // keep track of energy deposits due to particles killed below threshold
+  double theEnergyDeposit = 0.0;
+  if (theSecElE > theLowEnergyThreshold) {
+    // get a secondary e- track and sample/compute directions (all will be already in lab. frame)
+    G4HepEmTrack* theSecTrack = tlData->AddSecondaryElectronTrack()->GetTrack();
+    double*       theSecElDir = theSecTrack->GetDirection();
+    theSecElDir[0] = thePrimGmE * theOrgGmDir[0] - thePostGmE * thePrimGmDir[0];
+    theSecElDir[1] = thePrimGmE * theOrgGmDir[1] - thePostGmE * thePrimGmDir[1];
+    theSecElDir[2] = thePrimGmE * theOrgGmDir[2] - thePostGmE * thePrimGmDir[2];
+    // normalisation
+    const double  norm = 1.0 / std::sqrt(theSecElDir[0] * theSecElDir[0] + theSecElDir[1] * theSecElDir[1] + theSecElDir[2] * theSecElDir[2]);
+    theSecElDir[0] *= norm;
+    theSecElDir[1] *= norm;
+    theSecElDir[2] *= norm;
+    // set other properties of the secondary track as well
+    theSecTrack->SetEKin(theSecElE);
+    theSecTrack->SetParentID(thePrimaryTrack->GetID());
+  } else {
+    theEnergyDeposit += theSecElE;
+  }
+  //
+  // check the post interaction gamma energy aganints the threshold:
+  //  - if below threshold: simple deposit the corresponding energy
+  if (thePostGmE > theLowEnergyThreshold) {
+    thePrimaryTrack->SetEKin(thePostGmE);
+  } else {
+    theEnergyDeposit += thePostGmE;
+    thePrimaryTrack->SetEKin(0.0);
+  }
+  thePrimaryTrack->SetEnergyDeposit(theEnergyDeposit);
+}
+
+G4HepEmHostDevice
+double SamplePhotonEnergyAndDirection(const double thePrimGmE, double* thePrimGmDir, const double* theOrgPrimGmDir, G4HepEmRandomEngine* rnge) {
+  // sample the post interaction reduced photon energy according to the KN DCS
+  const double kappa = thePrimGmE / kElectronMassC2;
+  const double eps0  = 1. / (1. + 2. * kappa);
+  const double eps02 = eps0 * eps0;
+  const double al1   = -std::log(eps0);
+  const double al2   = al1 + 0.5 * (1. - eps02);
+  double eps, eps2, gf;
+  double oneMinusCost, sint2;
+  double rndm[3];
+  do {
+    rnge->flatArray(3, rndm);
+    if (al1 > al2*rndm[0]) {
+      eps  = std::exp(-al1 * rndm[1]);
+      eps2 = eps * eps;
+    } else {
+      eps2 = eps02 + (1. - eps02) * rndm[1];
+      eps  = std::sqrt(eps2);
+    }
+    oneMinusCost = (1. - eps) / (eps * kappa);
+    sint2    = oneMinusCost * (2. - oneMinusCost);
+    gf       = 1. - eps * sint2 / (1. + eps2);
+  } while (gf < rndm[2]);
+  // compute the post interaction photon direction and transform to lab frame
+  const double cost = 1.0 - oneMinusCost;
+  const double sint = std::sqrt(G4HepEmMax(0., sint2));
+  const double phi  = k2Pi * rnge->flat();
+  // direction of the scattered gamma in the scattering frame
+  thePrimGmDir[0]   = sint * std::cos(phi);
+  thePrimGmDir[1]   = sint * std::sin(phi);
+  thePrimGmDir[2]   = cost;
+  // rotate to refernce frame (G4HepEmRunUtils function) to get it in lab. frame
+  RotateToReferenceFrame(thePrimGmDir, theOrgPrimGmDir);
+  // return with the post interaction gamma energy
+  return thePrimGmE*eps;
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionConversion.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionConversion.hh
@@ -1,0 +1,61 @@
+
+#ifndef G4HepEmGammaInteractionConversion_HH
+#define G4HepEmGammaInteractionConversion_HH
+
+#include "G4HepEmMacros.hh"
+
+#include <cmath>
+
+class  G4HepEmTLData;
+class  G4HepEmRandomEngine;
+struct G4HepEmData;
+struct G4HepEmElementData;
+
+
+
+void PerformGammaConversion(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData);
+
+G4HepEmHostDevice
+void SampleKinEnergies(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
+           int theMCIndx, double& eKinEnergy, double& pKinEnergy, G4HepEmRandomEngine* rnge);
+
+
+G4HepEmHostDevice
+void SampleDirections(const double* orgGammaDir, double* secElDir, double* secPosDir,
+                      const double secElEkin, const double secPosEkin, G4HepEmRandomEngine* rnge);
+
+
+// Target atom selector for the above bremsstrahlung intercations in case of
+// materials composed from multiple elements.
+G4HepEmHostDevice
+int SelectTargetAtom(const struct G4HepEmGammaData* gmData, const int imat, const double ekin,
+                     const double lekin, const double urndn);
+
+G4HepEmHostDevice
+double SampleEnergyRateNoLPM(const double normCond, const double epsMin, const double epsRange, const double deltaFactor,
+              const double invF10, const double invF20, const double fz, G4HepEmRandomEngine* rnge);
+
+G4HepEmHostDevice
+double SampleEnergyRateWithLPM(const double normCond, const double epsMin, const double epsRange, const double deltaFactor,
+                 const double invF10, const double invF20, const double fz, G4HepEmRandomEngine* rnge,
+                 const double eGamma, const double lpmEnergy, const struct G4HepEmElemData* elemData);
+
+G4HepEmHostDevice
+void ComputePhi12(const double delta, double &phi1, double &phi2);
+
+
+// Compute the value of the screening function 3*PHI1(delta) - PHI2(delta):
+G4HepEmHostDevice
+double ScreenFunction1(const double delta);
+
+
+// Compute the value of the screening function 1.5*PHI1(delta) +0.5*PHI2(delta):
+G4HepEmHostDevice
+double ScreenFunction2(const double delta);
+
+
+// Same as ScreenFunction1 and ScreenFunction2 but computes them at once
+G4HepEmHostDevice
+void ScreenFunction12(const double delta, double &f1, double &f2);
+
+#endif  // G4HepEmGammaInteractionConversion_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionConversion.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionConversion.icc
@@ -1,0 +1,273 @@
+#include "G4HepEmGammaInteractionConversion.hh"
+
+#include "G4HepEmTLData.hh"
+#include "G4HepEmRandomEngine.hh"
+#include "G4HepEmData.hh"
+#include "G4HepEmMatCutData.hh"
+#include "G4HepEmMaterialData.hh"
+#include "G4HepEmElementData.hh"
+#include "G4HepEmGammaData.hh"
+
+#include "G4HepEmConstants.hh"
+#include "G4HepEmInteractionUtils.hh"
+#include "G4HepEmRunUtils.hh"
+
+#include "G4HepEmMath.hh"
+
+#include <iostream>
+
+void PerformGammaConversion(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData) {
+  G4HepEmTrack* thePrimaryTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
+  const double       thePrimGmE = thePrimaryTrack->GetEKin();
+  //
+  // check kinematical limit: gamma energy(Eg) must be at least 2 e- rest mass
+  // (but the model should be used at higher energies above 100 MeV)
+  if (thePrimGmE < 2.*kElectronMassC2) {
+    return;
+  }
+  //
+  // Sample/compute kinetic energies of the e- and e+ pair
+  const double theLogPrimGmE = thePrimaryTrack->GetLogEKin();
+  const int        theMCIndx = thePrimaryTrack->GetMCIndex();
+  double elKinEnergy;  // e- kinetic energy
+  double posKinEnergy; // e+ kinetic energy
+  SampleKinEnergies(hepEmData, thePrimGmE, theLogPrimGmE, theMCIndx, elKinEnergy, posKinEnergy, tlData->GetRNGEngine());
+  //
+  // Sample/compute secondary e-/e+ directions:
+  // obtain 2 secondary electorn track (one with +1.0 charge for e+)
+  G4HepEmTrack* theSecElTrack  = tlData->AddSecondaryElectronTrack()->GetTrack();
+  G4HepEmTrack* theSecPosTrack = tlData->AddSecondaryElectronTrack()->GetTrack();
+  SampleDirections(thePrimaryTrack->GetDirection(), theSecElTrack->GetDirection(), theSecPosTrack->GetDirection(),
+                   elKinEnergy, posKinEnergy, tlData->GetRNGEngine());
+  //
+  // Set remaining properties of the secondary tracks
+  theSecElTrack->SetEKin(elKinEnergy);
+  theSecElTrack->SetParentID(thePrimaryTrack->GetID());
+  theSecPosTrack->SetEKin(posKinEnergy);
+  theSecPosTrack->SetParentID(thePrimaryTrack->GetID());
+  theSecPosTrack->SetCharge(+1.0);
+
+  //
+  // Kill the primary gamma track by setting its energy to zero.
+  thePrimaryTrack->SetEKin(0.0);
+}
+
+
+void SampleKinEnergies(struct G4HepEmData* hepEmData, double thePrimEkin, double theLogEkin,
+                      int theMCIndx, double& eKinEnergy, double& pKinEnergy, G4HepEmRandomEngine* rnge) {
+  // get the material data
+  const int               matIndx = (hepEmData->fTheMatCutData->fMatCutData[theMCIndx]).fHepEmMatIndex;
+  const G4HepEmMatData&  theMData = hepEmData->fTheMaterialData->fMaterialData[matIndx];
+  // sample target element
+  const int  elemIndx = (theMData.fNumOfElement > 1)
+                       ? SelectTargetAtom(hepEmData->fTheGammaData, matIndx, thePrimEkin, theLogEkin, rnge->flat())
+                       : 0;
+  const int      iZet = theMData.fElementVect[elemIndx];
+  const double lpmEnr = kLPMconstant * theMData.fRadiationLength;
+
+  // get the corresponding element data
+  const G4HepEmElemData& theElemData = hepEmData->fTheElementData->fElementData[G4HepEmMin(iZet, hepEmData->fTheElementData->fMaxZet)];
+  //
+  // == Sampling of the total energy, transferred to one of the e-/e+ pair in
+  //    units of initial photon energy
+  const double eps0 = kElectronMassC2/thePrimEkin;
+  double eps = 0.0;
+  if (thePrimEkin < 2.0) {
+    // uniform sampling at low energies (flat DCS) between the kinematical limits
+    // of eps0=mc^2/Eg <= eps <= 0.5 ( symmetric DCS around eps = 0.5)
+    eps = eps0 + (0.5-eps0)*rnge->flat();
+  } else {
+    // use a gamma energy limit of 50.0 [MeV] to turn off Coulomb correction below
+    const double deltaFactor = eps0*136./theElemData.fZet13;
+    const double    deltaMin = 4.*deltaFactor;
+    const double    deltaMax = (thePrimEkin < 50.0) ? theElemData.fDeltaMaxLow : theElemData.fDeltaMaxHigh;
+    const double    logZ13   = 0.333333*theElemData.fLogZ;
+    const double          FZ = (thePrimEkin < 50.0) ? 8.*logZ13 : 8.*(logZ13 + theElemData.fCoulomb);
+    // compute the limits of eps
+    const double        epsp = 0.5 - 0.5*std::sqrt(1. - deltaMin/deltaMax) ;
+    const double      epsMin = G4HepEmMax(eps0, epsp);
+    const double    epsRange = 0.5 - epsMin;
+    //
+    // sample the energy rate (eps) of the created electron (or positron)
+    double F10, F20;
+    ScreenFunction12(deltaMin, F10, F20);
+    F10 -= FZ;
+    F20 -= FZ;
+    const double NormF1   = G4HepEmMax(F10 * epsRange * epsRange, 0.);
+    const double NormF2   = G4HepEmMax(1.5 * F20                , 0.);
+    const double NormCond = NormF1/(NormF1 + NormF2);
+    // check if LPM correction is active ( active if gamma energy > 100 [GeV])
+    eps = (thePrimEkin < 100000.0)
+          ? SampleEnergyRateNoLPM  (NormCond, epsMin, epsRange, deltaFactor, 1./F10, 1./F20, FZ, rnge)
+          : SampleEnergyRateWithLPM(NormCond, epsMin, epsRange, deltaFactor, 1./F10, 1./F20, FZ, rnge,
+                                    thePrimEkin, lpmEnr, &theElemData);
+  }
+  //
+  // select charges randomly and compute kinetic
+  double eTotEnergy, pTotEnergy;
+  if (rnge->flat() > 0.5) {
+    eTotEnergy = (1.-eps)*thePrimEkin;
+    pTotEnergy = eps*thePrimEkin;
+  } else {
+    pTotEnergy = (1.-eps)*thePrimEkin;
+    eTotEnergy = eps*thePrimEkin;
+  }
+  //
+  // compute kinetic energies of the e- and e+ pair.
+  eKinEnergy = G4HepEmMax(0.,eTotEnergy - kElectronMassC2);
+  pKinEnergy = G4HepEmMax(0.,pTotEnergy - kElectronMassC2);
+}
+
+
+void SampleDirections(const double* orgGammaDir, double* secElDir, double* secPosDir, const double secElEkin, const double secPosEkin, G4HepEmRandomEngine* rnge) {
+  // sample azimuthal angle (2Pi symmetric)
+  const double  phi    = k2Pi*rnge->flat();
+  const double cosPhi  = std::cos(phi);
+  const double sinPhi  = std::sin(phi);
+  // sample e- cos(theta) by using the (modified Tsai sampling:
+  const double costEl  = SampleCostModifiedTsai(secElEkin, rnge);
+  const double sintEl  = std::sqrt((1.0-costEl)*(1.0+costEl));
+  secElDir[0] = sintEl * cosPhi;
+  secElDir[1] = sintEl * sinPhi;
+  secElDir[2] = costEl;
+  // rotate to refernce frame (G4HepEmRunUtils function) to get it in lab. frame
+  RotateToReferenceFrame(secElDir, orgGammaDir);
+  // sample e+ cos(theta) by using the (modified Tsai sampling:
+  const double costPos = SampleCostModifiedTsai(secPosEkin, rnge);
+  const double sintPos  = std::sqrt((1.0-costPos)*(1.0+costPos));
+  secPosDir[0] = -sintPos * cosPhi;
+  secPosDir[1] = -sintPos * sinPhi;
+  secPosDir[2] = costPos;
+  // rotate to refernce frame (G4HepEmRunUtils function) to get it in lab. frame
+  RotateToReferenceFrame(secPosDir, orgGammaDir);
+}
+
+
+
+// should be called only for mat-cuts with more than one elements in their material
+int SelectTargetAtom(const struct G4HepEmGammaData* gmData, const int imat, const double ekin,
+                     const double lekin, const double urndn) {
+  // start index for this material
+  const int   indxStart = gmData->fElemSelectorConvStartIndexPerMat[imat];
+  const double* theData = &(gmData->fElemSelectorConvData[indxStart]);
+  const int     numData = gmData->fElemSelectorConvEgridSize;
+  const int     numElem = theData[0]; // the very first element for each material
+  const double    logE0 = gmData->fElemSelectorConvLogMinEkin;
+  const double    invLD = gmData->fElemSelectorConvEILDelta;
+  const double*   xdata = gmData->fElemSelectorConvEgrid;
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double   xv = G4HepEmMax(xdata[0], G4HepEmMin(xdata[numData-1], ekin));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int idxEkin = G4HepEmMax(0.0, G4HepEmMin((lekin-logE0)*invLD, numData-2.0));
+  // linear interpolation
+  const double   x1 = xdata[idxEkin];
+  const double   x2 = xdata[idxEkin+1];
+  const double   dl = x2-x1;
+  const double    b = G4HepEmMax(0., G4HepEmMin(1., (xv - x1)/dl));
+  // the real index position of the y-data: idxEkin x (numElem-1)+1 (+1 the very first #element)
+  const int  indx0 = idxEkin*(numElem-1) + 1;
+  const int  indx1 = indx0 + (numElem-1);
+  int theElemIndex = 0;
+  while (theElemIndex<numElem-1 && urndn > theData[indx0+theElemIndex]+b*(theData[indx1+theElemIndex]-theData[indx0+theElemIndex])) { ++theElemIndex; }
+  return theElemIndex;
+}
+
+
+double SampleEnergyRateNoLPM(const double normCond, const double epsMin, const double epsRange, const double deltaFactor,
+               const double invF10, const double invF20, const double fz, G4HepEmRandomEngine* rnge) {
+  double rndmv[3];
+  double greject = 0.;
+  double eps     = 0.;
+  do {
+    rnge->flatArray(3, rndmv);
+    if (normCond > rndmv[0]) {
+      eps = 0.5 - epsRange * std::pow(rndmv[1], 1./3.);//G4HepEmX13(rndmv[1]);
+      const double delta = deltaFactor/(eps*(1.-eps));
+      greject = (ScreenFunction1(delta)-fz)*invF10;
+    } else {
+      eps = epsMin + epsRange*rndmv[1];
+      const double delta = deltaFactor/(eps*(1.-eps));
+      greject = (ScreenFunction2(delta)-fz)*invF20;
+    }
+    // Loop checking, 03-Aug-2015, Vladimir Ivanchenko
+  } while (greject < rndmv[2]);
+  //  end of eps sampling
+  return eps;
+}
+
+
+double SampleEnergyRateWithLPM(const double normCond, const double epsMin, const double epsRange, const double deltaFactor,
+                 const double invF10, const double invF20, const double fz, G4HepEmRandomEngine* rnge,
+                 const double eGamma, const double lpmEnergy, const struct G4HepEmElemData* elemData) {
+  const double         z23 = elemData->fZet23;
+  const double     ilVarS1 = elemData->fILVarS1;
+  const double ilVarS1Cond = elemData->fILVarS1Cond;
+  double rndmv[3];
+  double greject = 0.;
+  double eps     = 0.;
+  do {
+    rnge->flatArray(3, rndmv);
+    if (normCond > rndmv[0]) {
+      eps = 0.5 - epsRange * std::pow(rndmv[1], 1./3.); //G4HepEmX13(rndmv[1]);
+      const double delta = deltaFactor/(eps*(1.-eps));
+      double funcXiS, funcGS, funcPhiS, phi1, phi2;
+      ComputePhi12(delta, phi1, phi2);
+      //  0.0 = no density effect correction (only in case of Brem.)
+      // +1.0 => Brem:  s' = sqrt{ 0.125 E_lpm E_g / [ E_t ( E_t - E_g) ]  }
+      // -1.0 => Pair:  s' = sqrt{ 0.125 E_lpm E_g / [ E_t ( E_g - E_t) ]  } with E_t = eps*E_g
+      EvaluateLPMFunctions(funcXiS, funcGS, funcPhiS, eGamma, eps*eGamma, lpmEnergy, z23, ilVarS1, ilVarS1Cond, 0.0, -1.0);
+      greject = funcXiS*((2.*funcPhiS+funcGS)*phi1-funcGS*phi2-funcPhiS*fz)*invF10;
+    } else {
+      eps = epsMin + epsRange*rndmv[1];
+      const double delta = deltaFactor/(eps*(1.-eps));
+      double funcXiS, funcGS, funcPhiS, phi1, phi2;
+      ComputePhi12(delta, phi1, phi2);
+      EvaluateLPMFunctions(funcXiS, funcGS, funcPhiS, eGamma, eps*eGamma, lpmEnergy, z23, ilVarS1, ilVarS1Cond, 0.0, -1.0);
+      greject = funcXiS*( (funcPhiS+0.5*funcGS)*phi1 + 0.5*funcGS*phi2
+                         -0.5*(funcGS+funcPhiS)*fz)*invF20;
+    }
+  } while (greject < rndmv[2]);
+  //  end of eps sampling
+  return eps;
+}
+
+
+G4HepEmHostDevice
+void ComputePhi12(const double delta, double &phi1, double &phi2) {
+   if (delta > 1.4) {
+     phi1 = 21.0190 - 4.145*std::log(delta + 0.958);
+     phi2 = phi1;
+   } else {
+     phi1 = 20.806 - delta*(3.190 - 0.5710*delta);
+     phi2 = 20.234 - delta*(2.126 - 0.0903*delta);
+   }
+}
+
+
+// Compute the value of the screening function 3*PHI1(delta) - PHI2(delta):
+G4HepEmHostDevice
+double ScreenFunction1(const double delta) {
+ return (delta > 1.4) ? 42.038 - 8.29*std::log(delta + 0.958)
+                      : 42.184 - delta*(7.444 - 1.623*delta);
+}
+
+
+// Compute the value of the screening function 1.5*PHI1(delta) +0.5*PHI2(delta):
+G4HepEmHostDevice
+double ScreenFunction2(const double delta) {
+ return (delta > 1.4) ? 42.038 - 8.29*std::log(delta + 0.958)
+                      : 41.326 - delta*(5.848 - 0.902*delta);
+}
+
+
+// Same as ScreenFunction1 and ScreenFunction2 but computes them at once
+G4HepEmHostDevice
+void ScreenFunction12(const double delta, double &f1, double &f2) {
+ if (delta > 1.4) {
+   f1 = 42.038 - 8.29*std::log(delta + 0.958);
+   f2 = f1;
+ } else {
+   f1 = 42.184 - delta*(7.444 - 1.623*delta);
+   f2 = 41.326 - delta*(5.848 - 0.902*delta);
+ }
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.hh
@@ -1,0 +1,13 @@
+#ifndef G4HepEmGammaInteractionPhotoelectric_HH
+#define G4HepEmGammaInteractionPhotoelectric_HH
+
+#include "G4HepEmMacros.hh"
+
+class  G4HepEmTLData;
+struct G4HepEmData;
+
+
+void PerformPhotoelectric(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData);
+
+
+#endif // G4HepEmGammaInteractionPhotoelectric_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.icc
@@ -1,0 +1,13 @@
+
+#include "G4HepEmGammaInteractionPhotoelectric.hh"
+
+
+#include  "G4HepEmTLData.hh"
+#include  "G4HepEmData.hh"
+
+// simple gamma absorption at the moment
+void PerformPhotoelectric(G4HepEmTLData* tlData, struct G4HepEmData* /*hepEmData*/) {
+  G4HepEmTrack* thePrimaryTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
+  thePrimaryTrack->SetEnergyDeposit(thePrimaryTrack->GetEKin());
+  thePrimaryTrack->SetEKin(0.0);
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -2,17 +2,21 @@
 #ifndef G4HepEmGammaManager_HH
 #define G4HepEmGammaManager_HH
 
+#include "G4HepEmMacros.hh"
+
 struct G4HepEmData;
 struct G4HepEmParameters;
-//struct G4HepEmGammaData;
+struct G4HepEmGammaData;
 
 class  G4HepEmTLData;
+class  G4HepEmGammaTrack;
+class  G4HepEmTrack;
 
 /**
  * @file    G4HepEmGammaManager.hh
  * @struct  G4HepEmGammaManager
  * @author  M. Novak
- * @date    202X
+ * @date    2021
  *
  * @brief The top level run-time manager for \f$\gamma\f$ transport simulations.
  *
@@ -20,13 +24,26 @@ class  G4HepEmTLData;
  */
 
 class G4HepEmGammaManager {
-  
+
 public:
   // step length
-  void   HowFar(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/) {}
+  void   HowFar(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/);
+
+  G4HepEmHostDevice
+  void   HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTrack* theTrack);
+
+
   // interactions
-  void   Perform(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/) {}
+  void   Perform(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/);
+
+  void   UpdateNumIALeft(G4HepEmTrack* theTrack);
+
+
+  G4HepEmHostDevice
+  double  GetMacXSec(const struct G4HepEmGammaData* gmData, const int imat, const double ekin, const double lekin, const int iprocess);
+
+
+
 };
 
 #endif // G4HepEmGammaManager_HH
-

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -1,0 +1,144 @@
+#include "G4HepEmGammaManager.hh"
+
+#include "G4HepEmData.hh"
+#include "G4HepEmParameters.hh"
+#include "G4HepEmTLData.hh"
+
+#include "G4HepEmConstants.hh"
+#include "G4HepEmMatCutData.hh"
+#include "G4HepEmMaterialData.hh"
+#include "G4HepEmGammaData.hh"
+
+#include "G4HepEmMath.hh"
+
+#include "G4HepEmRunUtils.hh"
+#include "G4HepEmTrack.hh"
+#include "G4HepEmElectronTrack.hh"
+#include "G4HepEmGammaTrack.hh"
+
+#include "G4HepEmGammaInteractionConversion.hh"
+#include "G4HepEmGammaInteractionCompton.hh"
+#include "G4HepEmGammaInteractionPhotoelectric.hh"
+
+#include <iostream>
+
+// Note: pStepLength will be set here i.e. this is the first access to it that
+//       will clear the previous step value.
+void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
+  G4HepEmTrack* theTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
+  // Sample the `number-of-interaction-left`
+  for (int ip=0; ip<3; ++ip) {
+    if (theTrack->GetNumIALeft(ip)<=0.) {
+      theTrack->SetNumIALeft(-std::log(tlData->GetRNGEngine()->flat()), ip);
+    }
+  }
+  HowFar(hepEmData, hepEmPars, theTrack);
+}
+
+
+void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTrack* theTrack) {
+  const double   theEkin = theTrack->GetEKin();
+  const double  theLEkin = theTrack->GetLogEKin();
+  const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
+  // get the Gamma data from the op level data structure
+  const G4HepEmGammaData* theGammaData = hepEmData->fTheGammaData;
+  // === Gamma has only discrete limits due to Conversion, Compton (at the moment)
+  double mxSecs[3];
+  // conversion, compton and photoelectric
+  mxSecs[0] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 0);
+  mxSecs[1] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 1);
+  // NOTE: there is no-photoelectric at the moment!
+  //       But photons with an energy below 250.0 [keV] are absorbed by setting
+  //       the (fake absorption) process macroscopic cross section to a large value.
+  mxSecs[2] = (theEkin > 0.25) ? 0.0 : kALargeValue;
+  // compute mfp and see if we need to sample the `number-of-interaction-left`
+  // before we use it to get the current discrete proposed step length
+  int indxWinnerProcess = -1;             // init to nothing
+  double pStepLength    = kALargeValue;   // init to a large value
+  for (int ip=0; ip<3; ++ip) {
+    const double mxsec = mxSecs[ip];
+    const double   mfp = (mxsec>0.) ? 1./mxsec : kALargeValue;
+    // save the mac-xsec for the update of the `number-of-interaction-left`:
+    // the `number-of-intercation-left` should be updated in the along-step-action
+    theTrack->SetMFP(mfp, ip);
+    // sample the proposed step length
+    const double dStepLimit = mfp*theTrack->GetNumIALeft(ip);
+//    std::cout << " ip = " << ip << " mxsec = " << mxsec << " dStepLimit = " << dStepLimit << std::endl;
+    if (dStepLimit<pStepLength) {
+      pStepLength = dStepLimit;
+      indxWinnerProcess = ip;
+    }
+  }
+//  std::cout << "indxWinnerProcess = " << indxWinnerProcess <<  " dStepLimit = " << pStepLength << std::endl;
+  //
+  // the geometrical and physical step lengths are the same for gamma
+  theTrack->SetGStepLength(pStepLength);
+  theTrack->SetWinnerProcessIndex(indxWinnerProcess);
+  //
+}
+
+
+void G4HepEmGammaManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* tlData) {
+  G4HepEmTrack* theTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
+  // === 1. The `number-of-interaction-left` needs to be updated based on the actual
+  //        step lenght and the energy deposit needs to be reset to 0.0
+  // physical step length is the geometrical fo rgamma
+  UpdateNumIALeft(theTrack);
+  // reset energy deposit
+  theTrack->SetEnergyDeposit(0.0);
+  // === Gamma has pure Discrete interaction (if any)
+  // 2. check if discrete process limited the step return otherwise (i.e. if
+  //    boundary process limited the step)
+  if (theTrack->GetOnBoundary()) {
+    return;
+  }
+  // reset number of interaction left for the winner discrete process
+  const int iDProc = theTrack->GetWinnerProcessIndex();
+  theTrack->SetNumIALeft(-1.0, iDProc);
+//  std::cout<< " --- iDProc = " << iDProc << std::endl;
+  //
+  // perform the discrete part of the winner interaction
+  switch (iDProc) {
+    case 0: // invoke gamma Conversion to e-/e+ pairs: {
+            PerformGammaConversion(tlData, hepEmData);
+            break;
+    case 1: // invoke Compton scattering of gamma:
+            PerformComptonScattering(tlData, hepEmData);
+            break;
+    case 2: // invoke photoelectric process: pure absorption at the moment (aktive if E_g < 250 keV)
+            PerformPhotoelectric(tlData, hepEmData);
+            break;
+
+  }
+}
+
+
+void   G4HepEmGammaManager::UpdateNumIALeft(G4HepEmTrack* theTrack) {
+  const double pStepLength = theTrack->GetGStepLength();
+  double*    numInterALeft = theTrack->GetNumIALeft();
+  double*       preStepMFP = theTrack->GetMFP();
+  numInterALeft[0] -= pStepLength/preStepMFP[0];
+  numInterALeft[1] -= pStepLength/preStepMFP[1];
+  numInterALeft[2] -= pStepLength/preStepMFP[2];
+}
+
+
+double  G4HepEmGammaManager::GetMacXSec(const struct G4HepEmGammaData* gmData, const int imat, const double ekin, const double lekin, const int iprocess) {
+  // get number of Conversion and Compton discrete energy grid points
+  const int numConvData = gmData->fConvEnergyGridSize;
+  const int numCompData = gmData->fCompEnergyGridSize;
+  const int      iStart = imat*2*(numConvData + numCompData);
+  // use the G4HepEmRunUtils GetSplineLog function for interpolation
+  switch (iprocess) {
+    case 0: { // Conversion
+              const double  mxsec = GetSplineLog(numConvData, gmData->fConvEnergyGrid, &(gmData->fConvCompMacXsecData[iStart]) , ekin, lekin, gmData->fConvLogMinEkin, gmData->fConvEILDelta);
+              return G4HepEmMax(0.0, mxsec);
+            }
+    case 1: { // Compton
+              const double  mxsec = GetSplineLog(numCompData, gmData->fCompEnergyGrid, &(gmData->fConvCompMacXsecData[iStart+2*numConvData]) , ekin, lekin, gmData->fCompLogMinEkin, gmData->fCompEILDelta);
+              return G4HepEmMax(0.0, mxsec);
+            }
+    default:
+            return 0.0;
+  }
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmInteractionUtils.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmInteractionUtils.hh
@@ -1,0 +1,39 @@
+#ifndef G4HepEmInteractionUtil_HH
+#define G4HepEmInteractionUtil_HH
+
+#include "G4HepEmMacros.hh"
+
+class  G4HepEmRandomEngine;
+
+
+G4HepEmHostDevice
+double SampleCostModifiedTsai(const double thePrimEkin, G4HepEmRandomEngine* rnge);
+
+
+G4HepEmHostDevice
+void EvaluateLPMFunctions(double& funcXiS, double& funcGS, double& funcPhiS,
+                     const double egamma, const double etotal, const double elpm,
+                     const double z23, const double ilVarS1, const double ilVarS1Cond,
+                     const double densityCor, const double times);
+
+// LPM functions G(s) and Phi(s) over an s-value grid of: ds=0.05 on [0:2.0] (2x41)
+G4HepEmHostDeviceConstant
+const double kFuncLPM[] = {
+  0.0000E+00, 0.0000E+00,  6.9163E-02, 2.5747E-01,  2.0597E-01, 4.4573E-01,
+  3.5098E-01, 5.8373E-01,  4.8095E-01, 6.8530E-01,  5.8926E-01, 7.6040E-01,
+  6.7626E-01, 8.1626E-01,  7.4479E-01, 8.5805E-01,  7.9826E-01, 8.8952E-01,
+  8.4003E-01, 9.1338E-01,  8.7258E-01, 9.3159E-01,  8.9794E-01, 9.4558E-01,
+  9.1776E-01, 9.5640E-01,  9.3332E-01, 9.6483E-01,  9.4560E-01, 9.7143E-01,
+  9.5535E-01, 9.7664E-01,  9.6313E-01, 9.8078E-01,  9.6939E-01, 9.8408E-01,
+  9.7444E-01, 9.8673E-01,  9.7855E-01, 9.8888E-01,  9.8191E-01, 9.9062E-01,
+  9.8467E-01, 9.9204E-01,  9.8695E-01, 9.9321E-01,  9.8884E-01, 9.9417E-01,
+  9.9042E-01, 9.9497E-01,  9.9174E-01, 9.9564E-01,  9.9285E-01, 9.9619E-01,
+  9.9379E-01, 9.9666E-01,  9.9458E-01, 9.9706E-01,  9.9526E-01, 9.9739E-01,
+  9.9583E-01, 9.9768E-01,  9.9632E-01, 9.9794E-01,  9.9674E-01, 9.9818E-01,
+  9.9710E-01, 9.9839E-01,  9.9741E-01, 9.9857E-01,  9.9767E-01, 9.9873E-01,
+  9.9790E-01, 9.9887E-01,  9.9809E-01, 9.9898E-01,  9.9826E-01, 9.9909E-01,
+  9.9840E-01, 9.9918E-01,  9.9856E-01, 9.9926E-01
+};
+
+
+#endif // G4HepEmInteractionUtil_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmInteractionUtils.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmInteractionUtils.icc
@@ -1,0 +1,75 @@
+
+#include "G4HepEmInteractionUtils.hh"
+
+#include "G4HepEmRandomEngine.hh"
+#include "G4HepEmConstants.hh"
+
+#include <cmath>
+
+G4HepEmHostDevice
+double SampleCostModifiedTsai(const double thePrimEkin, G4HepEmRandomEngine* rnge) {
+  // sample photon direction (modified Tsai sampling):
+  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
+  double rndm3[3];
+  double u;
+  do {
+    rnge->flatArray(3, rndm3);
+    const double uu = -std::log(rndm3[0]*rndm3[1]);
+    u = (0.25 > rndm3[2]) ? uu*1.6 : uu*0.533333333;
+  } while (u > uMax);
+  // cost = 1.0 - 2.0*u*u/(uMax*uMax);
+  return 1.0 - 2.0*u*u/(uMax*uMax);
+}
+
+// times = 1.0 for Brem and -1.0 for Pair production
+// densityCor = 0.0  for Pair production
+G4HepEmHostDevice
+void EvaluateLPMFunctions(double& funcXiS, double& funcGS, double& funcPhiS, const double egamma,
+     const double etotal, const double elpm, const double z23, const double ilVarS1,
+     const double ilVarS1Cond, const double densityCor, const double times) {
+  const double     sqrt2 = 1.414213562373095;
+  const double redegamma = egamma / etotal;
+  const double varSprime = std::sqrt( 0.125 * redegamma * elpm / ( times*( 1.0 - redegamma ) * etotal ) );
+  const double     varS1 = z23 / ( 184.15 * 184.15 );
+  const double condition = sqrt2*varS1;
+  double funcXiSprime = 2.0;
+  if (varSprime > 1.0) {
+    funcXiSprime = 1.0;
+  } else if (varSprime > condition) {
+    const double funcHSprime = std::log(varSprime)*ilVarS1Cond;
+    funcXiSprime = 1.0 + funcHSprime - 0.08*(1.0-funcHSprime)*funcHSprime*(2.0-funcHSprime)*ilVarS1Cond;
+  }
+  funcXiS = funcXiSprime;
+  const double    varS = varSprime / std::sqrt( funcXiSprime );
+  // - include dielectric suppression effect into s according to Migdal (only in case of Brem !)
+  double varShat = varS;
+  if (densityCor != 0.0) {
+    varShat *= ( 1.0 + densityCor / (egamma*egamma) );
+    funcXiS = 2.0;
+    if (varShat > 1.0) {
+      funcXiS = 1.0;
+    } else if (varShat > varS1) {
+      funcXiS = 1.0 + std::log ( varShat ) * ilVarS1;
+    }
+  }
+  // avluate the LPM G(s) and Phi(s) function (approximations) at s = s-hat
+  const double lpmSLimit =  2.0;
+  const double lpmISDelt = 20.0;
+  if (varShat < lpmSLimit) {
+    double  val = varShat*lpmISDelt;
+    int    ilow = (int)val;
+    val        -= ilow;
+    ilow       *= 2;
+    funcGS      = ( kFuncLPM[ilow+2] - kFuncLPM[ilow]   ) * val + kFuncLPM[ilow];
+    funcPhiS    = ( kFuncLPM[ilow+3] - kFuncLPM[ilow+1] ) * val + kFuncLPM[ilow+1];
+  } else {
+    double ss = 1.0/(varShat*varShat);
+    ss *= ss;
+    funcGS   = 1.0-0.0230655*ss;
+    funcPhiS = 1.0-0.01190476*ss;
+  }
+  //MAKE SURE SUPPRESSION IS SMALLER THAN 1: due to Migdal's approximation on xi
+  if (funcXiS*funcPhiS > 1.0 || varShat > 0.57) {
+    funcXiS = 1.0/funcPhiS;
+  }
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmMath.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmMath.hh
@@ -2,6 +2,8 @@
 #ifndef G4HepEmMath_HH
 #define G4HepEmMath_HH
 
+#include <cmath>
+
 #include "G4HepEmMacros.hh"
 
 template <typename T>
@@ -14,6 +16,12 @@ template <typename T>
 G4HepEmHostDevice static inline
 T G4HepEmMin(T a, T b) {
  return a < b ? a : b;
+}
+
+template <typename T>
+G4HepEmHostDevice static inline
+T G4HepEmX13(T x) {
+ return std::pow(x, 1./3.);
 }
 
 #endif // G4HepEmMath_HH

--- a/G4HepEm/src/G4HepEmRunManager.cc
+++ b/G4HepEm/src/G4HepEmRunManager.cc
@@ -13,6 +13,9 @@
 #include "G4HepEmElectronInit.hh"
 #include "G4HepEmElectronManager.hh"
 
+#include "G4HepEmGammaInit.hh"
+#include "G4HepEmGammaManager.hh"
+
 #include "G4HepEmRandomEngine.hh"
 
 
@@ -38,6 +41,7 @@ G4HepEmRunManager::G4HepEmRunManager(bool ismaster) {
   fTheG4HepEmTLData              = nullptr;
   //
   fTheG4HepEmElectronManager     = nullptr;
+  fTheG4HepEmGammaManager        = nullptr;
   //
   G4HepEmRunManager::gTheG4HepEmRunManagers.push_back(this);
 }
@@ -105,16 +109,24 @@ void G4HepEmRunManager::Initialize(G4HepEmRandomEngine* theRNGEngine, int hepEmP
     switch (hepEmParticleIndx) {
       // === e- : use the G4HepEmElementInit::InitElectronData() method for e- initialization.
       case 0 : InitElectronData(fTheG4HepEmData, fTheG4HepEmParameters, true);
-               fTheG4HepEmElectronManager = new G4HepEmElectronManager;
+               if (fTheG4HepEmElectronManager == nullptr) {
+                 fTheG4HepEmElectronManager = new G4HepEmElectronManager;
+               }
                fIsInitialisedForParticle[0] = true;
                break;
       // === e+ : use the G4HepEmElementInit::InitElectronData() method for e+ initialization.
       case 1 : InitElectronData(fTheG4HepEmData, fTheG4HepEmParameters, false);
+               if (fTheG4HepEmElectronManager == nullptr) {
+                 fTheG4HepEmElectronManager = new G4HepEmElectronManager;
+               }
                fIsInitialisedForParticle[1] = true;
                //fTheG4HepEmPositronManager = new G4HepEmElectronManager;
                break;
-      // === Gamma:
-      case 2 : // InitGammaData();                 // gamma
+      // === Gamma: use the G4HepEmGammaInit::InitGammaData() method for gamma initialization.
+      case 2 : InitGammaData(fTheG4HepEmData, fTheG4HepEmParameters);
+               if (fTheG4HepEmGammaManager == nullptr) {
+                 fTheG4HepEmGammaManager = new G4HepEmGammaManager;
+               }
                fIsInitialisedForParticle[2] = true;
                break;
       default: std::cerr << " **** ERROR in G4HepEmRunManager::Initialize: unknown particle " << std::endl;
@@ -132,6 +144,7 @@ void G4HepEmRunManager::Initialize(G4HepEmRandomEngine* theRNGEngine, int hepEmP
       fTheG4HepEmParameters = G4HepEmRunManager::GetMasterRunManager()->GetHepEmParameters();
       fTheG4HepEmData       = G4HepEmRunManager::GetMasterRunManager()->GetHepEmData();
       fTheG4HepEmElectronManager = G4HepEmRunManager::GetMasterRunManager()->GetTheElectronManager();
+      fTheG4HepEmGammaManager    = G4HepEmRunManager::GetMasterRunManager()->GetTheGammaManager();
     }
     // Worker: 2. create a worker local data structure for this worker and set
     //            its RNG engine part if it has not been done yet.
@@ -158,6 +171,9 @@ void G4HepEmRunManager::Clear() {
     if (fTheG4HepEmElectronManager)
       delete fTheG4HepEmElectronManager;
     fTheG4HepEmElectronManager = nullptr;
+    if (fTheG4HepEmGammaManager)
+      delete fTheG4HepEmGammaManager;
+    fTheG4HepEmGammaManager    = nullptr;
     fIsInitialisedForParticle[0] = false;
     fIsInitialisedForParticle[1] = false;
     fIsInitialisedForParticle[2] = false;
@@ -167,6 +183,7 @@ void G4HepEmRunManager::Clear() {
     fTheG4HepEmParameters      = nullptr;
     fTheG4HepEmData            = nullptr;
     fTheG4HepEmElectronManager = nullptr;
+    fTheG4HepEmGammaManager    = nullptr;
     // clean local objects and set ptr
     if (fTheG4HepEmTLData)
       delete fTheG4HepEmTLData;

--- a/apps/examples/TestEm3/ATLASbar.mac
+++ b/apps/examples/TestEm3/ATLASbar.mac
@@ -3,13 +3,13 @@
 ## =============================================================================
 ##
 /control/verbose 0
-/run/numberOfThreads 6
+/run/numberOfThreads 4
 /run/verbose 0
 ##
 ## -----------------------------------------------------------------------------
-## Setup the ATLASbar simplified sampling calorimeter: 
+## Setup the ATLASbar simplified sampling calorimeter:
 ##   = 50 Layers of:
-##     - Absorber 1 (gap) : 2.3 mm Lead 
+##     - Absorber 1 (gap) : 2.3 mm Lead
 ##     - Absorber 2 (abs.): 5.7 mm liquid-Argon
 ## -----------------------------------------------------------------------------
 /testem/det/setSizeYZ 40 cm
@@ -19,7 +19,7 @@
 /testem/det/setAbsor 2 G4_lAr 5.7 mm
 ##
 ## -----------------------------------------------------------------------------
-## Set the physics list (more exactly, the EM physics constructor): 
+## Set the physics list (more exactly, the EM physics constructor):
 ##  = 'HepEm'           : the G4HepEm EM physics c.t.r.
 ##  =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
 ##  = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
@@ -28,7 +28,7 @@
 ##/testem/phys/addPhysics   G4Em
 ##
 ## -----------------------------------------------------------------------------
-## Set secondary production threshold, init. the run and set primary properties  
+## Set secondary production threshold, init. the run and set primary properties
 ## -----------------------------------------------------------------------------
 /run/setCut 0.7 mm
 /run/initialize
@@ -38,5 +38,6 @@
 ## -----------------------------------------------------------------------------
 ## Run the simulation with the given number of events and print list of processes
 ## -----------------------------------------------------------------------------
+##/tracking/verbose 1
 /run/beamOn 1000
 /process/list

--- a/apps/examples/TestEm3/include/GammaAbsorption.hh
+++ b/apps/examples/TestEm3/include/GammaAbsorption.hh
@@ -1,0 +1,46 @@
+
+#ifndef GammaAbsorption_HH
+#define GammaAbsorption_HH
+
+#include "globals.hh"
+#include "G4VDiscreteProcess.hh"
+#include "G4ParticleChangeForGamma.hh"
+
+
+
+class G4ParticleDefinition;
+
+// Simple G4VDiscreteProcess that will absorb gammas when their energy is
+// below the fAbsorptionThreshold ()= 250 [keV]) energy.
+// NOTE: this process will need to be replaced with G4PhotoElectricEffect when
+//       the corresponding interaction will be handled by G4HepEm. Till that,
+//       this process corresponds to the G4HepEmGammaInteractionPhotoelectric
+//       process.
+class GammaAbsorption : public G4VDiscreteProcess {
+
+public:
+   GammaAbsorption(const G4String& processName ="gammaAbsorption",
+			             G4ProcessType type = fElectromagnetic);
+
+  ~GammaAbsorption() override;
+
+  // implementation of virtual method, specific for G4VEmProcess
+  G4double PostStepGetPhysicalInteractionLength(const G4Track&, G4double, G4ForceCondition*) override;
+
+  // implementation of virtual method, specific for G4VEmProcess
+  G4VParticleChange* PostStepDoIt(const G4Track&, const G4Step&) override;
+
+
+protected:
+
+  G4double GetMeanFreePath( const G4Track& aTrack,
+                            G4double previousStepSize,
+                            G4ForceCondition* condition ) override;
+
+private:
+  G4ParticleChangeForGamma     fParticleChange;
+  G4double                     fAbsorptionThreshold;
+
+};
+
+#endif // GammaAbsorption_HH

--- a/apps/examples/TestEm3/src/GammaAbsorption.cc
+++ b/apps/examples/TestEm3/src/GammaAbsorption.cc
@@ -1,0 +1,38 @@
+
+#include "GammaAbsorption.hh"
+
+#include "G4EmProcessSubType.hh"
+
+GammaAbsorption::GammaAbsorption(const G4String& processName, G4ProcessType type)
+: G4VDiscreteProcess (processName, type) {
+  SetProcessSubType(fPhotoElectricEffect);
+  fAbsorptionThreshold = 0.25; // 250 keV;
+}
+
+GammaAbsorption::~GammaAbsorption() {}
+
+// implementation of virtual method, specific for G4VEmProcess
+G4double
+GammaAbsorption::PostStepGetPhysicalInteractionLength(const G4Track& track,
+                                                      G4double,
+                                                      G4ForceCondition* condition) {
+  *condition = NotForced;
+  return (track.GetDynamicParticle()->GetKineticEnergy() > fAbsorptionThreshold) ? DBL_MAX : 0.0;
+}
+
+// implementation of virtual method, specific for G4VEmProcess
+G4VParticleChange*
+GammaAbsorption::PostStepDoIt(const G4Track& track,const G4Step&) {
+  fParticleChange.InitializeForPostStep(track);
+  fParticleChange.ProposeLocalEnergyDeposit(track.GetDynamicParticle()->GetKineticEnergy());
+  fParticleChange.SetProposedKineticEnergy(0.0);
+  fParticleChange.ProposeTrackStatus(fStopAndKill);
+
+  return &fParticleChange;
+}
+
+
+G4double
+GammaAbsorption::GetMeanFreePath( const G4Track& track, G4double, G4ForceCondition*) {
+  return (track.GetDynamicParticle()->GetKineticEnergy() > fAbsorptionThreshold) ? DBL_MAX : 0.0;
+}

--- a/apps/examples/TestEm3/src/PhysListG4Em.cc
+++ b/apps/examples/TestEm3/src/PhysListG4Em.cc
@@ -9,8 +9,11 @@
 //#include "G4KleinNishinaModel.hh"  // by defult in G4ComptonScattering
 
 #include "G4GammaConversion.hh"
+
+#include "GammaAbsorption.hh"
 #include "G4PhotoElectricEffect.hh"
 #include "G4LivermorePhotoElectricModel.hh"
+
 //#include "G4RayleighScattering.hh"
 
 #include "G4eMultipleScattering.hh"
@@ -18,6 +21,7 @@
 #include "G4eIonisation.hh"
 #include "G4eBremsstrahlung.hh"
 #include "G4eplusAnnihilation.hh"
+
 
 #include "G4EmParameters.hh"
 #include "G4MscStepLimitType.hh"
@@ -80,7 +84,12 @@ void PhysListG4Em::ConstructProcess() {
 
     if (particleName == "gamma") {
       ph->RegisterProcess(new G4ComptonScattering(), particle);
+
       ph->RegisterProcess(new G4GammaConversion, particle);
+
+      ph->RegisterProcess(new GammaAbsorption, particle);
+
+/*
       G4double LivermoreLowEnergyLimit = 1*eV;
       G4double LivermoreHighEnergyLimit = 1*TeV;
       G4PhotoElectricEffect* thePhotoElectricEffect = new G4PhotoElectricEffect();
@@ -89,6 +98,7 @@ void PhysListG4Em::ConstructProcess() {
       theLivermorePhotoElectricModel->SetHighEnergyLimit(LivermoreHighEnergyLimit);
       thePhotoElectricEffect->AddEmModel(0, theLivermorePhotoElectricModel);
       ph->RegisterProcess(thePhotoElectricEffect, particle);
+*/
     } else if (particleName == "e-") {
 
 // //     ph->RegisterProcess(new G4eMultipleScattering(), particle);
@@ -106,8 +116,9 @@ void PhysListG4Em::ConstructProcess() {
       //
       G4eIonisation* eIoni = new G4eIonisation();
       ph->RegisterProcess(eIoni, particle);
-      
+
       ph->RegisterProcess(new G4eBremsstrahlung(), particle);
+
     } else if (particleName == "e+") {
 //      ph->RegisterProcess(new G4eMultipleScattering(), particle);
 
@@ -116,20 +127,20 @@ void PhysListG4Em::ConstructProcess() {
       G4GoudsmitSaundersonMscModel* msc1 = new G4GoudsmitSaundersonMscModel();
       msc->AddEmModel(0, msc1);
       ph->RegisterProcess(msc,particle);
-*/      
-     
+*/
+
 
       G4eIonisation* eIoni = new G4eIonisation();
       ph->RegisterProcess(eIoni, particle);
       ph->RegisterProcess(new G4eBremsstrahlung(), particle);
       ph->RegisterProcess(new G4eplusAnnihilation(), particle);
+
     }
   }
 
-  
+
   // Deexcitation
   //
 //  G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
 //  G4LossTableManager::Instance()->SetAtomDeexcitation(de);
 }
-

--- a/apps/examples/TestEm3/src/PhysListHepEm.cc
+++ b/apps/examples/TestEm3/src/PhysListHepEm.cc
@@ -85,8 +85,12 @@ void PhysListHepEm::ConstructProcess() {
     G4String particleName = particle->GetParticleName();
 
     if (particleName == "gamma") {
+
+/*
       ph->RegisterProcess(new G4ComptonScattering(), particle);
+
       ph->RegisterProcess(new G4GammaConversion, particle);
+
       G4double LivermoreLowEnergyLimit = 1*eV;
       G4double LivermoreHighEnergyLimit = 1*TeV;
       G4PhotoElectricEffect* thePhotoElectricEffect = new G4PhotoElectricEffect();
@@ -95,24 +99,29 @@ void PhysListHepEm::ConstructProcess() {
       theLivermorePhotoElectricModel->SetHighEnergyLimit(LivermoreHighEnergyLimit);
       thePhotoElectricEffect->AddEmModel(0, theLivermorePhotoElectricModel);
       ph->RegisterProcess(thePhotoElectricEffect, particle);
+*/
+      // Add G4HepEm process to gamma: includes Conversion, Compton and an simple
+      // absorption when E_g < 250 [keV].
+      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, 0, -1);
+
+
     } else if (particleName == "e-") {
 
       // Add G4HepEm process to e-: includes Ionisation and Bremsstrahlung for e-
-      particle->GetProcessManager()->AddProcess(hepEmProcess, -1, 0, -1);
+     particle->GetProcessManager()->AddProcess(hepEmProcess, -1, 0, -1);
 
     } else if (particleName == "e+") {
 
-      // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e- 
+      // Add G4HepEm process to e+: includes Ionisation, Bremsstrahlung and e+e-
       // annihilation into 2 gamma interactions for e+
       particle->GetProcessManager()->AddProcess(hepEmProcess, -1, 0, -1);
 
     }
   }
 
-  
+
   // Deexcitation
   //
 //  G4VAtomDeexcitation* de = new G4UAtomicDeexcitation();
 //  G4LossTableManager::Instance()->SetAtomDeexcitation(de);
 }
-


### PR DESCRIPTION
Adding `gamma` interactions to `G4HepEm`, activate them and update `TestEm3` accordingly. 

This PR contains a large amount of new functionalities for making `G4HepEm` covering gamma interactions as well. Interactions included are:
  - production of e- e+ pairs (final form based on  `G4PairProductionRelModel`)
  - Compton scattering (final form based on `G4KleinNishinaCompton`)
  - photoelectric absorption (simplified see below)

All `gamma` interactions are in their final form except the photoelectric absorption. This will require a bit more time later but a simple absorption of gammas (when their energy drops below 250 [keV]) has been implemented in order to prevent the unrealistically high, low energy e- production due to the high number of Compton scattering while the photon leaves the target or its energy drops below 100 [eV] in aCompton scattering. Note, that all these unrealistic behaviour is the consequence of the missing of photoelectric absorption, that would absorb the gamma when its energy is getting lower with a higher probability.

Since `G4HepEm` includes now simulation of the `gamma` interactions and transport, the provided `TestEm3` example application has been updated as well. In order to ensure the same `gamma` absorption when using the native `Geant4` EM physics, a special `GammaAbsorption` process has been implemented and used in the `Geant4` EM physics constructor. This will be updated (changed to `G4PhotoElectricEffect`) when the corresponding functionalities are available in `G4HepEm` as well.   
 