### PR TITLE
Disable DataImportExport test unless Geant4 supports GDML

### DIFF
--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -18,7 +18,12 @@ add_subdirectory(GammaTargetElementSelector)
 add_subdirectory(ElectronXSections)
 add_subdirectory(GammaXSections)
 add_subdirectory(MaterialAndRelated)
-add_subdirectory(DataImportExport)
+# Data test requires Geant4 GDML, so only add if supported
+if(Geant4_gdml_FOUND)
+  add_subdirectory(DataImportExport)
+else()
+  message(STATUS "Disabling TestDataImportExport: Geant4 GDML not found")
+endif()
 
 ## ----------------------------------------------------------------------------
 ## 3. Add the developer-only test applications


### PR DESCRIPTION
As this test will fail to build without Geant4's GDML support, only add it to the build if the Geant4 install has GDML. Resolves the problem @hahnjo noted in #34.