### PR TITLE
Implement G4HepEmState struct to associate parameters and data

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
@@ -10,46 +10,46 @@
  *
  * @brief Physics configuration related parameters.
  *
- * Collection of physics modelling related configuration parameters used in 
+ * Collection of physics modelling related configuration parameters used in
  * ``G4HepEm`` at initialization- and run-time.
  *
  * A single instance of this structure is created and stored in the `master`
  * G4HepEmRunManager when its InitializeGlobal() method is invoked by calling
  * the InitHepEmParameters() function declared in the G4HepEmParamatersInit
- * header file. This method extracts information (mainly) from the G4EmParameters 
+ * header file. This method extracts information (mainly) from the G4EmParameters
  * singletone object.
  */
- 
-struct G4HepEmParameters { 
-  /** \f$e^-/e^+\f$ tracking (kinetic) energy cut in Geant4 internal energy units: 
-    * \f$e^-/e^+\f$ tracks are stopped when their energy drops below this threshold, 
+
+struct G4HepEmParameters {
+  /** \f$e^-/e^+\f$ tracking (kinetic) energy cut in Geant4 internal energy units:
+    * \f$e^-/e^+\f$ tracks are stopped when their energy drops below this threshold,
     * their kinetic energy is deposited and annihilation to two \f$\gamma\f$-s interaction
     * is invoked for in case of \f$e^+\f$.*/
   double fElectronTrackingCut;
-  
+
   // The configuration of the kinetic energy grid of the energy loss related tables:
-  /** Minimum of the kinetic energy grid used to build the sub-(secondary-production)threshold 
-    * related energy loss quantity tables such as the *restricted stopping power*, *range* and 
+  /** Minimum of the kinetic energy grid used to build the sub-(secondary-production)threshold
+    * related energy loss quantity tables such as the *restricted stopping power*, *range* and
     * *inverse range* tables. */
   double fMinLossTableEnergy;
-  /** Maximum of the kinetic energy grid for loss tables.*/ 
+  /** Maximum of the kinetic energy grid for loss tables.*/
   double fMaxLossTableEnergy;
   /** Number of bins (equally spaced on log scale) of the loss table kinetic energy grid. */
   int    fNumLossTableBins;
-  
+
   /** The *final range* parameter of the sub-threshold energy loss related step limit function.*/
   double fFinalRange;
   /** The *rover range* parameter of the sub-threshold energy loss related step limit function.*/
   double fDRoverRange;
-  /** Maximum allowed *linear* energy loss along step due to sub-threshold (continuous) energy losses 
-    * given as fraction of the intial kinetic energy. Proper integral is used to compute the mean energy loss 
+  /** Maximum allowed *linear* energy loss along step due to sub-threshold (continuous) energy losses
+    * given as fraction of the intial kinetic energy. Proper integral is used to compute the mean energy loss
     * when the energy loss, according to linear approximation, is over this threshold.*/
   double fLinELossLimit;
-  
+
   /** Kinetic energy limit between the two (Seltzer-Berger and Relativistic) models for bremsstrahlung photon emission
     * in case of \f$e^-/e^+\f$ primary particles.*/
   double fElectronBremModelLim;
-  
+
 };
 
 #endif // G4HepEmParameters_HH

--- a/G4HepEm/G4HepEmData/include/G4HepEmState.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmState.hh
@@ -1,0 +1,24 @@
+#ifndef G4HepEmState_HH
+#define G4HepEmState_HH
+
+struct G4HepEmData;
+struct G4HepEmParameters;
+
+/**
+ * @file    G4HepEmState.hh
+ * @struct  G4HepEmState
+ * Non-owning view of a `G4HepEmData` and corresponding `G4HepEmParameters` instance.
+ *
+ * `G4HepEmRun` often requires parameters and data to be passed to its functions. The
+ * `G4HepEmState` struct provides a simple aggregate of pointers to each instance for
+ * convenience in handling.
+ *
+ * The pointers are not owned so it is up to the client to allocate and free these,
+ * or copy/delete from the device as appropriate.
+**/
+struct G4HepEmState {
+  struct G4HepEmParameters* fParameters = nullptr; //< Pointer to `G4HepEmParameters` used by `G4HepEmData` (not owned)
+  struct G4HepEmData* fData = nullptr; //< Pointer to `G4HepEmData` (not owned)
+};
+
+#endif  // G4HepEmState_HH

--- a/G4HepEm/G4HepEmDataJsonIO/include/G4HepEmDataJsonIO.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/include/G4HepEmDataJsonIO.hh
@@ -3,7 +3,9 @@
 
 #include <iosfwd>
 
+class G4HepEmParameters;
 class G4HepEmData;
+class G4HepEmState;
 
 /**
  * @file    G4HepEmDataJsonIO.hh
@@ -12,6 +14,28 @@ class G4HepEmData;
  *
  * @brief Functions to (de)serialize ``G4HepEMData`` data structures to/from JSON
  */
+
+/**
+ * Write a ``G4HepEmParameters` object to an output stream as JSON text
+ *
+ * @param[in,out] os output stream to serialize to
+ * @param[in] params ``G4HepEmParameters to serialize
+ *
+ * @pre params must not be nullptr
+ *
+ * @return true if the serialization completed correctly
+ */
+bool G4HepEmParametersToJson(std::ostream& os, const G4HepEmParameters* params);
+
+/**
+ * Create a new ``G4HepEmParameters`` instance from an input stream of JSON data
+ *
+ * @param[in] is input stream to read data from
+ * @return pointer to newly constructed ``G4HepEmParameters`` instance
+ *
+ * @post return value is ``nullptr`` if the data could not be read correctly
+ */
+G4HepEmParameters* G4HepEmParametersFromJson(std::istream& is);
 
 /**
  * Write a ``G4HepEmData`` object to an output stream as JSON text
@@ -26,7 +50,7 @@ class G4HepEmData;
 bool G4HepEmDataToJson(std::ostream& os, const G4HepEmData* data);
 
 /**
- * Create a new ``G4HepEMData`` instance from an input stream of JSON data
+ * Create a new ``G4HepEmData`` instance from an input stream of JSON data
  *
  * @param[in] is input stream to read data from
  *
@@ -35,5 +59,30 @@ bool G4HepEmDataToJson(std::ostream& os, const G4HepEmData* data);
  * @post return value is ``nullptr`` if the data could not be read correctly
  */
 G4HepEmData* G4HepEmDataFromJson(std::istream& is);
+
+/**
+ * Write a ``G4HepEmState`` object to an output stream as JSON text
+ *
+ * @param[in,out] os output stream to serialize to
+ * @param[in] data ``G4HepEmState`` to serialize
+ *
+ * @pre data must not be nullptr
+ *
+ * @return true if the serialization completed correctly
+ */
+bool G4HepEmStateToJson(std::ostream& os, const G4HepEmState* data);
+
+/**
+ * Create a new ``G4HepEmState`` instance from an input stream of JSON data
+ *
+ * @param[in] is input stream to read data from
+ *
+ * @return pointer to newly constructed ``G4HepEMState`` instance
+ *
+ * @post return value is ``nullptr`` if the data could not be read correctly
+ */
+G4HepEmState* G4HepEmStateFromJson(std::istream& is);
+
+
 
 #endif // G4HepEmDataDataJsonIO_HH

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIO.cc
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIO.cc
@@ -4,6 +4,25 @@
 
 #include <iostream>
 
+// Serialize parameters to os, return true if successful, false otherwise
+bool G4HepEmParametersToJson(std::ostream& os, const G4HepEmParameters* data) {
+  json jout;
+  // Pointers need more work in adl_serializer to cope with both
+  // const and non-const pointers. We take, for now, the dumb way, which
+  // is to call the adl_serializer _directly_ (rather than just `json j = data`)
+  nlohmann::adl_serializer<G4HepEmParameters*>::to_json(jout, data);
+  os << jout;
+  return true;
+}
+
+// Deserialize data from is, return new instance if successful, nullptr otherwise
+G4HepEmParameters* G4HepEmParametersFromJson(std::istream& is) {
+  json jin;
+  is >> jin;
+  G4HepEmParameters* inData = jin.get<G4HepEmParameters*>();
+  return inData;
+}
+
 // Serialize data to os, return true if successful, false otherwise
 bool G4HepEmDataToJson(std::ostream& os, const G4HepEmData* data) {
   json jout;
@@ -20,5 +39,24 @@ G4HepEmData* G4HepEmDataFromJson(std::istream& is) {
   json jin;
   is >> jin;
   G4HepEmData* inData = jin.get<G4HepEmData*>();
+  return inData;
+}
+
+// Serialize data to os, return true if successful, false otherwise
+bool G4HepEmStateToJson(std::ostream& os, const G4HepEmState* data) {
+  json jout;
+  // Pointers need more work in adl_serializer to cope with both
+  // const and non-const pointers. We take, for now, the dumb way, which
+  // is to call the adl_serializer _directly_ (rather than just `json j = data`)
+  nlohmann::adl_serializer<G4HepEmState*>::to_json(jout, data);
+  os << jout;
+  return true;
+}
+
+// Deserialize data from is, return new instance if successful, nullptr otherwise
+G4HepEmState* G4HepEmStateFromJson(std::istream& is) {
+  json jin;
+  is >> jin;
+  G4HepEmState* inData = jin.get<G4HepEmState*>();
   return inData;
 }

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -3,6 +3,7 @@
 
 #include <exception>
 
+#include "G4HepEmParameters.hh"
 #include "G4HepEmData.hh"
 #include "G4HepEmMatCutData.hh"
 #include "G4HepEmElementData.hh"
@@ -10,6 +11,7 @@
 #include "G4HepEmElectronData.hh"
 #include "G4HepEmSBTableData.hh"
 #include "G4HepEmGammaData.hh"
+#include "G4HepEmState.hh"
 
 #include "nlohmann/json.hpp"
 
@@ -43,8 +45,9 @@ struct dynamic_array
 template <typename T>
 dynamic_array<T> make_array(int n)
 {
-  if (n == 0) {
-    return {0, nullptr};
+  if(n == 0)
+  {
+    return { 0, nullptr };
   }
   return { n, new T[n] };
 }
@@ -109,6 +112,61 @@ namespace nlohmann
       auto d = make_array<T>(j.size());
       std::copy(j.begin(), j.end(), d.begin());
       return d;
+    }
+  };
+}  // namespace nlohmann
+
+// ===========================================================================
+// --- G4HepEmParameters
+namespace nlohmann
+{
+  // We *can* have direct to/from_json functions for G4HepEmParameters
+  // as it is simple. Use of adl_serializer is *purely* for consistency
+  // with other structures!
+  // We only support pointers as that's the form G4HepEmData expects
+  template <>
+  struct adl_serializer<G4HepEmParameters*>
+  {
+    static void to_json(json& j, const G4HepEmParameters* d)
+    {
+      if(d == nullptr)
+      {
+        j = nullptr;
+      }
+      else
+      {
+        j["fElectronTrackingCut"]  = d->fElectronTrackingCut;
+        j["fMinLossTableEnergy"]   = d->fMinLossTableEnergy;
+        j["fMaxLossTableEnergy"]   = d->fMaxLossTableEnergy;
+        j["fNumLossTableBins"]     = d->fNumLossTableBins;
+        j["fFinalRange"]           = d->fFinalRange;
+        j["fDRoverRange"]          = d->fDRoverRange;
+        j["fLinELossLimit"]        = d->fLinELossLimit;
+        j["fElectronBremModelLim"] = d->fElectronBremModelLim;
+      }
+    }
+
+    static G4HepEmParameters* from_json(const json& j)
+    {
+      if(j.is_null())
+      {
+        return nullptr;
+      }
+      else
+      {
+        auto* d = new G4HepEmParameters;
+
+        d->fElectronTrackingCut  = j.at("fElectronTrackingCut").get<double>();
+        d->fMinLossTableEnergy   = j.at("fMinLossTableEnergy").get<double>();
+        d->fMaxLossTableEnergy   = j.at("fMaxLossTableEnergy").get<double>();
+        d->fNumLossTableBins     = j.at("fNumLossTableBins").get<int>();
+        d->fFinalRange           = j.at("fFinalRange").get<double>();
+        d->fDRoverRange          = j.at("fDRoverRange").get<double>();
+        d->fLinELossLimit        = j.at("fLinELossLimit").get<double>();
+        d->fElectronBremModelLim = j.at("fElectronBremModelLim").get<double>();
+
+        return d;
+      }
     }
   };
 }  // namespace nlohmann
@@ -743,6 +801,42 @@ namespace nlohmann
           j.at("fThePositronData").get<G4HepEmElectronData*>();
         d->fTheSBTableData = j.at("fTheSBTableData").get<G4HepEmSBTableData*>();
         d->fTheGammaData   = j.at("fTheGammaData").get<G4HepEmGammaData*>();
+        return d;
+      }
+    }
+  };
+}  // namespace nlohmann
+
+// --- G4HepEmState
+namespace nlohmann
+{
+  template <>
+  struct adl_serializer<G4HepEmState*>
+  {
+    static void to_json(json& j, const G4HepEmState* d)
+    {
+      if(d == nullptr)
+      {
+        j = nullptr;
+      }
+      else
+      {
+        j["fParameters"] = d->fParameters;
+        j["fData"]       = d->fData;
+      }
+    }
+
+    static G4HepEmState* from_json(const json& j)
+    {
+      if(j.is_null())
+      {
+        return nullptr;
+      }
+      else
+      {
+        G4HepEmState* d = new G4HepEmState;
+        d->fParameters  = j.at("fParameters").get<G4HepEmParameters*>();
+        d->fData        = j.at("fData").get<G4HepEmData*>();
         return d;
       }
     }


### PR DESCRIPTION
Many G4HepEmRun functions take both G4HepEmData and G4HepEmParameters for their calculations. Clients serializing data will also need to store the parameters with the data for consistency when using the deserialized data.

Add new G4HepEmState struct that is a simple association between pointers to a G4HepEmData instance and a corresponding G4HepEmParameters instance. This is implemented as a simple view of these pointers, and no (de)allocation
is performed or implemented.

Add JSON (de)serialization functions for G4HepEmParameters and G4HepEmState.

Update DataImportExport test to roundtrip G4HepEmState and the held parameters and data.

Fixes: #45 