### PR TITLE
Discard second Gaussian value on new track

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionMSC.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionMSC.icc
@@ -63,10 +63,9 @@ void G4HepEmElectronInteractionMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPar
     // first step randomization
     // NOTE: we should probably randomize only if the step was limited by msc
     if (mscData->fIsFirstStep || onBoundary) {
-      mscData->fTrueStepLength = G4HepEmMin(mscData->fTrueStepLength, RandomizeTrueStepLength(tlimit, rnge));
-    } else {
-      mscData->fTrueStepLength = G4HepEmMin(mscData->fTrueStepLength, tlimit);
+      tlimit = RandomizeTrueStepLength(tlimit, rnge);
     }
+    mscData->fTrueStepLength = G4HepEmMin(mscData->fTrueStepLength, tlimit);
   }
   // msc step limit is done!
   //

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
@@ -54,6 +54,9 @@ public:
     return v2*fac*stDev+mean;
   }
 
+  G4HepEmHostDevice
+  void DiscardGauss() { fIsGauss = false; }
+
 
 private:
   void *fObject;

--- a/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/src/G4HepEmProcess.cc
@@ -92,6 +92,9 @@ void     G4HepEmProcess::StartTracking(G4Track* track) {
   } else if (partDef->GetPDGEncoding()==22) {   // gamma
     fTheG4HepEmRunManager->GetTheTLData()->GetPrimaryGammaTrack()->ReSet();
   }
+  // In principle, we could continue to use the other generated Gaussian number
+  // as long as we are in the same event, but play it safe.
+  fTheG4HepEmRandomEngine->DiscardGauss();
 }
 
 G4double G4HepEmProcess::PostStepGetPhysicalInteractionLength ( const G4Track& track,


### PR DESCRIPTION
This restores reproducibility with more than one thread where G4HepEm must not use random numbers from a previous event with a different seed.
(The change in `StepLimit` simplified debugging because it only requires commenting out one line to disable the MSC step limit randomization.)