### PR TITLE
Provide InitG4HepEmState function for direct initialization of parameters and data

### DIFF
--- a/G4HepEm/G4HepEmInit/include/G4HepEmStateInit.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmStateInit.hh
@@ -1,0 +1,30 @@
+#ifndef G4HepEmStateInit_HH
+#define G4HepEmStateInit_HH
+
+struct G4HepEmState;
+
+/**
+ * @file    G4HepEmStateInit.hh
+ * @author  B. Morgan
+ * @date    2021
+ *
+ * @brief Function to initialize ``G4HepEmState`` data structure and members
+ */
+
+/**
+ * Initialize a G4HepEmState struct with parameters and data from Geant4
+ *
+ * The input struct's pointers will be set to the newly initialized `G4HepEmParameters`
+ * and `G4HepEmData` instances. These will be constructed using the underlying
+ * parameters and data from Geant4.
+ *
+ * Any existing data held by the input struct will not be freed
+ *
+ * @param[in,out] hepEmState pointer to G4HepEmState struct to initialize
+ *
+ * @pre Underlying Geant4 data required by G4HepEm must be initialized
+ *
+ */
+void InitG4HepEmState(struct G4HepEmState* hepEmState);
+
+#endif // G4HepEmStateInit_HH

--- a/G4HepEm/G4HepEmInit/src/G4HepEmStateInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmStateInit.cc
@@ -1,0 +1,29 @@
+#include "G4HepEmStateInit.hh"
+
+#include "G4HepEmState.hh"
+#include "G4HepEmParameters.hh"
+#include "G4HepEmData.hh"
+
+#include "G4HepEmParametersInit.hh"
+#include "G4HepEmMaterialInit.hh"
+#include "G4HepEmElectronInit.hh"
+#include "G4HepEmGammaInit.hh"
+
+void InitG4HepEmState(struct G4HepEmState* hepEmState)
+{
+  // Initialize parameters
+  hepEmState->fParameters = new G4HepEmParameters;
+  InitHepEmParameters(hepEmState->fParameters);
+
+  // Initialize data and fill each subtable using its initialize function
+  hepEmState->fData = new G4HepEmData;
+  InitG4HepEmData(hepEmState->fData);
+
+  InitMaterialAndCoupleData(hepEmState->fData, hepEmState->fParameters);
+
+  // electrons, positrons
+  InitElectronData(hepEmState->fData, hepEmState->fParameters, true);
+  InitElectronData(hepEmState->fData, hepEmState->fParameters, false);
+
+  InitGammaData(hepEmState->fData, hepEmState->fParameters);
+}

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -2,6 +2,7 @@
 ## 1. TestUtils helper library
 ##
 add_library(TestUtils STATIC
+  TestUtils/G4HepEmDataComparison.hh
   TestUtils/G4SetUp.hh
   TestUtils/G4SetUp.cc
   TestUtils/Hist.hh)
@@ -26,6 +27,7 @@ add_subdirectory(ElectronXSections)
 add_subdirectory(GammaXSections)
 add_subdirectory(MaterialAndRelated)
 add_subdirectory(DataImportExport)
+add_subdirectory(DataInitialization)
 
 ## ----------------------------------------------------------------------------
 ## 3. Add the developer-only test applications

--- a/testing/DataImportExport/TestDataImportExport.cc
+++ b/testing/DataImportExport/TestDataImportExport.cc
@@ -1,9 +1,9 @@
 // local (and TestUtils) includes
 #include "TestUtils/G4SetUp.hh"
+#include "TestUtils/G4HepEmDataComparison.hh"
 #include "SimpleFakeG4Setup.h"
 
 #include "G4HepEmDataJsonIO.hh"
-#include "G4HepEmDataComparison.h"
 
 // G4 includes
 #include "globals.hh"

--- a/testing/DataInitialization/CMakeLists.txt
+++ b/testing/DataInitialization/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(TestG4HepEmInit TestG4HepEmInit.cc)
+target_link_libraries(TestG4HepEmInit G4HepEm::g4HepEm TestUtils)
+add_test(NAME TestG4HepEmInit COMMAND TestG4HepEmInit)

--- a/testing/DataInitialization/Readme.md
+++ b/testing/DataInitialization/Readme.md
@@ -1,0 +1,8 @@
+# Testing initialization via G4HepEm and G4HepEmInit
+
+G4HepEm's data structures (`G4HepEmParameters`, `G4HepEmData` and members) can be
+initialized using the functions declared in `G4HepEmInit`. These are also called
+by G4HepEm's `G4HepEmRunManager.hh` for use in CPU Geant4.
+
+This test confirms that the data structures constructed by both methods are numerically
+identical.

--- a/testing/DataInitialization/TestG4HepEmInit.cc
+++ b/testing/DataInitialization/TestG4HepEmInit.cc
@@ -1,0 +1,91 @@
+// local (and TestUtils) includes
+#include "TestUtils/G4SetUp.hh"
+#include "TestUtils/G4HepEmDataComparison.hh"
+
+// G4 includes
+#include "globals.hh"
+#include "G4SystemOfUnits.hh"
+#include "Randomize.hh"
+
+// G4HepEm includes
+#include "G4HepEmRunManager.hh"
+#include "G4HepEmCLHEPRandomEngine.hh"
+#include "G4HepEmStateInit.hh"
+#include "G4HepEmState.hh"
+#include "G4HepEmParameters.hh"
+#include "G4HepEmData.hh"
+
+int main() {
+  // --- Set up a fake G4 geometry with including all pre-defined NIST materials
+  //     to produce the G4MaterialCutsCouple objects.
+  //
+  // secondary production threshold in length
+  const G4double secProdThreshold = 0.7*mm;
+  FakeG4Setup (secProdThreshold, true);
+
+  //
+  // --- Initialise the `global` data structures of G4HepEm:
+  //     - the `global`-s are the G4HepEmParameters, G4HepEmMatCutData, G4HepEmMaterialData,
+  //       and G4HepEmElementData members of the G4HepEmData, top level data structure member
+  //       of the `master` G4HepEmRunManager
+  //     - these above data structures are constructed and initialised in the G4HepEmRunManager::InitializeGlobal()
+  //       method, that is invoked when the `master` G4HepEmRunManager::Initialize() method is invoked
+  //       first time (i.e. for the first particle)
+  //     - this should be done after the Geant4 geometry is already initialized, since data will be
+  //       extracted from the already initialized Geant4 obejcts such as G4ProductionCutsTable
+  //
+  //     Therefore, here we create a `master` G4HepEmRunManager and call its Initialize()
+  //     method for e- (could be any of e-: 0; e+: 1; or gamma: 2).
+  G4HepEmRunManager* runMgr = new G4HepEmRunManager ( true );
+  runMgr->Initialize ( new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine()), 0 );
+  runMgr->Initialize ( new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine()), 1 );
+  runMgr->Initialize ( new G4HepEmCLHEPRandomEngine(G4Random::getTheEngine()), 2 );
+
+  G4HepEmParameters* rmParams = runMgr->GetHepEmParameters();
+  G4HepEmData* rmData = runMgr->GetHepEmData();
+
+  if(rmParams == nullptr)
+  {
+    std::cerr << "Failed to create G4HepEmParameters from G4HepEmRunManager" << std::endl;
+    return 1;
+  }
+  if(rmData == nullptr)
+  {
+    std::cerr << "Failed to create G4HepEmData from G4HepEmRunManager" << std::endl;
+    return 1;
+  }
+
+  // Now via G4HepEmInit
+  G4HepEmState initState;
+  InitG4HepEmState(&initState);
+  if(initState.fParameters == nullptr)
+  {
+    std::cerr << "Failed to create G4HepEmParameters from G4HepEmInit" << std::endl;
+    return 1;
+  }
+  if(initState.fData == nullptr)
+  {
+    std::cerr << "Failed to create G4HepEmData from G4HepEmInit" << std::endl;
+    return 1;
+  }
+
+  // Comparison
+  if(*rmParams != *(initState.fParameters))
+  {
+    std::cerr << "G4HepEmParameters from G4HepEmRunManager and G4HepEmInit are not numerically equal" << std::endl;
+    return 1;
+  }
+
+  if(*rmData != *(initState.fData))
+  {
+    std::cerr << "G4HepEmData from G4HepEmRunManager and G4HepEmInit are not numerically equal" << std::endl;
+    return 1;
+  }
+
+  // Cleanup
+  delete runMgr;
+  delete initState.fParameters;
+  delete initState.fData;
+
+  return 0;
+}

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -3,6 +3,7 @@
 
 #include <tuple>
 
+#include "G4HepEmParameters.hh"
 #include "G4HepEmData.hh"
 #include "G4HepEmMatCutData.hh"
 #include "G4HepEmElementData.hh"
@@ -39,6 +40,24 @@ bool compare_arrays(int lhsSize, const T* lhsData, int rhsSize,
   }
 
   return true;
+}
+
+// --- G4HepEmParameters
+bool operator==(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)
+{
+  return std::tie(lhs.fElectronTrackingCut, lhs.fMinLossTableEnergy,
+                  lhs.fMaxLossTableEnergy, lhs.fNumLossTableBins,
+                  lhs.fFinalRange, lhs.fDRoverRange, lhs.fLinELossLimit,
+                  lhs.fElectronBremModelLim) ==
+         std::tie(rhs.fElectronTrackingCut, rhs.fMinLossTableEnergy,
+                  rhs.fMaxLossTableEnergy, rhs.fNumLossTableBins,
+                  rhs.fFinalRange, rhs.fDRoverRange, rhs.fLinELossLimit,
+                  rhs.fElectronBremModelLim);
+}
+
+bool operator!=(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)
+{
+  return !(lhs == rhs);
 }
 
 // --- G4HepEmElemData


### PR DESCRIPTION
As identified in apt-sim/adept#87, we should prefer use of the functions in `G4HepEmInit` to initialise the parameters and data without going through `G4HepEmRunManager`. Whilst going through these functions is o.k., it requires several calls and  construction of the params/data instances. This PR implements a new `InitG4HepEmState` function, that allows clients to do:

```cpp
G4HepEmState s;
InitG4HepEmState(&s);

// s.fParameters, s.fData now point to the initialized instances
```

So it's nothing more than a convenience wrapper around the direct calls, but can simplify usage and make things clearer in client code.
