### PR TITLE
Move safety helper to G4HepEmProcess

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmTLData.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmTLData.hh
@@ -6,7 +6,6 @@
 #include "G4HepEmElectronTrack.hh"
 #include "G4HepEmGammaTrack.hh"
 #include "G4HepEmRandomEngine.hh"
-#include "G4SafetyHelper.hh"
 
 #include <vector>
 
@@ -45,9 +44,6 @@ public:
   void SetRandomEngine(G4HepEmRandomEngine* rnge) { fRNGEngine = rnge; }
   G4HepEmRandomEngine* GetRNGEngine() { return fRNGEngine; }
 
-  void SetSafetyHelper(G4SafetyHelper* sh) { fSafetyHelper = sh; }
-  G4SafetyHelper* GetSafetyHelper() { return fSafetyHelper; }
-
   G4HepEmElectronTrack* GetPrimaryElectronTrack()   { return &fElectronTrack; }
   G4HepEmElectronTrack* AddSecondaryElectronTrack() {
     if (fNumSecondaryElectronTracks==fElectronSecondaryTracks.size()) {
@@ -77,9 +73,6 @@ private:
 
   // needs to set to point to the RNG engine of the thread
   G4HepEmRandomEngine*               fRNGEngine;
-
-  // for the MSC dispalcement
-  G4SafetyHelper*                    fSafetyHelper;
 
   std::size_t                        fNumSecondaryElectronTracks;
   G4HepEmElectronTrack               fElectronTrack;

--- a/G4HepEm/G4HepEmRun/src/G4HepEmTLData.cc
+++ b/G4HepEm/G4HepEmRun/src/G4HepEmTLData.cc
@@ -7,7 +7,6 @@
 
 G4HepEmTLData::G4HepEmTLData() {
   fRNGEngine    = nullptr;
-  fSafetyHelper = nullptr;
   fElectronSecondaryTracks.resize(2);
   fNumSecondaryElectronTracks = 0;
 

--- a/G4HepEm/include/G4HepEmProcess.hh
+++ b/G4HepEm/include/G4HepEmProcess.hh
@@ -9,6 +9,7 @@ class  G4HepEmRunManager;
 class  G4HepEmRandomEngine;
 
 class  G4ParticleChange;
+class  G4SafetyHelper;
 
 #include <vector>
 
@@ -104,6 +105,7 @@ private:
   G4HepEmRandomEngine*     fTheG4HepEmRandomEngine;
 
   G4ParticleChange* fParticleChange;
+  G4SafetyHelper* fSafetyHelper;
 
   const std::vector<G4double>* theCutsGamma = nullptr;
   const std::vector<G4double>* theCutsElectron = nullptr;

--- a/G4HepEm/src/G4HepEmRunManager.cc
+++ b/G4HepEm/src/G4HepEmRunManager.cc
@@ -18,9 +18,6 @@
 
 #include "G4HepEmRandomEngine.hh"
 
-#include "G4TransportationManager.hh"
-#include "G4SafetyHelper.hh"
-
 #include <iostream>
 
 
@@ -125,8 +122,6 @@ void G4HepEmRunManager::Initialize(G4HepEmRandomEngine* theRNGEngine, int hepEmP
     if  (!fTheG4HepEmTLData) {
       fTheG4HepEmTLData = new G4HepEmTLData;
       fTheG4HepEmTLData->SetRandomEngine(theRNGEngine);
-      fTheG4HepEmTLData->SetSafetyHelper(G4TransportationManager::GetTransportationManager()->GetSafetyHelper());
-      fTheG4HepEmTLData->GetSafetyHelper()->InitialiseHelper();
     }
   } else {
     //
@@ -141,8 +136,6 @@ void G4HepEmRunManager::Initialize(G4HepEmRandomEngine* theRNGEngine, int hepEmP
     if  (!fTheG4HepEmTLData) {
       fTheG4HepEmTLData = new G4HepEmTLData;
       fTheG4HepEmTLData->SetRandomEngine(theRNGEngine);
-      fTheG4HepEmTLData->SetSafetyHelper(G4TransportationManager::GetTransportationManager()->GetSafetyHelper());
-      fTheG4HepEmTLData->GetSafetyHelper()->InitialiseHelper();
     }
   }
 }


### PR DESCRIPTION
The interaction is only needed in the process, located in the G4HepEm library; the G4HepEmRun library should not depend on Geant4 itself.