### PR TITLE
Replace deprecated G4RadioactiveDecay with G4RadioactiveDecayBase

### DIFF
--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -265,13 +265,13 @@ void PhysicsList::AddDecay()
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #include "G4PhysicsListHelper.hh"
-#include "G4RadioactiveDecay.hh"
+#include "G4RadioactiveDecayBase.hh"
 #include "G4GenericIon.hh"
 #include "G4NuclideTable.hh"
 
 void PhysicsList::AddRadioactiveDecay()
 {
-  G4RadioactiveDecay* radioactiveDecay = new G4RadioactiveDecay();
+  G4RadioactiveDecayBase* radioactiveDecay = new G4RadioactiveDecayBase();
 
   radioactiveDecay->SetARM(true);                //Atomic Rearangement
 


### PR DESCRIPTION
G4RadioactiveDecay is deprecated since Geant4 10.6.1 while the replacement is available since version 10.4. Tests show identical
results with `emstandard_opt0`.