### PR TITLE
Default to Release builds for single-mode generators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,19 @@ set(CMAKE_LINK_DEPENDS_NO_SHARED ON)
 # - Only report newly installed files
 set(CMAKE_INSTALL_MESSAGE LAZY)
 
+# - Default to Release mode build in single mode
+if(NOT CMAKE_CONFIGURATION_TYPES)
+  if(NOT CMAKE_BUILD_TYPE)
+    # Default to a Release build if nothing else...
+    set(CMAKE_BUILD_TYPE Release)
+  endif()
+  # Force to the cache, but use existing value.
+  set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}"
+    CACHE STRING "Choose the type of build, options are: None Release Debug RelWithDebInfo MinSizeRel"
+    FORCE)
+endif()
+
+
 # - Minimums required by G4HepEm
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
To match up the default build mode to that of the primary Geant4 dependency, default builds of `G4HepEm` with single mode generators to `Release`. Multiconfig generators like Xcode etc will still use Debug as the default.

No use of Geant4 C++ flags is added _in this PR_ as local testing of `TestEm3` and the `ATLASbar.mac` script show average runtimes with differences dominated by system fluctuations. There is _not yet_ an observable difference with/without `Geant4_CXX_FLAGS`, the build mode fix here providing the real difference.

Fixes: #29 