### PR TITLE
Fix data transfer to GPU and make it more resistent

### DIFF
--- a/G4HepEm/G4HepEmData/src/G4HepEmElementData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElementData.cc
@@ -27,6 +27,8 @@ void FreeElementData(struct G4HepEmElementData** theElementData) {
 #include <cuda_runtime.h>
 #include "G4HepEmCuUtils.hh"
 
+#include <cstring>
+
 void CopyElementDataToGPU(struct G4HepEmElementData* onCPU, struct G4HepEmElementData** onGPU) {
   // clean away previous (if any)
   if ( *onGPU != nullptr) {
@@ -41,7 +43,8 @@ void CopyElementDataToGPU(struct G4HepEmElementData* onCPU, struct G4HepEmElemen
   // `struct G4HepEmElemData* fElementData` array member, then copy to the
   // corresponding structure
   struct G4HepEmElementData* elData_h = new G4HepEmElementData;
-  elData_h->fMaxZet      = onCPU->fMaxZet;
+  // Set non-pointer members via a memcpy of the entire structure.
+  memcpy(elData_h, onCPU, sizeof(G4HepEmElementData));
   elData_h->fElementData = arrayHto_d;
   gpuErrchk ( cudaMalloc ( onGPU, sizeof( struct G4HepEmElementData ) ) );
   gpuErrchk ( cudaMemcpy ( *onGPU, elData_h, sizeof( struct G4HepEmElementData ), cudaMemcpyHostToDevice ) );

--- a/G4HepEm/G4HepEmData/src/G4HepEmGSTableData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGSTableData.cc
@@ -41,6 +41,8 @@ void FreeGSTableData(struct G4HepEmGSTableData** theGSTableData) {
 #include <cuda_runtime.h>
 #include "G4HepEmCuUtils.hh"
 
+#include <cstring>
+
 void CopyGSTableDataToDevice(struct G4HepEmGSTableData* onHOST, struct G4HepEmGSTableData** onDEVICE) {
   if ( !onHOST ) return;
   // clean away previous (if any)
@@ -50,23 +52,12 @@ void CopyGSTableDataToDevice(struct G4HepEmGSTableData* onHOST, struct G4HepEmGS
   // Create a G4HepEmGSTableData structure on the host to store pointers to _d
   // side arrays on the _h side.
   struct G4HepEmGSTableData* gsTablesHTo_d = new G4HepEmGSTableData;
-  //
-  // set member values
+  // Set non-pointer members via a memcpy of the entire structure.
+  memcpy(gsTablesHTo_d, onHOST, sizeof(G4HepEmGSTableData));
   const int numMaterials         = onHOST->fNumMaterials;
   const int numDtrData1          = onHOST->fNumDtrData1;
   const int numDtrData2          = onHOST->fNumDtrData2;
   const int numPWACorData        = onHOST->fPWACorDataNum;
-  gsTablesHTo_d->fNumDtrData1    = numMaterials;
-  gsTablesHTo_d->fNumDtrData2    = numDtrData1;
-  gsTablesHTo_d->fNumMaterials   = numDtrData2;
-  gsTablesHTo_d->fPWACorDataNum  = numPWACorData;
-  // copy fix-size array values
-  for (int i=0; i<960; ++i) {
-    gsTablesHTo_d->fDtrDataStarts1[i] = onHOST->fDtrDataStarts1[i];
-  }
-  for (int i=0; i<2048; ++i) {
-    gsTablesHTo_d->fDtrDataStarts2[i] = onHOST->fDtrDataStarts2[i];
-  }
   //
   // allocate device side memory for the dynamic arrys
   gpuErrchk ( cudaMalloc ( &(gsTablesHTo_d->fGSDtrData1),    sizeof( double ) * numDtrData1    ) );

--- a/G4HepEm/G4HepEmData/src/G4HepEmMatCutData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmMatCutData.cc
@@ -40,6 +40,8 @@ void FreeMatCutData (struct G4HepEmMatCutData** theMatCutData) {
 #include <cuda_runtime.h>
 #include "G4HepEmCuUtils.hh"
 
+#include <cstring>
+
 void CopyMatCutDataToGPU(struct G4HepEmMatCutData* onCPU, struct G4HepEmMatCutData** onGPU) {
   // clean away previous (if any)
   if ( *onGPU != nullptr) {
@@ -54,7 +56,8 @@ void CopyMatCutDataToGPU(struct G4HepEmMatCutData* onCPU, struct G4HepEmMatCutDa
   // `struct G4HepEmMCCData* fMaterialData` array member, then copy to the
   // corresponding structure
   struct G4HepEmMatCutData* mcData_h = new G4HepEmMatCutData;
-  mcData_h->fNumMatCutData = onCPU->fNumMatCutData;
+  // Set non-pointer members via a memcpy of the entire structure.
+  memcpy(mcData_h, onCPU, sizeof(G4HepEmMatCutData));
   mcData_h->fMatCutData    = arrayHto_d;
   gpuErrchk ( cudaMalloc ( onGPU, sizeof( struct G4HepEmMatCutData ) ) );
   gpuErrchk ( cudaMemcpy ( *onGPU, mcData_h, sizeof( struct G4HepEmMatCutData ), cudaMemcpyHostToDevice ) );

--- a/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmSBTableData.cc
@@ -42,6 +42,8 @@ void FreeSBTableData(struct G4HepEmSBTableData** theSBTableData) {
 #include <cuda_runtime.h>
 #include "G4HepEmCuUtils.hh"
 
+#include <cstring>
+
 void CopySBTableDataToDevice(struct G4HepEmSBTableData* onHOST, struct G4HepEmSBTableData** onDEVICE) {
   if ( !onHOST ) return;
   // clean away previous (if any)
@@ -51,28 +53,11 @@ void CopySBTableDataToDevice(struct G4HepEmSBTableData* onHOST, struct G4HepEmSB
   // Create a G4HepEmSBTableData structure on the host to store pointers to _d
   // side arrays on the _h side.
   struct G4HepEmSBTableData* sbTablesHTo_d = new G4HepEmSBTableData;
-  //
-  // set member values
-  sbTablesHTo_d->fLogMinElEnergy    = onHOST->fLogMinElEnergy;
-  sbTablesHTo_d->fILDeltaElEnergy   = onHOST->fILDeltaElEnergy;
+  // Set non-pointer members via a memcpy of the entire structure.
+  memcpy(sbTablesHTo_d, onHOST, sizeof(G4HepEmSBTableData));
   const int numHepEmMatCuts         = onHOST->fNumHepEmMatCuts;
   const int numElemsInMatCuts       = onHOST->fNumElemsInMatCuts;
   const int numSBTableData          = onHOST->fNumSBTableData;
-  sbTablesHTo_d->fNumHepEmMatCuts   = numHepEmMatCuts;
-  sbTablesHTo_d->fNumElemsInMatCuts = numElemsInMatCuts;
-  sbTablesHTo_d->fNumSBTableData    = numSBTableData;
-  // copy array values
-  for (int i=0; i<121; ++i) {
-    sbTablesHTo_d->fSBTablesStartPerZ[i] = onHOST->fSBTablesStartPerZ[i];
-  }
-  for (int i=0; i<65; ++i) {
-    sbTablesHTo_d->fElEnergyVect[i]  = onHOST->fElEnergyVect[i];
-    sbTablesHTo_d->fLElEnergyVect[i] = onHOST->fLElEnergyVect[i];
-  }
-  for (int i=0; i<54; ++i) {
-    sbTablesHTo_d->fKappaVect[i]  = onHOST->fKappaVect[i];
-    sbTablesHTo_d->fLKappaVect[i] = onHOST->fLKappaVect[i];
-  }
   //
   // allocate device side memory for the dynamic arrys
   gpuErrchk ( cudaMalloc ( &(sbTablesHTo_d->fGammaCutIndxStartIndexPerMC), sizeof( int )    * numHepEmMatCuts   ) );


### PR DESCRIPTION
When implementing the (simplified) photoelectric effect in commit 26f6ead338, I assumed that non-pointer members are automatically copied to the GPU via a `memcpy`. As this was not the case, the new data members were missing and not properly initialized. Change all copy functions to now use a `memcpy` of the data structure to catch newly added fields in the future.