### PR TITLE
Enable linking against static CLHEP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ endif()
 set(G4HepEm_CLHEP_TARGET CLHEP::CLHEP)
 if(TARGET Geant4::G4clhep)
   set(G4HepEm_CLHEP_TARGET Geant4::G4clhep)
+elseif (TARGET Geant4::G4clhep-static)
+  set(G4HepEm_CLHEP_TARGET Geant4::G4clhep-static)
 endif()
 
 #----------------------------------------------------------------------------


### PR DESCRIPTION
Also try target `Geant4::G4clhep-static` if the shared library is not available.