### PR TITLE
Update values of the unused dynamic array pointers of the target element selectors.

### DIFF
--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
@@ -114,24 +114,30 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
   // allocate memory for Ionisation related data on the _d and copy form _h
   const int numIoniData = onHOST->fElemSelectorIoniNumData;
   elDataHTo_d->fElemSelectorIoniNumData = numIoniData;
-  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorIoniStartIndexPerMatCut), sizeof( int )    * numHepEmMatCuts ) );
-  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorIoniData),                sizeof( double ) * numIoniData     ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorIoniStartIndexPerMatCut,  onHOST->fElemSelectorIoniStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorIoniData,                 onHOST->fElemSelectorIoniData,                sizeof( double ) * numIoniData,     cudaMemcpyHostToDevice ) );
+  if (numIoniData > 0) {
+    gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorIoniStartIndexPerMatCut), sizeof( int )    * numHepEmMatCuts ) );
+    gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorIoniData),                sizeof( double ) * numIoniData     ) );
+    gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorIoniStartIndexPerMatCut,  onHOST->fElemSelectorIoniStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
+    gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorIoniData,                 onHOST->fElemSelectorIoniData,                sizeof( double ) * numIoniData,     cudaMemcpyHostToDevice ) );
+  }
   // the same for SB brem
   const int numBremSBData = onHOST->fElemSelectorBremSBNumData;
   elDataHTo_d->fElemSelectorBremSBNumData = numBremSBData;
-  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremSBStartIndexPerMatCut), sizeof( int )    * numHepEmMatCuts ) );
-  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremSBData),                sizeof( double ) * numBremSBData   ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremSBStartIndexPerMatCut,  onHOST->fElemSelectorBremSBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremSBData,                 onHOST->fElemSelectorBremSBData,                sizeof( double ) * numBremSBData,   cudaMemcpyHostToDevice ) );
+  if (numBremSBData > 0) {
+    gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremSBStartIndexPerMatCut), sizeof( int )    * numHepEmMatCuts ) );
+    gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremSBData),                sizeof( double ) * numBremSBData   ) );
+    gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremSBStartIndexPerMatCut,  onHOST->fElemSelectorBremSBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
+    gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremSBData,                 onHOST->fElemSelectorBremSBData,                sizeof( double ) * numBremSBData,   cudaMemcpyHostToDevice ) );
+  }
   // the same for RB brem
   const int numBremRBData = onHOST->fElemSelectorBremRBNumData;
   elDataHTo_d->fElemSelectorBremRBNumData = numBremRBData;
-  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut), sizeof( int )    * numHepEmMatCuts ) );
-  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremRBData),                sizeof( double ) * numBremRBData   ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut,  onHOST->fElemSelectorBremRBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBData,                 onHOST->fElemSelectorBremRBData,                sizeof( double ) * numBremRBData,   cudaMemcpyHostToDevice ) );
+  if (numBremRBData > 0) {
+    gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut), sizeof( int )    * numHepEmMatCuts ) );
+    gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremRBData),                sizeof( double ) * numBremRBData   ) );
+    gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut,  onHOST->fElemSelectorBremRBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
+    gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBData,                 onHOST->fElemSelectorBremRBData,                sizeof( double ) * numBremRBData,   cudaMemcpyHostToDevice ) );
+  }
   //
   // Finaly copy the top level, i.e. the main struct with the already
   // appropriate pointers to device side memory locations but stored on the host

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -86,16 +86,18 @@ void CopyGammaDataToDevice(struct G4HepEmGammaData* onHOST, struct G4HepEmGammaD
   // -- go for the conversion element selector related data
   int numElSelE   = onHOST->fElemSelectorConvEgridSize;
   int numElSelDat = onHOST->fElemSelectorConvNumData;
-  gmDataHTo_d->fElemSelectorConvEgridSize   = numElSelE;
-  gmDataHTo_d->fElemSelectorConvNumData     = numElSelDat;
-  gmDataHTo_d->fElemSelectorConvLogMinEkin  = onHOST->fElemSelectorConvLogMinEkin;
-  gmDataHTo_d->fElemSelectorConvEILDelta    = onHOST->fElemSelectorConvEILDelta;
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvStartIndexPerMat), sizeof( int ) * numHepEmMat ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvStartIndexPerMat,  onHOST->fElemSelectorConvStartIndexPerMat, sizeof( int ) * numHepEmMat, cudaMemcpyHostToDevice ) );
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvEgrid), sizeof( double ) * numElSelE ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvEgrid,  onHOST->fElemSelectorConvEgrid, sizeof( double ) * numElSelE,   cudaMemcpyHostToDevice ) );
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvData),  sizeof( double ) * numElSelDat ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvData,   onHOST->fElemSelectorConvData,  sizeof( double ) * numElSelDat, cudaMemcpyHostToDevice ) );
+  if (numElSelDat > 0) {
+    gmDataHTo_d->fElemSelectorConvEgridSize   = numElSelE;
+    gmDataHTo_d->fElemSelectorConvNumData     = numElSelDat;
+    gmDataHTo_d->fElemSelectorConvLogMinEkin  = onHOST->fElemSelectorConvLogMinEkin;
+    gmDataHTo_d->fElemSelectorConvEILDelta    = onHOST->fElemSelectorConvEILDelta;
+    gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvStartIndexPerMat), sizeof( int ) * numHepEmMat ) );
+    gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvStartIndexPerMat,  onHOST->fElemSelectorConvStartIndexPerMat, sizeof( int ) * numHepEmMat, cudaMemcpyHostToDevice ) );
+    gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvEgrid), sizeof( double ) * numElSelE ) );
+    gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvEgrid,  onHOST->fElemSelectorConvEgrid, sizeof( double ) * numElSelE,   cudaMemcpyHostToDevice ) );
+    gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvData),  sizeof( double ) * numElSelDat ) );
+    gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvData,   onHOST->fElemSelectorConvData,  sizeof( double ) * numElSelDat, cudaMemcpyHostToDevice ) );
+  }
   //
   // Finaly copy the top level, i.e. the main struct with the already
   // appropriate pointers to device side memory locations but stored on the host

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -473,19 +473,27 @@ void BuildElementSelectorTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerMod
 
   // write data to the final destination and clean all dynamically allocated auxilary memory
   elData->fElemSelectorIoniNumData = indxContIoni;
-  elData->fElemSelectorIoniData    = new double[indxContIoni];
-  for (int i=0; i<indxContIoni; ++i) {
-    elData->fElemSelectorIoniData[i] = ioniData[i];
+  if (indxContIoni > 0) {
+    elData->fElemSelectorIoniData    = new double[indxContIoni];
+    for (int i=0; i<indxContIoni; ++i) {
+      elData->fElemSelectorIoniData[i] = ioniData[i];
+    }
   }
+
   elData->fElemSelectorBremSBNumData = indxContBremSB;
-  elData->fElemSelectorBremSBData    = new double[indxContBremSB];
-  for (int i=0; i<indxContBremSB; ++i) {
-    elData->fElemSelectorBremSBData[i] = bremSBData[i];
+  if (indxContBremSB > 0) {
+    elData->fElemSelectorBremSBData    = new double[indxContBremSB];
+    for (int i=0; i<indxContBremSB; ++i) {
+      elData->fElemSelectorBremSBData[i] = bremSBData[i];
+    }
   }
+
   elData->fElemSelectorBremRBNumData = indxContBremRB;
-  elData->fElemSelectorBremRBData    = new double[indxContBremRB];
-  for (int i=0; i<indxContBremRB; ++i) {
-    elData->fElemSelectorBremRBData[i] = bremRBData[i];
+  if (indxContBremRB > 0) {
+    elData->fElemSelectorBremRBData    = new double[indxContBremRB];
+    for (int i=0; i<indxContBremRB; ++i) {
+      elData->fElemSelectorBremRBData[i] = bremRBData[i];
+    }
   }
 
   delete[] ioniData;
@@ -585,7 +593,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     int izST = std::min(iz, sbTables->fMaxZet);
     // and construct the HepEm-SB-sampling tables for each
     const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);
-    if (!stPerZ) {
+    if (stPerZ == nullptr) {
       std::cout << " *** No SB-STable for iz = " << iz << ": gcut probably above max-model-energy of 1 GeV " << std::endl;
       continue;
     }
@@ -642,7 +650,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     int izST = std::min(iz,sbTables->fMaxZet);
     // and construct the HepEm-SB-sampling tables for each
     const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);
-    if (!stPerZ) {
+    if (stPerZ == nullptr) {
       continue;
     }
     // Construct the HepEm-Samplng-tables for this Z:
@@ -685,7 +693,7 @@ void BuildSBBremSTables(struct G4HepEmData* hepEmData, struct G4HepEmParameters*
     for (int ie=0; ie<numElems; ++ie) {
       int izST = std::min(elemVect[ie], sbTables->fMaxZet);
       const G4HepEmSBBremTableBuilder::SamplingTablePerZ* stPerZ = sbTables->GetSamplingTablesForZ(izST);
-      if (!stPerZ) {
+      if (stPerZ == nullptr) {
         continue;
       }
       // get the index of the gamma-cut in this element that corresponds to this mat-cut

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -148,9 +148,6 @@ void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepE
   int numConvEkin = (int)(G4EmParameters::Instance()->NumberOfBinsPerDecade()*std::log(emax/emin)*invlog106);
   gmData->fElemSelectorConvEgridSize = numConvEkin;
   // allocate array for the kinetic energy grid
-  if (gmData->fElemSelectorConvEgrid) {
-    delete[] gmData->fElemSelectorConvEgrid;
-  }
   gmData->fElemSelectorConvEgrid = new double[numConvEkin];
   double lemin = std::log(emin);
   double delta = std::log(emax/emin)/(numConvEkin-1.0);
@@ -179,13 +176,15 @@ void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepE
     if (numElem>1) {
       // should be numElem-1 but for each material 1 extra is #elements that is the first elem
       num += numElem;
+    } else {
+      gmData->fElemSelectorConvStartIndexPerMat[im] = -1;
     }
   }
   // allocate memory:
   int size = num*numConvEkin;
   gmData->fElemSelectorConvNumData = size;
-  if (gmData->fElemSelectorConvData) {
-    delete gmData->fElemSelectorConvData;
+  if (size == 0) {
+    return;
   }
   gmData->fElemSelectorConvData = new double[size];
   G4VEmModel* emModel = ppModel;
@@ -193,8 +192,9 @@ void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepE
   for (int im=0; im<numHepEmMatData; ++im) {
     const struct G4HepEmMatData& matData = hepEmMatData->fMaterialData[im];
     int numElem = matData.fNumOfElement;
-    if (numElem<2) {
-      gmData->fElemSelectorConvStartIndexPerMat[im] = -1;
+    if (numElem < 2) {
+//      gmData->fElemSelectorConvStartIndexPerMat[im] = -1;
+      continue;
     }
     gmData->fElemSelectorConvStartIndexPerMat[im] = indxCont;
     gmData->fElemSelectorConvData[indxCont++]     = numElem;


### PR DESCRIPTION
When a target element selector data is not necessary just leave the corresponding dynamic array data pointer to be `nullptr` (and the corresponding number-of-data is equal to 0). See more at the discussion of #41. 