### PR TITLE
Initial skeleton for development of import/export of G4HepEM data

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -18,6 +18,7 @@ add_subdirectory(GammaTargetElementSelector)
 add_subdirectory(ElectronXSections)
 add_subdirectory(GammaXSections)
 add_subdirectory(MaterialAndRelated)
+add_subdirectory(DataImportExport)
 
 ## ----------------------------------------------------------------------------
 ## 3. Add the developer-only test applications

--- a/testing/DataImportExport/CMakeLists.txt
+++ b/testing/DataImportExport/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_executable(TestDataImportExport
+  TestDataImportExport.cc
+  include/MockG4.h
+  src/MockG4.cc)
+
+target_include_directories(TestDataImportExport PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_link_libraries(TestDataImportExport
+  PRIVATE
+  g4HepEm TestUtils ${Geant4_LIBRARIES})
+
+add_test(NAME TestDataImportExport COMMAND TestDataImportExport)

--- a/testing/DataImportExport/Readme.md
+++ b/testing/DataImportExport/Readme.md
@@ -1,0 +1,7 @@
+# Testing Export and Import of G4HepEM data
+
+This test constructs a mock Geant4 setup consisting of two materials (Pb and LAr)
+and a nested geometry of three volumes. Two `G4Regions` are defined with different
+production cuts. After setting up this system, the `G4HepEm` data tables are constructed
+(Host only, no Device side operations are needed in this test) and written out to file
+together with the geometry information in a separate GDML file.

--- a/testing/DataImportExport/TestDataImportExport.cc
+++ b/testing/DataImportExport/TestDataImportExport.cc
@@ -1,0 +1,40 @@
+#include "MockG4.h"
+#include "G4GDMLParser.hh"
+#include "G4ProductionCutsTable.hh"
+#include "G4Version.hh"
+
+#include <cstdio>
+
+int main(int argc, char* argv[])
+{
+  // Only outputs are the data file(s)
+  // Separate for now, but will want to unify/connect
+  const G4String baseFilename = "G4HepEMTestDataImportExport";
+  const G4String gdmlFile     = baseFilename + ".gdml";
+  const G4String g4hepemFile  = baseFilename + ".g4hepem";
+
+  // Build mock geant4 setup
+  // - Should create geometry, regions and cuts
+  G4PVPlacement* world = MockG4();
+
+  // Dump cuts couples to check
+  G4ProductionCutsTable::GetProductionCutsTable()->DumpCouples();
+
+  // Persist data
+  // Add export of regions and energy cuts to see what these
+  // do and how to use. Remove pointer from exported names for
+  // now to aid reabability (we know we won't have duplicated names)
+  G4GDMLParser gdmlParser;
+  gdmlParser.SetAddPointerToName(false);
+// Only for Geant4 10.7!
+#if G4VERSION > 1069
+  gdmlParser.SetOutputFileOverwrite(true);
+#else
+  std::remove(gdmlFile.c_str());
+#endif
+  gdmlParser.SetRegionExport(true);
+  gdmlParser.SetEnergyCutsExport(true);
+  gdmlParser.Write(gdmlFile, world, false);
+
+  return 0;
+}

--- a/testing/DataImportExport/include/MockG4.h
+++ b/testing/DataImportExport/include/MockG4.h
@@ -1,0 +1,8 @@
+#ifndef TESTDATAIMPORTEXPORT_MOCKG4_H
+#define TESTDATAIMPORTEXPORT_MOCKG4_H
+
+#include "G4PVPlacement.hh"
+
+G4PVPlacement* MockG4();
+
+#endif // TESTDATAIMPORTEXPORT_MOCKG4_H

--- a/testing/DataImportExport/src/MockG4.cc
+++ b/testing/DataImportExport/src/MockG4.cc
@@ -1,0 +1,108 @@
+#include "MockG4.h"
+
+#include "G4Types.hh"
+
+#include "G4Box.hh"
+#include "G4LogicalVolume.hh"
+#include "G4Material.hh"
+#include "G4NistManager.hh"
+#include "G4PVPlacement.hh"
+#include "G4SystemOfUnits.hh"
+#include "G4ThreeVector.hh"
+
+#include "G4Gamma.hh"
+#include "G4Electron.hh"
+#include "G4Positron.hh"
+#include "G4Proton.hh"
+#include "G4ParticleTable.hh"
+#include "G4ProductionCuts.hh"
+#include "G4ProductionCutsTable.hh"
+
+G4PVPlacement* MockG4()
+{
+  // This largely follows G4HepEM's testing methods
+  // Want nested regions with common materials to make sure we can connect these
+  // up
+
+  // -- Materials (Matched to TestEm3)
+  G4Material* g4Galactic =
+    G4NistManager::Instance()->FindOrBuildMaterial("G4_Galactic");
+  G4Material* g4Pb  = G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb");
+  G4Material* g4LAr = G4NistManager::Instance()->FindOrBuildMaterial("G4_lAr");
+
+  // -- Geometry
+  const G4double worldHalfLength    = 5.0 * CLHEP::m;
+  const G4double outerAbsHalfLength = 0.8 * worldHalfLength;
+  const G4double scintHalfLength    = 0.8 * outerAbsHalfLength;
+  const G4double innerAbsHalfLength = 0.8 * scintHalfLength;
+
+  // world...
+  auto* worldBox =
+    new G4Box("World", worldHalfLength, worldHalfLength, worldHalfLength);
+  auto* worldLogical = new G4LogicalVolume(worldBox, g4Galactic, "World");
+  auto* worldPhysical =
+    new G4PVPlacement(0, G4ThreeVector(), worldLogical, "World", 0, false, 0);
+
+  // Lead "Outer Absorber"
+  auto* outerAbsBox = new G4Box("OuterAbsorber", outerAbsHalfLength,
+                                outerAbsHalfLength, outerAbsHalfLength);
+  auto* outerAbsLogical =
+    new G4LogicalVolume(outerAbsBox, g4Pb, "OuterAbsorber");
+  auto* outerAbsPhysical =
+    new G4PVPlacement(0, G4ThreeVector(), outerAbsLogical, "OuterAbsorber",
+                      worldLogical, false, 0);
+
+  // Liquid argon "scintillator"
+  auto* scintBox = new G4Box("Scintillator", scintHalfLength, scintHalfLength,
+                             scintHalfLength);
+  auto* scintLogical = new G4LogicalVolume(scintBox, g4LAr, "Scintillator");
+  auto* scintPhysical =
+    new G4PVPlacement(0, G4ThreeVector(), scintLogical, "Scintillator",
+                      outerAbsLogical, false, 0);
+
+  // Lead "Inner Absorber"
+  auto* innerAbsBox = new G4Box("InnerAbsorber", innerAbsHalfLength,
+                                innerAbsHalfLength, innerAbsHalfLength);
+  auto* innerAbsLogical =
+    new G4LogicalVolume(innerAbsBox, g4Pb, "InnerAbsorber");
+  auto* innerAbsPhysical =
+    new G4PVPlacement(0, G4ThreeVector(), innerAbsLogical, "InnerAbsorber",
+                      scintLogical, false, 0);
+
+  // -- Create particles that have secondary production threshold.
+  G4Gamma::Gamma();
+  G4Electron::Electron();
+  G4Positron::Positron();
+  G4Proton::Proton();
+  G4ParticleTable* partTable = G4ParticleTable::GetParticleTable();
+  partTable->SetReadiness();
+
+  // --- Create production - cuts object and set the secondary production
+  // threshold.
+  G4ProductionCuts* productionCuts = new G4ProductionCuts();
+  constexpr G4double ProductionCut = 1 * mm;
+  productionCuts->SetProductionCut(ProductionCut);
+
+  // --- Register a default region
+  G4Region* reg = new G4Region("default");
+  reg->AddRootLogicalVolume(worldLogical);
+  reg->UsedInMassGeometry(true);
+  reg->SetProductionCuts(productionCuts);
+
+  // --- and one for the Inner Absorber with different production cuts
+  G4Region* absReg = new G4Region("inner_absorber");
+  absReg->AddRootLogicalVolume(innerAbsLogical);
+  absReg->UsedInMassGeometry(true);
+
+  auto* absProductionCuts = new G4ProductionCuts();
+  absProductionCuts->SetProductionCut(0.7 * CLHEP::mm);
+
+  absReg->SetProductionCuts(absProductionCuts);
+
+  // --- Update the couple tables.
+  G4ProductionCutsTable* theCoupleTable =
+    G4ProductionCutsTable::GetProductionCutsTable();
+  theCoupleTable->UpdateCoupleTable(worldPhysical);
+
+  return worldPhysical;
+}


### PR DESCRIPTION
Upstream clients of G4HepEM may wish to export the data tables from G4HepEm into a file for later use in a separate application. This is to allow decoupling from Geant4 itself and its data libraries for lighter weight testing and development, for example EM physics using accelerator devices.

Following initial work and discussion in apt-sim/adept#87, this PR moves this to `G4HepEm` so that it can be cohesive with ongoing work here on the data tables and formats. Only a basic skeleton is implemented as a test to get things started. I've used a different "mock" Geant4 setup from `TestUtils` as I thought we should cover `G4Regions` (i.e. same material, different production cut). However, we can adapt as needed. 

I'll move forward with creating the G4HepEm data from the setup, and then we can discuss about how to persist it.