### PR TITLE
Simplify allocation/initialization of G4HepEmData structures

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
@@ -80,7 +80,7 @@
 
 struct G4HepEmElectronData {
   /** Number of G4HepEm material - cuts: number of G4HepEmMCCData structures stored in the G4HepEmMatCutData::fMatCutData array. */
-  int        fNumMatCuts;
+  int        fNumMatCuts = 0;
 
 //// === ENERGY LOSS DATA
   /**
@@ -91,13 +91,13 @@ struct G4HepEmElectronData {
    */
 ///@{
   /** Number of discrete kinetic energy values in the grid (\f$N\f$). */
-  int        fELossEnergyGridSize;
+  int        fELossEnergyGridSize = 0;
   /** Logarithm of the minimum kinetic energy value of the grid (\f$\ln(E_0)\f$)*/
   double     fELossLogMinEkin;     // log of the E_0
   /** Inverse of the log-scale delta value (\f$ 1/[log(E_{N-1}/E_0)/(N-1)]\f$). */
   double     fELossEILDelta;
   /** The grid of the discrete kinetic energy values (\f$E_0, E_1,\ldots, E_{N-1}\f$).*/
-  double*    fELossEnergyGrid;
+  double*    fELossEnergyGrid = nullptr; // [fELossEnergyGridSize]
   /** The energy loss data: **restricted dE/dx, range and inverse range** data.
     *
     * The restricted dE/dx, range (and corresponding inverse range) data values,
@@ -149,7 +149,7 @@ struct G4HepEmElectronData {
     * terms of memory consumption and speed) when accessing the restricted energy loss
     * related, i.e. stopping power, range and inverse range data in the \f$e^-/e^+\f$ stepping.
     */
-  double*    fELossData; // [5xfELossEnergyGridSize x fNumMatCuts]
+  double*    fELossData = nullptr; // [5xfELossEnergyGridSize x fNumMatCuts]
 /// @} */ // end: eloss
   //
 
@@ -161,9 +161,9 @@ struct G4HepEmElectronData {
    */
 ///@{
   /** Total number of restricted macroscopic cross sections realted data stored in the single G4HepEmElectronData::fResMacXSecData array.*/
-  int        fResMacXSecNumData;
+  int        fResMacXSecNumData = 0;
   /** Start index of the macroscopic cross section data, for the material - cuts couple with the given index, in the G4HepEmElectronData::fResMacXSecData array.*/
-  int*       fResMacXSecStartIndexPerMatCut;  // [fNumMatCuts]
+  int*       fResMacXSecStartIndexPerMatCut = nullptr;  // [fNumMatCuts]
   /** The restricted macroscopic cross section data for **ionisation** and **bremsstrahlung** for all material - cuts couples.
    *
    * All the restricted macroscopic cross section data are stored continuously in this G4HepEmElectronData::fResMacXSecData single array.
@@ -228,7 +228,7 @@ struct G4HepEmElectronData {
    * accessing the restricted macroscopic cross section data in the \f$e^-/e^+\f$ stepping.
    *
    */
-  double*    fResMacXSecData; // [fResMacXSecNumData]
+  double*    fResMacXSecData = nullptr; // [fResMacXSecNumData]
 /// @} */ // end: macroscopic cross section
 
 //// === TARGET ELEMENT SELECTOR
@@ -285,25 +285,25 @@ struct G4HepEmElectronData {
    */
 ///@{
   /** Total number of element selector data for the Moller-Bhabha model for e-/e+ ionisation.*/
-  int       fElemSelectorIoniNumData;
+  int       fElemSelectorIoniNumData = 0;
   /** Indices, at which data starts for a given material - cuts couple.*/
-  int*      fElemSelectorIoniStartIndexPerMatCut;     // [#material-cuts couple]
+  int*      fElemSelectorIoniStartIndexPerMatCut = nullptr;     // [fNumMatCuts]
   /** Element selector data for all material - cuts couples with multiple element material.*/
-  double*   fElemSelectorIoniData;                    // [fElemSelectorIoniNumData]
+  double*   fElemSelectorIoniData = nullptr;                    // [fElemSelectorIoniNumData]
 
   /** Total number of element selector data for the Seltzer-Berger model for e-/e+ bremsstrahlung.*/
-  int       fElemSelectorBremSBNumData;
+  int       fElemSelectorBremSBNumData = 0;
   /** Indices, at which data starts for a given material - cuts couple.*/
-  int*      fElemSelectorBremSBStartIndexPerMatCut;   // [#material-cuts couple]
+  int*      fElemSelectorBremSBStartIndexPerMatCut = nullptr;   // [fNumMatCuts]
   /** Element selector data for all material - cuts couples with multiple element material.*/
-  double*   fElemSelectorBremSBData;                  // [fElemSelectorBremSBNumData]
+  double*   fElemSelectorBremSBData = nullptr;                  // [fElemSelectorBremSBNumData]
 
   /** Total number of element selector data for the relativistic (improved Bethe-Heitler) model for e-/e+ bremsstrahlung.*/
-  int       fElemSelectorBremRBNumData;
+  int       fElemSelectorBremRBNumData = 0;
   /** Indices, at which data starts for a given material - cuts couple.*/
-  int*      fElemSelectorBremRBStartIndexPerMatCut;   // [#material-cuts couple]
+  int*      fElemSelectorBremRBStartIndexPerMatCut = nullptr;   // [fNumMatCuts]
   /** Element selector data for all material - cuts couples with multiple element material.*/
-  double*   fElemSelectorBremRBData;                  // [fElemSelectorBremRBNumData]
+  double*   fElemSelectorBremRBData = nullptr;                  // [fElemSelectorBremRBNumData]
 /// @} */ // end: target element selectors
 };
 
@@ -325,6 +325,17 @@ struct G4HepEmElectronData {
   *   dynamic memory members, is freed before the new allocation.
   */
 void AllocateElectronData (struct G4HepEmElectronData** theElectronData);
+
+/**
+ * Initializes a new @ref G4HepEmElectronData structure
+ *
+ * This function default constructs an instance of G4HepEmElectronData and returns
+ * a pointer to the freshly constructed instance. It is the callees responsibility
+ * to free the instance using @ref FreeElectronData.
+ *
+ * @return Pointer to instance of @ref G4HepEmElectronData
+ */
+G4HepEmElectronData* MakeElectronData();
 
 /**
   * Frees a G4HepEmElectronData structure.

--- a/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
@@ -93,9 +93,9 @@ struct G4HepEmElectronData {
   /** Number of discrete kinetic energy values in the grid (\f$N\f$). */
   int        fELossEnergyGridSize = 0;
   /** Logarithm of the minimum kinetic energy value of the grid (\f$\ln(E_0)\f$)*/
-  double     fELossLogMinEkin;     // log of the E_0
+  double     fELossLogMinEkin = 0.0;     // log of the E_0
   /** Inverse of the log-scale delta value (\f$ 1/[log(E_{N-1}/E_0)/(N-1)]\f$). */
-  double     fELossEILDelta;
+  double     fELossEILDelta = 0.0;
   /** The grid of the discrete kinetic energy values (\f$E_0, E_1,\ldots, E_{N-1}\f$).*/
   double*    fELossEnergyGrid = nullptr; // [fELossEnergyGridSize]
   /** The energy loss data: **restricted dE/dx, range and inverse range** data.

--- a/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
@@ -39,31 +39,31 @@ struct G4HepEmElemData {
   double  fZet = -1.0;
 
   /** \f$Z^{1/3}\f$ */
-  double  fZet13;
+  double  fZet13 = 0.0;
 
   /** \f$Z^{2/3}\f$ */
-  double  fZet23;
+  double  fZet23 = 0.0;
 
   /** Coulomb correction \f$ f_C \f$ */
-  double  fCoulomb;
+  double  fCoulomb = 0.0;
 
   /** \f$ \ln(Z) \f$  */
-  double  fLogZ;
+  double  fLogZ = 0.0;
 
   /** \f$ F_{\text{el}}-f_c+F_{\text{inel}}/Z \f$  */
-  double  fZFactor1;
+  double  fZFactor1 = 0.0;
 
   /** \f$ \exp \left[ \frac{42.038-F_{\text{low}}}{8.29} \right] -0.958 \f$ with \f$ Z_{\text{low}} = \frac{8}{3}\log(Z) \f$ */
-  double  fDeltaMaxLow;
+  double  fDeltaMaxLow = 0.0;
 
   /** \f$ \exp \left[ \frac{42.038-F_{\text{high}}}{8.29} \right] -0.958 \f$ with \f$ F_{\text{high}} = 8[\log(Z)/3 + f_C] \f$ */
-  double  fDeltaMaxHigh;
+  double  fDeltaMaxHigh = 0.0;
 
   /** LPM variable \f$ 1/ln [ \sqrt{2}s1 ] \f$ */
-  double  fILVarS1;
+  double  fILVarS1 = 0.0;
 
   /** LPM variable \f$ 1/ln[s1] \f$ */
-  double  fILVarS1Cond;
+  double  fILVarS1Cond = 0.0;
 
 };
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
@@ -36,7 +36,7 @@
 struct G4HepEmElemData {
 
   /** The atomic number (Z) of the element. */
-  double  fZet;
+  double  fZet = -1.0;
 
   /** \f$Z^{1/3}\f$ */
   double  fZet13;
@@ -70,13 +70,13 @@ struct G4HepEmElemData {
 // Data for all elements that are used by G4HepEm.
 struct G4HepEmElementData {
   /** Maximum capacity of the below G4HepEmElemData structure container (max Z that can be stored).*/
-  int     fMaxZet;
+  int     fMaxZet = 0;
   /** Collection of G4HepEmElemData structures indexed by the atomic number Z. */
-  struct G4HepEmElemData* fElementData;  // [fMaxZet]
+  struct G4HepEmElemData* fElementData = nullptr;  // [fMaxZet]
 };
 
 /**
-  * Allocates and pre-initialises the G4HepEmMaterialData structure.
+  * Allocates and pre-initialises an existing @ref G4HepEmMaterialData structure.
   *
   * This method is invoked from the InitMaterialAndCoupleData() function declared
   * in the G4HepEmMaterialInit header file. The input argument address of the
@@ -84,12 +84,23 @@ struct G4HepEmElementData {
   * member of the `master` G4HepEmRunManager and the initialisation should be
   * done by the master G4HepEmRunManager.
   *
-  * @param theElementData address of a G4HepEmElementData structure pointer. At termination,
+  * @param [in][out] theElementData address of a G4HepEmElementData structure pointer. At termination,
   *   the correspondig pointer will be set to a memory location with a freshly allocated
   *   G4HepEmElementData structure. If the pointer was not null at input, the pointed
   *   memory is freed before the new allocation.
   */
 void AllocateElementData(struct G4HepEmElementData** theElementData);
+
+/**
+ * Initializes a new @ref G4HepEmMaterialData structure
+ *
+ * This function default constructs an instance of G4HepEmMaterialData and returns
+ * a pointer to the freshly constructed instance. It is the callees responsibility
+ * to free the instance using @ref FreeElementData.
+ *
+ * @return Pointer to instance of @ref G4HepEmMaterialData
+ */
+G4HepEmElementData* MakeElementData();
 
 /**
   * Frees a G4HepEmElementData structure.
@@ -101,7 +112,7 @@ void AllocateElementData(struct G4HepEmElementData** theElementData);
   * The input argument is supposed to be the address of the corresponding pointer
   * member of the G4HepEmData member of the `master` G4HepEmRunManager.
   *
-  * @param theElementData memory address that stores pointer to a G4HepEmElementData
+  * @param [in][out] theElementData memory address that stores pointer to a G4HepEmElementData
   *  structure. The memory is freed and the input address will store a null pointer
   *  at termination.
   */

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -18,14 +18,14 @@ struct G4HepEmGammaData {
 
 //// === conversion related data. Grid: 146 bins form 2mc^2 - 100 TeV
   const int     fConvEnergyGridSize = 147;
-  double        fConvLogMinEkin;    // = 0.021759358706830;  // log(2mc^2)
-  double        fConvEILDelta;      // = 7.935247775833226;  // 1./[log(emax/emin)/146]
+  double        fConvLogMinEkin = 0.0;    // = 0.021759358706830;  // log(2mc^2)
+  double        fConvEILDelta = 0.0;      // = 7.935247775833226;  // 1./[log(emax/emin)/146]
   double*       fConvEnergyGrid = nullptr;    // [fConvEnergyGrid]
 
 //// === compton related data. 84 bins (7 per decades) from 100 eV - 100 TeV
   const int     fCompEnergyGridSize = 85;
-  double        fCompLogMinEkin;     // = -9.210340371976182; // log(0.0001) i.e. log(100 eV)
-  double        fCompEILDelta;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
+  double        fCompLogMinEkin = 0.0;     // = -9.210340371976182; // log(0.0001) i.e. log(100 eV)
+  double        fCompEILDelta = 0.0;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
   double*       fCompEnergyGrid = nullptr;     // [fCompEnergyGridSize]
 
   // the macroscopic cross sections for all materials and for [conversion,compton]
@@ -35,8 +35,8 @@ struct G4HepEmGammaData {
 //// === element selector for conversion (note: KN compton interaction do not know anything about Z)
   int           fElemSelectorConvEgridSize = 0;
   int           fElemSelectorConvNumData = 0;          // total number of data i.e. lenght of fElemSelectorConvData
-  double        fElemSelectorConvLogMinEkin;
-  double        fElemSelectorConvEILDelta;         //
+  double        fElemSelectorConvLogMinEkin = 0.0;
+  double        fElemSelectorConvEILDelta = 0.0;         //
   int*          fElemSelectorConvStartIndexPerMat = nullptr; // [fNumMaterials]
   double*       fElemSelectorConvEgrid = nullptr;            // [fElemSelectorConvEgridSize]
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -14,34 +14,34 @@
 
 struct G4HepEmGammaData {
   /** Number of G4HepEm materials: number of G4HepEmMatData structures stored in the G4HepEmMaterialData::fMaterialData array. */
-  int           fNumMaterials;
+  int           fNumMaterials = 0;
 
 //// === conversion related data. Grid: 146 bins form 2mc^2 - 100 TeV
   const int     fConvEnergyGridSize = 147;
   double        fConvLogMinEkin;    // = 0.021759358706830;  // log(2mc^2)
   double        fConvEILDelta;      // = 7.935247775833226;  // 1./[log(emax/emin)/146]
-  double*       fConvEnergyGrid;    // the enrgy grid
+  double*       fConvEnergyGrid = nullptr;    // [fConvEnergyGrid]
 
 //// === compton related data. 84 bins (7 per decades) from 100 eV - 100 TeV
   const int     fCompEnergyGridSize = 85;
   double        fCompLogMinEkin;     // = -9.210340371976182; // log(0.0001) i.e. log(100 eV)
   double        fCompEILDelta;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
-  double*       fCompEnergyGrid;     // the enrgy grid
+  double*       fCompEnergyGrid = nullptr;     // [fCompEnergyGridSize]
 
   // the macroscopic cross sections for all materials and for [conversion,compton]
   // at each material
-  double*       fConvCompMacXsecData;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize)]
+  double*       fConvCompMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize)]
 
 //// === element selector for conversion (note: KN compton interaction do not know anything about Z)
-  int           fElemSelectorConvEgridSize;
-  int           fElemSelectorConvNumData;          // total number of data i.e. lenght of fElemSelectorConvData
+  int           fElemSelectorConvEgridSize = 0;
+  int           fElemSelectorConvNumData = 0;          // total number of data i.e. lenght of fElemSelectorConvData
   double        fElemSelectorConvLogMinEkin;
   double        fElemSelectorConvEILDelta;         //
-  int*          fElemSelectorConvStartIndexPerMat; // [#materials]
-  double*       fElemSelectorConvEgrid;            // common energy grid for all element selectors
+  int*          fElemSelectorConvStartIndexPerMat = nullptr; // [fNumMaterials]
+  double*       fElemSelectorConvEgrid = nullptr;            // [fElemSelectorConvEgridSize]
 
   /** Element selector data for all materials */
-  double*       fElemSelectorConvData;             // [fElemSelectorConvEGridSize]
+  double*       fElemSelectorConvData = nullptr;             // [fElemSelectorConvNumData]
 };
 
 /**
@@ -61,6 +61,17 @@ struct G4HepEmGammaData {
   *   dynamic memory members, is freed before the new allocation.
   */
 void AllocateGammaData (struct G4HepEmGammaData** theGammaData);
+
+/**
+ * Initializes a new @ref G4HepEmGammaData structure
+ *
+ * This function default constructs an instance of G4HepEmGammaData and returns
+ * a pointer to the freshly constructed instance. It is the callees responsibility
+ * to free the instance using @ref FreeGammaData.
+ *
+ * @return Pointer to instance of @ref G4HepEmGammaData
+ */
+G4HepEmGammaData* MakeGammaData();
 
 /**
   * Frees a G4HepEmGammaData structure.

--- a/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
@@ -46,21 +46,21 @@ struct G4HepEmMCCData {
   /** Logarithm of the above secondary \f$\gamma\f$ production threshold. */
   double  fLogSecGamCutE;
   /** Index of its material realted data: index of its G4HepEmMatData in the G4HepEmMaterialData. */
-  int     fHepEmMatIndex;
+  int     fHepEmMatIndex = -1;
   /** Index of the corresponding G4MaterialCutsCouple object.*/
-  int     fG4MatCutIndex;
+  int     fG4MatCutIndex = -1;
 };
 
 // Data for all matrial cuts couple that are used by G4HepEm.
 struct G4HepEmMatCutData {
   /** Number of G4MaterialCutsCouple objects in ``Geant4`` (irrespectively if used or not).  */
-  int      fNumG4MatCuts;
+  int      fNumG4MatCuts = 0;
   /** Number of G4HepEmMCCData structure in ``G4HepEm`` (only the used G4MaterialCutsCouple objects are translated). */
-  int      fNumMatCutData;
+  int      fNumMatCutData = 0;
   /** Array that translates a Geant4 G4MaterialCutsCouple object index to the correspondig G4HepEmMCCData index in the collection below.*/
-  int*     fG4MCIndexToHepEmMCIndex;  // [fNumG4MatCuts]
+  int*     fG4MCIndexToHepEmMCIndex = nullptr;  // [fNumG4MatCuts]
   /** Collection of G4HepEmMCCData structures for all material-cuts couples used in the current geometry.*/
-  struct G4HepEmMCCData* fMatCutData; // [fNumMatCutData]
+  struct G4HepEmMCCData* fMatCutData = nullptr; // [fNumMatCutData]
 };
 
 /**
@@ -76,12 +76,26 @@ struct G4HepEmMatCutData {
   *   the correspondig pointer will be set to a memory location with a freshly allocated
   *   G4HepEmMatCutData structure. If the pointer is not null at input, the pointed
   *   memory is freed before the new allocation.
-  * @param numG4MatCuts number of Geant4 material-cuts couple objects (irrespectively if used or not).
+  * @param[in] numG4MatCuts number of Geant4 material-cuts couple objects (irrespectively if used or not).
   *   It determines the maximum value of the G4MaterialCutsCouple object index.
-  * @param numUsedG4MatCuts number of Geant4 material-cuts couple objects used in the current geometry.
+  * @param[in] numUsedG4MatCuts number of Geant4 material-cuts couple objects used in the current geometry.
   *   It determines the number of the G4HepEmMCCData structures.
   */
 void AllocateMatCutData(struct G4HepEmMatCutData** theMatCutData, int numG4MatCuts, int numUsedG4MatCuts);
+
+
+/**
+ * Initializes a new @ref G4HepEmMatCutData structure
+ *
+ * This function constructs and returns an instance of G4HepEmMatCutData to hold a given number of indices
+ * to Geant4 material-cuts couple objects and their corresponding G4HepEmMCCData instance.
+ * It is the callees responsibility to free the instance using @ref FreeMatCutData.
+ *
+  * @param[in] numG4MatCuts number of Geant4 material-cuts couple objects
+  * @param[in] numUsedG4MatCuts number of Geant4 material-cuts couple objects used in the current geometry.
+  * @return Pointer to instance of @ref G4HepEmMatCutData
+ */
+G4HepEmMatCutData* MakeMatCutData(int numG4MatCuts, int numUsedG4MatCuts);
 
 /**
   * Frees a G4HepEmMatCutData structure.
@@ -98,9 +112,6 @@ void AllocateMatCutData(struct G4HepEmMatCutData** theMatCutData, int numG4MatCu
   *  at termination.
   */
 void FreeMatCutData (struct G4HepEmMatCutData** theMatCutData);
-
-
-
 
 
 #ifdef G4HepEm_CUDA_BUILD

--- a/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
@@ -40,11 +40,11 @@
 /** Data that describes a single matrial-cuts couple in ``G4HepEm``. */
 struct G4HepEmMCCData {
   /** Secondary \f$e^-\f$ production threshold energy [MeV]. */
-  double  fSecElProdCutE;
+  double  fSecElProdCutE = 0.0;
   /** Secondary \f$\gamma\f$ production threshold energy [MeV]. */
-  double  fSecGamProdCutE;
+  double  fSecGamProdCutE = 0.0;
   /** Logarithm of the above secondary \f$\gamma\f$ production threshold. */
-  double  fLogSecGamCutE;
+  double  fLogSecGamCutE = 0.0;
   /** Index of its material realted data: index of its G4HepEmMatData in the G4HepEmMaterialData. */
   int     fHepEmMatIndex = -1;
   /** Index of the corresponding G4MaterialCutsCouple object.*/

--- a/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
@@ -40,13 +40,13 @@
 /** Data that describes a single matrial in ``G4HepEm``. */
 struct G4HepEmMatData {
   /** The corresponding G4Material object index.*/
-  int       fG4MatIndex;
+  int       fG4MatIndex = -1;
   /** Number of elements this matrial is composed of (size of the arrays below). */
-  int       fNumOfElement;
+  int       fNumOfElement = 0;
   /** The list of element indices in G4HepEmElemData (their atomic number Z), this material is composed of.*/
-  int*      fElementVect;
+  int*      fElementVect = nullptr; // [fNumOfElement]
   /** The list of number-of-atoms-per-unit-volume for each element this material is composed of.*/
-  double*   fNumOfAtomsPerVolumeVect;
+  double*   fNumOfAtomsPerVolumeVect = nullptr; // [fNumOfElement]
   /** The mass density (\f$\rho\f$) of the material in Geant4 internal units. */
   double    fDensity;
   /** Density correction factor (\f$C_{Mg}\rho_{e^-}\f$) used in the `dielectric suppression`
@@ -62,13 +62,13 @@ struct G4HepEmMatData {
 // Data for all materials used in the current geometry.
 struct G4HepEmMaterialData {
   /** Number of Geant4 material objects (irrespectively if used or not).*/
-  int       fNumG4Material;
+  int       fNumG4Material = 0;
   /** Number of G4HepEmMatData structures in ``G4HepEm`` (only the used G4Material objects are translated).*/
-  int       fNumMaterialData;
+  int       fNumMaterialData = 0;
   /** Array that translates a Geant4 G4Material object index to the correspondig G4HepEmMatData index in the collection below.*/
-  int*      fG4MatIndexToHepEmMatIndex; // [fNumG4Material]
+  int*      fG4MatIndexToHepEmMatIndex = nullptr; // [fNumG4Material]
   /** Collection of G4HepEmMatData structures for all materials used in the current geometry.*/
-  struct G4HepEmMatData* fMaterialData; // [fNumMaterialData]
+  struct G4HepEmMatData* fMaterialData = nullptr; // [fNumMaterialData]
 };
 
 
@@ -92,6 +92,18 @@ struct G4HepEmMaterialData {
   */
 void AllocateMaterialData(struct G4HepEmMaterialData** theMatData, int numG4Mat, int numUsedG4Mat);
 
+/**
+ * Initializes a new @ref G4HepEmMaterialData structure
+ *
+ * This function constructs and returns an instance of G4HepEmMaterialData to hold a given number of indices
+ * to Geant4 materials objects and their corresponding G4HepEmMaterialData instance.
+ * It is the callees responsibility to free the instance using @ref FreeMaterialData.
+ *
+  * @param[in] numG4Mat number of Geant4 material objects
+  * @param[in] numUsedG4Mat number of Geant4 materials objects used in the current geometry.
+  * @return Pointer to instance of @ref G4HepEmMaterialData
+ */
+G4HepEmMaterialData* MakeMaterialData(int numG4Mat, int numUsedG4Mat);
 
 /**
   * Frees a G4HepEmMaterialData structure.

--- a/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
@@ -48,15 +48,15 @@ struct G4HepEmMatData {
   /** The list of number-of-atoms-per-unit-volume for each element this material is composed of.*/
   double*   fNumOfAtomsPerVolumeVect = nullptr; // [fNumOfElement]
   /** The mass density (\f$\rho\f$) of the material in Geant4 internal units. */
-  double    fDensity;
+  double    fDensity = 0.0;
   /** Density correction factor (\f$C_{Mg}\rho_{e^-}\f$) used in the `dielectric suppression`
     * of bremsstrahlung photon emission (\f$C_{Mg}=4\pi r_0 \hbar c/(mc^2)\f$ is the `Migdal constant`
     * and \f$\rho_{e^-}\f$ is the electron density of the material). */
-  double    fDensityCorFactor;
+  double    fDensityCorFactor = 0.0;
   /** Electron density (\f$\rho_{e^-}\f$) of the material in Geant4 internal units.*/
-  double    fElectronDensity;
+  double    fElectronDensity = 0.0;
   /** Radiation length. */
-  double    fRadiationLength;
+  double    fRadiationLength = 0.0;
 };
 
 // Data for all materials used in the current geometry.

--- a/G4HepEm/G4HepEmData/include/G4HepEmSBTableData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmSBTableData.hh
@@ -11,8 +11,8 @@ struct G4HepEmSBTableData {
   const int               fNumElEnergy      = 65; // # e- kine (E_k) per Z
   const int               fNumKappa         = 54; // # red. photon eners per E_k
   // min/max electron kinetic energy usage limits
-  double                  fLogMinElEnergy;
-  double                  fILDeltaElEnergy;
+  double                  fLogMinElEnergy = 0.0;
+  double                  fILDeltaElEnergy = 0.0;
 
   // e- kinetic energy and reduced photon energy grids and tehir logarithms
   double                  fElEnergyVect[65];   // [fNumElEnergy]

--- a/G4HepEm/G4HepEmData/include/G4HepEmSBTableData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmSBTableData.hh
@@ -5,7 +5,6 @@
 
 // tables for sampling energy transfer for the Seltzer-Berger brem model
 
-
 struct G4HepEmSBTableData {
   // pre-prepared sampling tables are available:
   const int               fMaxZet           = 99; // max Z number
@@ -21,15 +20,16 @@ struct G4HepEmSBTableData {
   double                  fKappaVect[54];      // [fNumKappa]
   double                  fLKappaVect[54];     // [fNumKappa]
 
-  int                     fNumHepEmMatCuts;              // #hepEm-MC
-  int                     fNumElemsInMatCuts;            // #elements-in-all-hepEm-MC
-  int*                    fGammaCutIndxStartIndexPerMC;  // [ #hepEm-MC]
-  int*                    fGammaCutIndices;              // for each mat-cut and for each of their elements in the corresponding elemnt SB-table [ #elements-in-all-hepEm-MC]
+  int                     fNumHepEmMatCuts = 0;              // #hepEm-MC
+  int                     fNumElemsInMatCuts = 0;            // #elements-in-all-hepEm-MC
+  int*                    fGammaCutIndxStartIndexPerMC = nullptr;  // [fNumHepEmMatCuts]
+  int*                    fGammaCutIndices = nullptr;              // [fNumElemsInMatCuts]
+                                                                   // for each mat-cut and for each of their elements in the corresponding elemnt SB-table [ #elements-in-all-hepEm-MC]
 
   // data starts index for a given Z
-  int                     fNumSBTableData;         // # all data stored in fSBTableData
+  int                     fNumSBTableData = 0;     // # all data stored in fSBTableData
   int                     fSBTablesStartPerZ[121]; // max Z is 99 so all values above 99 will cast to 99 if any
-  double*                 fSBTableData;            // [fNumSBTableData]
+  double*                 fSBTableData = nullptr;  // [fNumSBTableData]
   // for each Z:
   // - [0] #data
   // - [1] minE-grid index for table
@@ -44,6 +44,10 @@ struct G4HepEmSBTableData {
 
 // Allocates some of the dynamic part of the G4HepEmSBTableData structure (completed and filled in G4HepEmElectronInit)
 void AllocateSBTableData(struct G4HepEmSBTableData** theSBTableData, int numHepEmMatCuts, int numElemsInMC, int numElemsUnique);
+
+// Makes a new instance of G4HepEmSBTableData with the requested sizes for the dynamic components
+G4HepEmSBTableData* MakeSBTableData(int numHepEmMatCuts, int numElemsInMC, int numElemsUnique);
+
 
 // Clears all the dynamic part of the G4HepEmSBTableData structure (filled in G4HepEmElectronInit)
 void FreeSBTableData (struct G4HepEmSBTableData** theSBTableData);

--- a/G4HepEm/G4HepEmData/src/G4HepEmData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmData.cc
@@ -42,6 +42,10 @@ void InitG4HepEmData (struct G4HepEmData* theHepEmData) {
 
 
 void FreeG4HepEmData (struct G4HepEmData* theHepEmData) {
+  if(theHepEmData == nullptr) {
+    return;
+  }
+
   FreeMatCutData   ( &(theHepEmData->fTheMatCutData)   );
   FreeMaterialData ( &(theHepEmData->fTheMaterialData) );
   FreeElementData  ( &(theHepEmData->fTheElementData)  );

--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
@@ -6,61 +6,28 @@
 void AllocateElectronData (struct G4HepEmElectronData** theElectronData) {
   // clean away previous (if any)
   FreeElectronData(theElectronData);
-  *theElectronData   = new G4HepEmElectronData;
-  // eloss
-  (*theElectronData)->fELossEnergyGrid                       = nullptr;
-  (*theElectronData)->fELossData                             = nullptr;
-  // mac-xsec
-  (*theElectronData)->fResMacXSecStartIndexPerMatCut         = nullptr;
-  (*theElectronData)->fResMacXSecData                        = nullptr;
-  // elemen selectors per models:
-  // - Moller-Bhabha ionisation
-  (*theElectronData)->fElemSelectorIoniStartIndexPerMatCut   = nullptr;
-  (*theElectronData)->fElemSelectorIoniData                  = nullptr;
-  // - Seltzer-Berger model for e-/e+ bremsstrahlung
-  (*theElectronData)->fElemSelectorBremSBStartIndexPerMatCut = nullptr;
-  (*theElectronData)->fElemSelectorBremSBData                = nullptr;
-  // - relativistic (improved Bethe-Heitler) model for e-/e+ bremsstrahlung
-  (*theElectronData)->fElemSelectorBremRBStartIndexPerMatCut = nullptr;
-  (*theElectronData)->fElemSelectorBremRBData                = nullptr;
+  *theElectronData = MakeElectronData();
+}
+
+G4HepEmElectronData* MakeElectronData() {
+  // Default construction handles everything we need, but add
+  // additional initialization here if required
+  return new G4HepEmElectronData;
 }
 
 
 void FreeElectronData (struct G4HepEmElectronData** theElectronData)  {
-  if (*theElectronData) {
-    // eloss
-    if ((*theElectronData)->fELossEnergyGrid) {
-      delete[] (*theElectronData)->fELossEnergyGrid;
-    }
-    if ((*theElectronData)->fELossData) {
-      delete[] (*theElectronData)->fELossData;
-    }
-    // mac-xsec
-    if ((*theElectronData)->fResMacXSecData) {
-      delete[] (*theElectronData)->fResMacXSecData;
-    }
-    if ((*theElectronData)->fResMacXSecStartIndexPerMatCut) {
-      delete[] (*theElectronData)->fResMacXSecStartIndexPerMatCut;
-    }
-    // element selectors:
-    if ((*theElectronData)->fElemSelectorIoniStartIndexPerMatCut) {
-      delete[] (*theElectronData)->fElemSelectorIoniStartIndexPerMatCut;
-    }
-    if ((*theElectronData)->fElemSelectorIoniData) {
-      delete[] (*theElectronData)->fElemSelectorIoniData;
-    }
-    if ((*theElectronData)->fElemSelectorBremSBStartIndexPerMatCut) {
-      delete[] (*theElectronData)->fElemSelectorBremSBStartIndexPerMatCut;
-    }
-    if ((*theElectronData)->fElemSelectorBremSBData) {
-      delete[] (*theElectronData)->fElemSelectorBremSBData;
-    }
-    if ((*theElectronData)->fElemSelectorBremRBStartIndexPerMatCut) {
-      delete[] (*theElectronData)->fElemSelectorBremRBStartIndexPerMatCut;
-    }
-    if ((*theElectronData)->fElemSelectorBremRBData) {
-      delete[] (*theElectronData)->fElemSelectorBremRBData;
-    }
+  if (*theElectronData != nullptr) {
+    delete[] (*theElectronData)->fELossEnergyGrid;
+    delete[] (*theElectronData)->fELossData;
+    delete[] (*theElectronData)->fResMacXSecData;
+    delete[] (*theElectronData)->fResMacXSecStartIndexPerMatCut;
+    delete[] (*theElectronData)->fElemSelectorIoniStartIndexPerMatCut;
+    delete[] (*theElectronData)->fElemSelectorIoniData;
+    delete[] (*theElectronData)->fElemSelectorBremSBStartIndexPerMatCut;
+    delete[] (*theElectronData)->fElemSelectorBremSBData;
+    delete[] (*theElectronData)->fElemSelectorBremRBStartIndexPerMatCut;
+    delete[] (*theElectronData)->fElemSelectorBremRBData;
 
     delete *theElectronData;
     *theElectronData = nullptr;

--- a/G4HepEm/G4HepEmData/src/G4HepEmElementData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElementData.cc
@@ -4,22 +4,20 @@
 void AllocateElementData(struct G4HepEmElementData** theElementData) {
   // clean away the previous (if any)
   FreeElementData ( theElementData );
-  *theElementData   = new G4HepEmElementData;
-  int maxZetPlusOne = 121;
-  (*theElementData)->fMaxZet      = maxZetPlusOne-1;
-  (*theElementData)->fElementData = new G4HepEmElemData[maxZetPlusOne];
-  // init the all Z to -1 to indicate that it has not been set
-  for (int ie=0; ie<(*theElementData)->fMaxZet; ++ie) {
-    (*theElementData)->fElementData[ie].fZet = -1.0;
-  }
+  *theElementData = MakeElementData();
 }
 
+G4HepEmElementData* MakeElementData() {
+  auto* p = new G4HepEmElementData;
+  const int maxZetPlusOne = 121;
+  p->fMaxZet      = maxZetPlusOne-1;
+  p->fElementData = new G4HepEmElemData[maxZetPlusOne];
+  return p;
+}
 
 void FreeElementData(struct G4HepEmElementData** theElementData) {
-  if ( *theElementData ) {
-    if ( (*theElementData)->fElementData ) {
-      delete[] (*theElementData)->fElementData;
-    }
+  if ( *theElementData != nullptr ) {
+    delete[] (*theElementData)->fElementData;
     delete *theElementData;
     *theElementData = nullptr;
   }
@@ -31,7 +29,7 @@ void FreeElementData(struct G4HepEmElementData** theElementData) {
 
 void CopyElementDataToGPU(struct G4HepEmElementData* onCPU, struct G4HepEmElementData** onGPU) {
   // clean away previous (if any)
-  if ( *onGPU ) {
+  if ( *onGPU != nullptr) {
     FreeElementDataOnGPU ( onGPU );
   }
   // allocate array of G4HepEmElemData structures on _d (its pointer adress will on _h)
@@ -52,7 +50,7 @@ void CopyElementDataToGPU(struct G4HepEmElementData* onCPU, struct G4HepEmElemen
 }
 
 void FreeElementDataOnGPU ( struct G4HepEmElementData** onGPU ) {
-  if ( *onGPU ) {
+  if ( *onGPU != nullptr ) {
     // copy the struct G4HepEmElementData` struct, including its `struct G4HepEmElemData* fElementData`
     // pointer member, from _d to _h in order to be able to free the _d sice memory
     // pointed by `fElementData` by calling to cudaFree from the host.

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -4,44 +4,23 @@
 void AllocateGammaData (struct G4HepEmGammaData** theGammaData) {
   // clean away previous (if any)
   FreeGammaData(theGammaData);
-  *theGammaData   = new G4HepEmGammaData;
-  // energy grids for conversion and compton
-  (*theGammaData)->fConvEnergyGrid                      = nullptr;
-  (*theGammaData)->fCompEnergyGrid                      = nullptr;
-  // macroscopic cross sections, for conversina and compton, per materials
-  (*theGammaData)->fConvCompMacXsecData                 = nullptr;  // mac-xsec
-  // element selector for conversion (no need for the dummy KN compton)
-  (*theGammaData)->fElemSelectorConvStartIndexPerMat    = nullptr;
-  (*theGammaData)->fElemSelectorConvEgrid               = nullptr;
-  (*theGammaData)->fElemSelectorConvData                = nullptr;
-
+  *theGammaData   = MakeGammaData();
 }
 
+G4HepEmGammaData* MakeGammaData() {
+  // Default construction handles everything we need, but add
+  // additional initialization here if required
+  return new G4HepEmGammaData;
+}
 
 void FreeGammaData (struct G4HepEmGammaData** theGammaData)  {
-  if (*theGammaData) {
-    // energy grids for conversion and compton
-    if ((*theGammaData)->fConvEnergyGrid ) {
-      delete[] (*theGammaData)->fConvEnergyGrid ;
-    }
-    if ((*theGammaData)->fCompEnergyGrid) {
-      delete[] (*theGammaData)->fCompEnergyGrid;
-    }
-    // mac-xsec for conversion and compton
-    if ((*theGammaData)->fConvCompMacXsecData) {
-      delete[] (*theGammaData)->fConvCompMacXsecData;
-    }
-    // element selector for conversion
-    if ((*theGammaData)->fElemSelectorConvStartIndexPerMat) {
-      delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
-    }
-    if ((*theGammaData)->fElemSelectorConvEgrid) {
-      delete[] (*theGammaData)->fElemSelectorConvEgrid;
-    }
-    if ((*theGammaData)->fElemSelectorConvData) {
-      delete[] (*theGammaData)->fElemSelectorConvData;
-    }
-
+  if (*theGammaData != nullptr) {
+    delete[] (*theGammaData)->fConvEnergyGrid ;
+    delete[] (*theGammaData)->fCompEnergyGrid;
+    delete[] (*theGammaData)->fConvCompMacXsecData;
+    delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
+    delete[] (*theGammaData)->fElemSelectorConvEgrid;
+    delete[] (*theGammaData)->fElemSelectorConvData;
     delete *theGammaData;
     *theGammaData = nullptr;
   }

--- a/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cc
@@ -3,37 +3,36 @@
 
 void AllocateSBTableData(struct G4HepEmSBTableData** theSBTableData, int numHepEmMatCuts, int numElemsInMC, int numSBData) {
   FreeSBTableData(theSBTableData);
-  *theSBTableData = new G4HepEmSBTableData;
-  (*theSBTableData)->fNumHepEmMatCuts             = numHepEmMatCuts;
-  (*theSBTableData)->fGammaCutIndxStartIndexPerMC = new int[numHepEmMatCuts];
+  *theSBTableData = MakeSBTableData(numHepEmMatCuts, numElemsInMC, numSBData);
+}
+
+G4HepEmSBTableData* MakeSBTableData(int numHepEmMatCuts, int numElemsInMC, int numSBData) {
+  auto* tmp = new G4HepEmSBTableData;
+
+  tmp->fNumHepEmMatCuts             = numHepEmMatCuts;
+  tmp->fGammaCutIndxStartIndexPerMC = new int[numHepEmMatCuts];
   for (int i=0; i<numHepEmMatCuts; ++i) {
-    (*theSBTableData)->fGammaCutIndxStartIndexPerMC[i] = -1;
+    tmp->fGammaCutIndxStartIndexPerMC[i] = -1;
   }
-  (*theSBTableData)->fNumElemsInMatCuts           = numElemsInMC;
-  (*theSBTableData)->fGammaCutIndices             = new int[numElemsInMC];
+
+  tmp->fNumElemsInMatCuts = numElemsInMC;
+  tmp->fGammaCutIndices   = new int[numElemsInMC];
   for (int i=0; i<numElemsInMC; ++i) {
-    (*theSBTableData)->fGammaCutIndices[i] = -1;
+    tmp->fGammaCutIndices[i] = -1;
   }
-  //
-  (*theSBTableData)->fNumSBTableData              = numSBData;
-  (*theSBTableData)->fSBTableData                 = new double[numSBData];
+
+  tmp->fNumSBTableData = numSBData;
+  tmp->fSBTableData    = new double[numSBData];
+
+  return tmp;
 }
 
 
 void FreeSBTableData(struct G4HepEmSBTableData** theSBTableData) {
   if (*theSBTableData) {
-    if ((*theSBTableData)->fGammaCutIndxStartIndexPerMC) {
-      delete[] (*theSBTableData)->fGammaCutIndxStartIndexPerMC;
-      (*theSBTableData)->fGammaCutIndxStartIndexPerMC = nullptr;
-    }
-    if ((*theSBTableData)->fGammaCutIndices) {
-      delete[] (*theSBTableData)->fGammaCutIndices;
-      (*theSBTableData)->fGammaCutIndices = nullptr;
-    }
-    if ((*theSBTableData)->fSBTableData) {
-      delete[] (*theSBTableData)->fSBTableData;
-      (*theSBTableData)->fSBTableData = nullptr;
-    }
+    delete[] (*theSBTableData)->fGammaCutIndxStartIndexPerMC;
+    delete[] (*theSBTableData)->fGammaCutIndices;
+    delete[] (*theSBTableData)->fSBTableData;
     delete (*theSBTableData);
     *theSBTableData = nullptr;
   }

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -12,12 +12,20 @@ target_link_libraries(TestUtils PUBLIC ${Geant4_LIBRARIES})
 ## ----------------------------------------------------------------------------
 ## 2. Add the unit test applications
 ##
+find_package(GTest QUIET)
+if(GTest_FOUND)
+  add_subdirectory(G4HepEmDataInterfaces)
+else()
+  message(STATUS "Disabling G4HepEmDataInterfaces: GTest not found")
+endif()
+
 add_subdirectory(ElectronEnergyLoss)
 add_subdirectory(ElectronTargetElementSelector)
 add_subdirectory(GammaTargetElementSelector)
 add_subdirectory(ElectronXSections)
 add_subdirectory(GammaXSections)
 add_subdirectory(MaterialAndRelated)
+
 # Data test requires Geant4 GDML, so only add if supported
 if(Geant4_gdml_FOUND)
   add_subdirectory(DataImportExport)

--- a/testing/G4HepEmDataInterfaces/CMakeLists.txt
+++ b/testing/G4HepEmDataInterfaces/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(TestG4HepEmDataInterfaces TestG4HepEmDataInterfaces)
+target_link_libraries(TestG4HepEmDataInterfaces G4HepEm::g4HepEmData GTest::GTest GTest::Main)
+add_test(NAME TestG4HepEmDataInterfaces COMMAND TestG4HepEmDataInterfaces)

--- a/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
+++ b/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
@@ -1,0 +1,265 @@
+#include "G4HepEmElectronData.hh"
+#include "G4HepEmElementData.hh"
+#include "G4HepEmGammaData.hh"
+#include "G4HepEmMatCutData.hh"
+#include "G4HepEmMaterialData.hh"
+#include "G4HepEmSBTableData.hh"
+
+#include "gtest/gtest.h"
+
+// Simple check of a size-dynamic array pair
+// Returns true if:
+// - size is 0, pointer is nullptr
+// - size is >0, pointer is not null
+// Thus only confirms that a pointer exists if size is > 0
+template <typename T>
+bool valid_array(int size, T* data) {
+  if(size == 0 && data == nullptr) {
+    return true;
+  }
+  return (size > 0 && data != nullptr);
+}
+
+// --- G4HepEmElectronData
+void G4HepEmElectronDataTester(G4HepEmElectronData* d) {
+  // Construction/Allocation interfaces only ever default
+  // so we just test that all dynamic memory is null
+  ASSERT_NE(d, nullptr);
+
+  EXPECT_EQ(d->fNumMatCuts, 0);
+  EXPECT_EQ(d->fELossEnergyGridSize, 0);
+  EXPECT_EQ(d->fELossEnergyGrid, nullptr);
+  EXPECT_EQ(d->fELossData, nullptr);
+
+  EXPECT_EQ(d->fResMacXSecNumData, 0);
+  EXPECT_EQ(d->fResMacXSecStartIndexPerMatCut, nullptr);
+  EXPECT_EQ(d->fResMacXSecData, nullptr);
+
+  EXPECT_EQ(d->fElemSelectorIoniNumData, 0);
+  EXPECT_EQ(d->fElemSelectorIoniStartIndexPerMatCut, nullptr);
+  EXPECT_EQ(d->fElemSelectorIoniData, nullptr);
+
+  EXPECT_EQ(d->fElemSelectorBremSBNumData, 0);
+  EXPECT_EQ(d->fElemSelectorBremSBStartIndexPerMatCut, nullptr);
+  EXPECT_EQ(d->fElemSelectorBremSBData, nullptr);
+
+  EXPECT_EQ(d->fElemSelectorBremRBNumData, 0);
+  EXPECT_EQ(d->fElemSelectorBremRBStartIndexPerMatCut, nullptr);
+  EXPECT_EQ(d->fElemSelectorBremRBData, nullptr);
+}
+
+TEST(G4HepEmElectronData, DefaultConstruction) {
+  G4HepEmElectronData d;
+  G4HepEmElectronDataTester(&d);
+}
+
+TEST(G4HepEmElectronData, MakerFunction) {
+  G4HepEmElectronData* d = MakeElectronData();
+  G4HepEmElectronDataTester(d);
+  FreeElectronData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+TEST(G4HepEmElectronData, AllocationInterface) {
+  G4HepEmElectronData* d = nullptr;
+  AllocateElectronData(&d);
+  G4HepEmElectronDataTester(d);
+  FreeElectronData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+// --- G4HepEmElementData
+void G4HepEmElementDataTester(G4HepEmElementData* d) {
+  ASSERT_NE(d, nullptr);
+  EXPECT_NE(d->fMaxZet, 0);
+  ASSERT_NE(d->fElementData, nullptr);
+
+  // Indexing is by Z, so from 1 to fMaxZet, but with
+  // fMaxZet+1 elements!
+  for(int i = 0; i < d->fMaxZet+1 ; ++i) {
+    EXPECT_LT(d->fElementData[i].fZet, 0.0);
+  }
+}
+
+TEST(G4HepEmElementData, DefaultConstruction) {
+  G4HepEmElementData d;
+  EXPECT_EQ(d.fMaxZet, 0);
+  EXPECT_EQ(d.fElementData, nullptr);
+}
+
+TEST(G4HepEmElementData, MakerFunction) {
+  G4HepEmElementData* d = MakeElementData();
+  G4HepEmElementDataTester(d);
+  FreeElementData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+TEST(G4HepEmElementData, AllocationInterface) {
+  G4HepEmElementData* d = nullptr;
+  AllocateElementData(&d);
+  G4HepEmElementDataTester(d);
+  FreeElementData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+// --- G4HepEmGammaData
+void G4HepEmGammaDataTester(G4HepEmGammaData* d) {
+  // Construction/Allocation interfaces only ever default
+  // so we just test that all dynamic memory is null
+  ASSERT_NE(d, nullptr);
+
+  EXPECT_EQ(d->fNumMaterials, 0);
+
+  // Energy grid has a fixed size, but dynamic allocation
+  EXPECT_EQ(d->fConvEnergyGridSize, 147);
+  EXPECT_EQ(d->fConvEnergyGrid, nullptr);
+
+  // Energy grid has a fixed size, but dynamic allocation
+  EXPECT_EQ(d->fCompEnergyGridSize, 85);
+  EXPECT_EQ(d->fCompEnergyGrid, nullptr);
+  EXPECT_EQ(d->fConvCompMacXsecData, nullptr);
+
+  EXPECT_EQ(d->fElemSelectorConvEgridSize, 0);
+  EXPECT_EQ(d->fElemSelectorConvNumData, 0);
+  EXPECT_EQ(d->fElemSelectorConvStartIndexPerMat, nullptr);
+  EXPECT_EQ(d->fElemSelectorConvEgrid, nullptr);
+  EXPECT_EQ(d->fElemSelectorConvData, nullptr);
+}
+
+TEST(G4HepEmGammaData, DefaultConstruction) {
+  G4HepEmGammaData d;
+  G4HepEmGammaDataTester(&d);
+}
+
+TEST(G4HepEmGammaData, MakerFunction) {
+  G4HepEmGammaData* d = MakeGammaData();
+  G4HepEmGammaDataTester(d);
+  FreeGammaData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+TEST(G4HepEmGammaData, AllocationInterface) {
+  G4HepEmGammaData* d = nullptr;
+  AllocateGammaData(&d);
+  G4HepEmGammaDataTester(d);
+  FreeGammaData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+// --- G4HepEmMatCutData
+void G4HepEmMatCutDataTester(G4HepEmMatCutData* d, int expectedG4Cuts, int expectedUsedCuts) {
+  ASSERT_NE(d, nullptr);
+
+  EXPECT_EQ(d->fNumG4MatCuts, expectedG4Cuts);
+  EXPECT_PRED2(valid_array<int>, d->fNumG4MatCuts, d->fG4MCIndexToHepEmMCIndex);
+  EXPECT_EQ(d->fNumMatCutData, expectedUsedCuts);
+  ASSERT_PRED2(valid_array<G4HepEmMCCData>, d->fNumMatCutData, d->fMatCutData);
+
+  for(int i = 0; i < d->fNumMatCutData; ++i) {
+    // Each G4HepEmMCCData element must be default constructed
+    EXPECT_EQ((d->fMatCutData[i]).fHepEmMatIndex, -1);
+    EXPECT_EQ((d->fMatCutData[i]).fG4MatCutIndex, -1);
+  }
+}
+
+TEST(G4HepEmMatCutData, DefaultConstruction) {
+  G4HepEmMatCutData d;
+  G4HepEmMatCutDataTester(&d, 0, 0);
+}
+
+TEST(G4HepEmMatCutData, MakerFunction) {
+  G4HepEmMatCutData* d = MakeMatCutData(3,2);
+  G4HepEmMatCutDataTester(d, 3,2);
+  FreeMatCutData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+TEST(G4HepEmMatCutData, AllocationInterface) {
+  G4HepEmMatCutData* d = nullptr;
+  AllocateMatCutData(&d, 42, 24);
+  G4HepEmMatCutDataTester(d, 42, 24);
+  FreeMatCutData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+// --- G4HepEmMaterialData
+void G4HepEmMatDataTester(const G4HepEmMatData& d) {
+  EXPECT_EQ(d.fG4MatIndex, -1);
+  EXPECT_EQ(d.fNumOfElement, 0);
+  EXPECT_EQ(d.fElementVect, nullptr);
+  EXPECT_EQ(d.fNumOfAtomsPerVolumeVect, nullptr);
+}
+
+
+void G4HepEmMaterialDataTester(G4HepEmMaterialData* d, int expectedNumMat, int expectedUsedMat) {
+  ASSERT_NE(d, nullptr);
+
+  EXPECT_EQ(d->fNumG4Material, expectedNumMat);
+  EXPECT_PRED2(valid_array<int>, d->fNumG4Material, d->fG4MatIndexToHepEmMatIndex);
+  ASSERT_PRED2(valid_array<G4HepEmMatData>, d->fNumMaterialData, d->fMaterialData);
+
+  for(int i = 0; i < d->fNumMaterialData; ++i) {
+    // Each G4HepEmMatData element must be default constructed
+    G4HepEmMatDataTester(d->fMaterialData[i]);
+  }
+}
+
+TEST(G4HepEmMaterialData, DefaultConstruction) {
+  G4HepEmMaterialData d;
+  G4HepEmMaterialDataTester(&d, 0, 0);
+}
+
+TEST(G4HepEmMaterialData, MakerFunction) {
+  G4HepEmMaterialData* d = MakeMaterialData(5,3);
+  G4HepEmMaterialDataTester(d, 5, 3);
+  FreeMaterialData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+TEST(G4HepEmMaterialData, AllocationInterface) {
+  G4HepEmMaterialData* d = nullptr;
+  AllocateMaterialData(&d, 53, 26);
+  G4HepEmMaterialDataTester(d, 53, 26);
+  FreeMaterialData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+
+// --- G4HepEmSBTableData
+void G4HepEmSBTableDataTester(G4HepEmSBTableData* d, int expectedNumCuts, int expectedNumElems, int expectedNumSBElems) {
+  ASSERT_NE(d, nullptr);
+
+  EXPECT_EQ(sizeof(d->fElEnergyVect)/sizeof(*(d->fElEnergyVect)), d->fNumElEnergy);
+  EXPECT_EQ(sizeof(d->fLElEnergyVect)/sizeof(*(d->fLElEnergyVect)), d->fNumElEnergy);
+  EXPECT_EQ(sizeof(d->fKappaVect)/sizeof(*(d->fKappaVect)), d->fNumKappa);
+  EXPECT_EQ(sizeof(d->fLKappaVect)/sizeof(*(d->fLKappaVect)), d->fNumKappa);
+
+  EXPECT_EQ(d->fNumHepEmMatCuts, expectedNumCuts);
+  EXPECT_PRED2(valid_array<int>, d->fNumHepEmMatCuts, d->fGammaCutIndxStartIndexPerMC);
+
+  EXPECT_EQ(d->fNumElemsInMatCuts, expectedNumElems);
+  EXPECT_PRED2(valid_array<int>, d->fNumElemsInMatCuts, d->fGammaCutIndices);
+
+  EXPECT_EQ(d->fNumSBTableData, expectedNumSBElems);
+  EXPECT_PRED2(valid_array<double>, d->fNumSBTableData, d->fSBTableData);
+}
+
+TEST(G4HepEmSBTableData, DefaultConstruction) {
+  G4HepEmSBTableData d;
+  G4HepEmSBTableDataTester(&d, 0, 0, 0);
+}
+
+TEST(G4HepEmSBTableData, MakerFunction) {
+  G4HepEmSBTableData* d = MakeSBTableData(5, 3, 5);
+  G4HepEmSBTableDataTester(d, 5, 3, 5);
+  FreeSBTableData(&d);
+  ASSERT_EQ(d, nullptr);
+}
+
+TEST(G4HepEmSBTableData, AllocationInterface) {
+  G4HepEmSBTableData* d = nullptr;
+  AllocateSBTableData(&d, 53, 26, 42);
+  G4HepEmSBTableDataTester(d, 53, 26, 42);
+  FreeSBTableData(&d);
+  ASSERT_EQ(d, nullptr);
+}


### PR DESCRIPTION
This is a Draft/WIP PR to add a few simplifications to init/allocation of the G4HepEmData `struct`s. These have come up through the work on (de)serialising these data (to/from JSON using nlohmann_json), but I think will be of use more broadly for working with these structures, hence a separate PR. Marked as Draft and so not for merge yet so @mnovak42 can check the initial working (@hahnjo your input is also welcome!) before I go further.

To that end I've just implemented things for the lowest level `G4HepEmElementData` struct as this nicely illustrates the updates in a simple way, which are:

* Use in-struct initialization of the `fZet` data member of `G4HepEmElemData` to save the loop over the array in `AllocateElementData`.
  * I haven't intialized any other data members for now, as only the above is used to mark "default-ness/unitialized" as far as I can tell.
* Add new `MakeElementData` function that allocates and returns an default constructed instance of G4HepEmElementData on the heap. This saves the _slightly_ awkward case of needed a new instance (e.g. in the serialisation case) and having to do

  ```c++
  G4HepEmElementData* p = nullptr;
  AllocateElementData(&p);
  ```

  whilst with the new function this is just

  ```c++
  G4HepEmElementData* p = MakeElementData();
  ```

These the major changes, and can also be applied pretty easily for the other structs in `G4HepEmData`. I've also added a simple test case that just confirms correct alloc/dealloc of the memory and defaults - the filling of this memory is of course left to `G4HepEmInit`.

Let me know if this pattern looks reasonable and I'll go ahead and implement this for the remainder.