### PR TITLE
Use full Sandia table for photoelectric effect

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElementData.hh
@@ -65,6 +65,15 @@ struct G4HepEmElemData {
   /** LPM variable \f$ 1/ln[s1] \f$ */
   double  fILVarS1Cond = 0.0;
 
+  /** Number of intervals in the Sandia table */
+  int     fNumOfSandiaIntervals = 0;
+  /** Starting energy of the intervals */
+  double* fSandiaEnergies = nullptr; // [fNumOfSandiaIntervals]
+  /** Coefficients for the interval (four per energy range) */
+  double* fSandiaCoefficients = nullptr; // [4 x fNumOfSandiaIntervals]
+
+  /** Binding energy of the k-shell */
+  double  fKShellBindingEnergy = 0;
 };
 
 // Data for all elements that are used by G4HepEm.

--- a/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
@@ -57,13 +57,12 @@ struct G4HepEmMatData {
   double    fElectronDensity = 0.0;
   /** Radiation length. */
   double    fRadiationLength = 0.0;
-  /** The Sandia coefficients for this material */
-  double    fSandia1Energy = 0.0;
-  double    fSandia2Energy = 0.0;
-  double    fSandia1Cof[4]{};
-  double    fSandia2Cof[4]{};
-  /** The maximum binding energy of an element in this material */
-  double    fMaxBinding = 0.0;
+  /** Number of intervals in the Sandia table */
+  int       fNumOfSandiaIntervals = 0;
+  /** Starting energy of the intervals */
+  double*   fSandiaEnergies = nullptr; // [fNumOfSandiaIntervals]
+  /** Coefficients for the interval (four per energy range) */
+  double*   fSandiaCoefficients = nullptr; // [4 x fNumOfSandiaIntervals]
 };
 
 // Data for all materials used in the current geometry.

--- a/G4HepEm/G4HepEmData/src/G4HepEmElementData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElementData.cc
@@ -17,7 +17,13 @@ G4HepEmElementData* MakeElementData() {
 
 void FreeElementData(struct G4HepEmElementData** theElementData) {
   if ( *theElementData != nullptr ) {
-    delete[] (*theElementData)->fElementData;
+    if ( (*theElementData)->fElementData != nullptr ) {
+      for (int i = 0; i < (*theElementData)->fMaxZet; i++) {
+        delete[] (*theElementData)->fElementData[i].fSandiaEnergies;
+        delete[] (*theElementData)->fElementData[i].fSandiaCoefficients;
+      }
+      delete[] (*theElementData)->fElementData;
+    }
     delete *theElementData;
     *theElementData = nullptr;
   }
@@ -37,8 +43,30 @@ void CopyElementDataToGPU(struct G4HepEmElementData* onCPU, struct G4HepEmElemen
   // allocate array of G4HepEmElemData structures on _d (its pointer adress will on _h)
   struct G4HepEmElemData* arrayHto_d;
   gpuErrchk ( cudaMalloc ( &arrayHto_d, sizeof( struct G4HepEmElemData )*onCPU->fMaxZet ) );
-  // - copy the array of G4HepEmElemData structures from the _h to _d
-  gpuErrchk ( cudaMemcpy ( arrayHto_d, onCPU->fElementData, onCPU->fMaxZet*sizeof( struct G4HepEmElemData ), cudaMemcpyHostToDevice ) );
+  // fill in the structures on _d by copying the G4HepEmElemData one-by-one such that:
+  //  - for each G4HepEmElemData struct, first allocate the double arrays
+  //    on the device and set the corresponding _h reside pointers as the struct
+  //    members
+  //  - copy this struct from the _h to _d: the result of the copy will contain
+  //    pointers to device memeory reside on the device
+  struct G4HepEmElemData* dataHtoD_h = new G4HepEmElemData;
+  for (int i = 0; i < onCPU->fMaxZet; i++) {
+    struct G4HepEmElemData& eData_h = onCPU->fElementData[i];
+    // Set non-pointer members via a memcpy of the entire structure.
+    memcpy(dataHtoD_h, &eData_h, sizeof(G4HepEmElemData));
+
+    int numSandiaIntervals = eData_h.fNumOfSandiaIntervals;
+    //
+    gpuErrchk ( cudaMalloc ( &(dataHtoD_h->fSandiaEnergies), sizeof( double )*numSandiaIntervals ) );
+    gpuErrchk ( cudaMemcpy ( dataHtoD_h->fSandiaEnergies, eData_h.fSandiaEnergies, sizeof( double )*numSandiaIntervals, cudaMemcpyHostToDevice ) );
+    //
+    gpuErrchk ( cudaMalloc ( &(dataHtoD_h->fSandiaCoefficients), sizeof( double )*4*numSandiaIntervals ) );
+    gpuErrchk ( cudaMemcpy ( dataHtoD_h->fSandiaCoefficients, eData_h.fSandiaCoefficients, sizeof( double )*4*numSandiaIntervals, cudaMemcpyHostToDevice ) );
+    //
+    // copy this G4HepEmElemData structure to _d
+    gpuErrchk ( cudaMemcpy ( &(arrayHto_d[i]), dataHtoD_h, sizeof( struct G4HepEmElemData ), cudaMemcpyHostToDevice ) );
+  }
+
   // now create a helper G4HepEmElementData and set its fMaxZet and
   // `struct G4HepEmElemData* fElementData` array member, then copy to the
   // corresponding structure
@@ -59,11 +87,27 @@ void FreeElementDataOnGPU ( struct G4HepEmElementData** onGPU ) {
     // pointed by `fElementData` by calling to cudaFree from the host.
     struct G4HepEmElementData* elData_h = new G4HepEmElementData;
     gpuErrchk ( cudaMemcpy ( elData_h, *onGPU, sizeof( struct G4HepEmElementData ), cudaMemcpyDeviceToHost ) );
+    // Then copy each of the struct G4HepEmElemData structures of the array
+    // from _d to _h in order to have their double* pointer members
+    // on the host, then free the pointed device memory by using these _h side
+    // pointer addresses to _d side memory locations.
+    struct G4HepEmElemData* eData_h = new G4HepEmElemData;
+    for (int i = 0; i < elData_h->fMaxZet; i++) {
+      gpuErrchk ( cudaMemcpy ( eData_h, &(elData_h->fElementData[i]), sizeof( struct G4HepEmElemData ), cudaMemcpyDeviceToHost ) );
+      cudaFree ( eData_h->fSandiaEnergies );
+      cudaFree ( eData_h->fSandiaCoefficients );
+    }
+    // Then at the and free the whole `struct G4HepEmElemData* fElementData`
+    // array (after all dynamically allocated memory is freed) by using the
+    // _h side address of the _d sice memory pointer.
     cudaFree( elData_h->fElementData );
     // free the whole remaining device side memory (after cleaning all dynamically
     // allocated members)
     cudaFree( *onGPU );
     *onGPU = nullptr;
+    // free auxilary objects
+    delete elData_h;
+    delete eData_h;
   }
 }
 #endif // G4HepEm_CUDA_BUILD

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -203,6 +203,11 @@ namespace nlohmann
       j["fDeltaMaxHigh"] = d.fDeltaMaxHigh;
       j["fILVarS1"]      = d.fILVarS1;
       j["fILVarS1Cond"]  = d.fILVarS1Cond;
+      j["fSandiaEnergies"] =
+        make_span(d.fNumOfSandiaIntervals, d.fSandiaEnergies);
+      j["fSandiaCoefficients"] =
+        make_span(4 * d.fNumOfSandiaIntervals, d.fSandiaCoefficients);
+      j["fKShellBindingEnergy"] = d.fKShellBindingEnergy;
     }
 
     static G4HepEmElemData from_json(const json& j)
@@ -219,6 +224,17 @@ namespace nlohmann
       j.at("fDeltaMaxHigh").get_to(d.fDeltaMaxHigh);
       j.at("fILVarS1").get_to(d.fILVarS1);
       j.at("fILVarS1Cond").get_to(d.fILVarS1Cond);
+
+      auto tmpSandiaEnergies =
+        j.at("fSandiaEnergies").get<dynamic_array<double>>();
+      d.fNumOfSandiaIntervals = tmpSandiaEnergies.N;
+      d.fSandiaEnergies       = tmpSandiaEnergies.data;
+
+      auto tmpSandiaCoefficients =
+        j.at("fSandiaCoefficients").get<dynamic_array<double>>();
+      d.fSandiaCoefficients = tmpSandiaCoefficients.data;
+
+      j.at("fKShellBindingEnergy").get_to(d.fKShellBindingEnergy);
 
       return d;
     }
@@ -297,11 +313,10 @@ namespace nlohmann
       j["fDensityCorfactor"] = d.fDensityCorFactor;
       j["fElectronDensity"]  = d.fElectronDensity;
       j["fRadiationLength"]  = d.fRadiationLength;
-      j["fSandia1Energy"]    = d.fSandia1Energy;
-      j["fSandia2Energy"]    = d.fSandia2Energy;
-      j["fSandia1Cof"]       = d.fSandia1Cof;
-      j["fSandia2Cof"]       = d.fSandia2Cof;
-      j["fMaxBinding"]       = d.fMaxBinding;
+      j["fSandiaEnergies"] =
+        make_span(d.fNumOfSandiaIntervals, d.fSandiaEnergies);
+      j["fSandiaCoefficients"] =
+        make_span(4 * d.fNumOfSandiaIntervals, d.fSandiaCoefficients);
     }
 
     static G4HepEmMatData from_json(const json& j)
@@ -321,11 +336,15 @@ namespace nlohmann
       j.at("fDensityCorfactor").get_to(d.fDensityCorFactor);
       j.at("fElectronDensity").get_to(d.fElectronDensity);
       j.at("fRadiationLength").get_to(d.fRadiationLength);
-      j.at("fSandia1Energy").get_to(d.fSandia1Energy);
-      j.at("fSandia2Energy").get_to(d.fSandia2Energy);
-      j.at("fSandia1Cof").get_to(d.fSandia1Cof);
-      j.at("fSandia2Cof").get_to(d.fSandia2Cof);
-      j.at("fMaxBinding").get_to(d.fMaxBinding);
+
+      auto tmpSandiaEnergies =
+        j.at("fSandiaEnergies").get<dynamic_array<double>>();
+      d.fNumOfSandiaIntervals = tmpSandiaEnergies.N;
+      d.fSandiaEnergies       = tmpSandiaEnergies.data;
+
+      auto tmpSandiaCoefficients =
+        j.at("fSandiaCoefficients").get<dynamic_array<double>>();
+      d.fSandiaCoefficients = tmpSandiaCoefficients.data;
 
       return d;
     }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.hh
@@ -17,6 +17,9 @@ public:
   static void Perform(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData);
 
   G4HepEmHostDevice
+  static double SelectElementBindingEnergy(const struct G4HepEmData* hepEmData, const int imc, const double mxsec, const double ekin, G4HepEmRandomEngine* rnge);
+
+  G4HepEmHostDevice
   static void SamplePhotoElectronDirection(const double theGammaE, const double* theGammaDir, double* theDir, G4HepEmRandomEngine* rnge);
 };
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.icc
@@ -4,35 +4,76 @@
 
 #include  "G4HepEmTLData.hh"
 #include  "G4HepEmData.hh"
+#include  "G4HepEmElementData.hh"
 #include  "G4HepEmMaterialData.hh"
 #include  "G4HepEmMatCutData.hh"
 #include  "G4HepEmRunUtils.hh"
 
 void G4HepEmGammaInteractionPhotoelectric::Perform(G4HepEmTLData* tlData, struct G4HepEmData* hepEmData) {
-  G4HepEmTrack* thePrimaryTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
-  const double*     theGammaDir = thePrimaryTrack->GetDirection();
-  const double        theGammaE = thePrimaryTrack->GetEKin();
+  G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
+  G4HepEmTrack*    thePrimaryTrack = theGammaTrack->GetTrack();
+  const double*        theGammaDir = thePrimaryTrack->GetDirection();
+  const double           theGammaE = thePrimaryTrack->GetEKin();
 
-  const int  theMCIndx = thePrimaryTrack->GetMCIndex();
-  const int theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theMCIndx].fHepEmMatIndex;
-  const G4HepEmMatData* matData = &hepEmData->fTheMaterialData->fMaterialData[theMatIndx];
+  const int theMCIndx = thePrimaryTrack->GetMCIndex();
+  const double  mxsec = theGammaTrack->GetPEmxSec();
+
+  const double bindingEnergy = SelectElementBindingEnergy(hepEmData, theMCIndx, mxsec, theGammaE, tlData->GetRNGEngine());
 
   const double theLowEnergyThreshold = 0.000001; // 1 eV
-  // Only check the maximum binding energy of the current material. If the
-  // gamma energy is below that, the energy of the secondary photo electron
-  // will be so low that it won't travel far and we can skip generating it.
-  const double photoElecE = theGammaE - matData->fMaxBinding;
+  const double photoElecE = theGammaE - bindingEnergy;
   if (photoElecE > theLowEnergyThreshold) {
     G4HepEmTrack* theSecTrack = tlData->AddSecondaryElectronTrack()->GetTrack();
     double*       theSecElDir = theSecTrack->GetDirection();
     SamplePhotoElectronDirection(photoElecE, theGammaDir, theSecElDir, tlData->GetRNGEngine());
     theSecTrack->SetEKin(photoElecE);
     theSecTrack->SetParentID(thePrimaryTrack->GetID());
-    thePrimaryTrack->SetEnergyDeposit(matData->fMaxBinding);
+    thePrimaryTrack->SetEnergyDeposit(bindingEnergy);
   } else {
     thePrimaryTrack->SetEnergyDeposit(theGammaE);
   }
   thePrimaryTrack->SetEKin(0.0);
+}
+
+double G4HepEmGammaInteractionPhotoelectric::SelectElementBindingEnergy(const struct G4HepEmData* hepEmData, const int imc, const double mxsec, const double ekin, G4HepEmRandomEngine *rnge) {
+  const int theMatIndx = hepEmData->fTheMatCutData->fMatCutData[imc].fHepEmMatIndex;
+  const G4HepEmMatData& theMData = hepEmData->fTheMaterialData->fMaterialData[theMatIndx];
+
+  // Possible optimization: if ekin minus the minimum binding energy of all elements in the material
+  // is already smaller than the electron cut, we could skip selecting an element.
+
+  int ielem = 0;
+  if (theMData.fNumOfElement > 1) {
+    const double x = rnge->flat() * mxsec;
+    double sum = 0;
+    double invE = 1 / ekin;
+    for (int i = 0; i < theMData.fNumOfElement; i++) {
+      const G4HepEmElemData& theEData = hepEmData->fTheElementData->fElementData[theMData.fElementVect[i]];
+      int interval = 0;
+      if (ekin >= theEData.fSandiaEnergies[0]) {
+        // Optimization: linear search starting with intervals for higher energies.
+        for (int i = theEData.fNumOfSandiaIntervals - 1; i >= 0; i--) {
+          if (ekin >= theEData.fSandiaEnergies[i]) {
+            interval = i;
+            break;
+          }
+        }
+      }
+      const double* sandiaCof = &theEData.fSandiaCoefficients[4 * interval];
+      sum += theMData.fNumOfAtomsPerVolumeVect[i] *
+        invE * (sandiaCof[0] + invE * (sandiaCof[1] + invE * (sandiaCof[2] + invE * sandiaCof[3])));
+      if (x <= sum) {
+        ielem = i;
+        break;
+      }
+    }
+  }
+
+  // Only check the k-shell binding energy of the sampled element. If the
+  // gamma energy is below that, the energy of the secondary photo electron
+  // will be so low that it won't travel far and we can skip generating it.
+
+  return hepEmData->fTheElementData->fElementData[theMData.fElementVect[ielem]].fKShellBindingEnergy;
 }
 
 void G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(const double kinE, const double* theGammaDir, double* theDir, G4HepEmRandomEngine* rnge) {

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -32,7 +32,7 @@ public:
   static void HowFar(struct G4HepEmData* /*hepEmData*/, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* /*tlData*/);
 
   G4HepEmHostDevice
-  static void HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTrack* theTrack);
+  static void HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmGammaTrack* theTrack);
 
 
   // interactions

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -25,29 +25,33 @@
 // Note: pStepLength will be set here i.e. this is the first access to it that
 //       will clear the previous step value.
 void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
-  G4HepEmTrack* theTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
+  G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
+  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
   // Sample the `number-of-interaction-left`
   for (int ip=0; ip<3; ++ip) {
     if (theTrack->GetNumIALeft(ip)<=0.) {
       theTrack->SetNumIALeft(-std::log(tlData->GetRNGEngine()->flat()), ip);
     }
   }
-  HowFar(hepEmData, hepEmPars, theTrack);
+  HowFar(hepEmData, hepEmPars, theGammaTrack);
 }
 
 
-void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTrack* theTrack) {
+void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmGammaTrack* theGammaTrack) {
+  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
   const double   theEkin = theTrack->GetEKin();
   const double  theLEkin = theTrack->GetLogEKin();
   const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
   // get the Gamma data from the op level data structure
   const G4HepEmGammaData* theGammaData = hepEmData->fTheGammaData;
-  // === Gamma has only discrete limits due to Conversion, Compton (at the moment)
+  // === Gamma has only discrete limits due to Conversion, Compton, and the photoelectric effect.
   double mxSecs[3];
   // conversion, compton and photoelectric
   mxSecs[0] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 0);
   mxSecs[1] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 1);
   mxSecs[2] = GetMacXSecPE(hepEmData, theMatIndx, theEkin);
+  // Remember value of photoelectric effect, needed for selecting the element.
+  theGammaTrack->SetPEmxSec(mxSecs[2]);
   // compute mfp and see if we need to sample the `number-of-interaction-left`
   // before we use it to get the current discrete proposed step length
   int indxWinnerProcess = -1;             // init to nothing
@@ -142,13 +146,17 @@ double  G4HepEmGammaManager::GetMacXSec(const struct G4HepEmGammaData* gmData, c
 
 double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin) {
   const G4HepEmMatData* matData = &hepEmData->fTheMaterialData->fMaterialData[imat];
-  if (ekin <= matData->fSandia1Energy) {
-    return kALargeValue;
+  int interval = 0;
+  if (ekin >= matData->fSandiaEnergies[0]) {
+    // Optimization: linear search starting with intervals for higher energies.
+    for (int i = matData->fNumOfSandiaIntervals - 1; i >= 0; i--) {
+      if (ekin >= matData->fSandiaEnergies[i]) {
+        interval = i;
+        break;
+      }
+    }
   }
-  const double* sandiaCof = &matData->fSandia1Cof[0];
-  if (ekin > matData->fSandia2Energy) {
-    sandiaCof = &matData->fSandia2Cof[0];
-  }
+  const double* sandiaCof = &matData->fSandiaCoefficients[4 * interval];
   const double inv = 1 / ekin;
   return inv * (sandiaCof[0] + inv * (sandiaCof[1] + inv * (sandiaCof[2] + inv * sandiaCof[3])));
 }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaTrack.hh
@@ -17,21 +17,32 @@
 class G4HepEmGammaTrack {
 
 public:
+  G4HepEmHostDevice
   G4HepEmGammaTrack() { fTrack.ReSet(); }
   
+  G4HepEmHostDevice
   G4HepEmGammaTrack(const G4HepEmGammaTrack& o) { 
     fTrack = o.fTrack;
   }
 
+  G4HepEmHostDevice
   G4HepEmTrack*  GetTrack()  { return &fTrack; }
 
+  G4HepEmHostDevice
+  void   SetPEmxSec(double mxsec) { fPEmxSec = mxsec; }
+  G4HepEmHostDevice
+  double GetPEmxSec() const       { return fPEmxSec; }
+
+  G4HepEmHostDevice
   void ReSet() {
     fTrack.ReSet();
+    fPEmxSec = 0.0;
   }
 
     
 private:
   G4HepEmTrack  fTrack;
+  double        fPEmxSec;
 };
 
 

--- a/docs/source/IntroAndInstall/introduction.rst
+++ b/docs/source/IntroAndInstall/introduction.rst
@@ -119,7 +119,7 @@ i.e. :math:`\texttt{G4EmStandardPhysics}`.
    .. [#]  i.e. annihilation at rest.
 
    .. [#]  A simplified version of the ``G4PEEffectFluoModel`` has been implemented in ``G4HepEm`` by taking into account
-       only the two highest intervals of ``G4SandiaTable``.
+       only the k-shell binding energy.
 
    .. [#]  Primary :math:`\gamma` energies below the highest binding energy are
       absorbed without generating a secondary photoelectron.
@@ -194,7 +194,7 @@ i.e. :math:`\texttt{G4EmStandardPhysics}`.
       \footnotetext{i.e. annihilation at rest.}
       \addtocounter{footnote}{1}
       \footnotetext{A simplified version of the \texttt{G4PEEffectFluoModel} model has been implemented in \texttt{G4HepEm} by taking into account
-          only the two highest intervals of \texttt{G4SandiaTable}.}
+          only the k-shell binding energy.}
       \addtocounter{footnote}{1}
       \footnotetext{Primary $\gamma$ energies below the highest binding energy are
            absorbed without generating a secondary photoelectron.}

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -63,12 +63,29 @@ bool operator!=(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)
 // --- G4HepEmElemData
 bool operator==(const G4HepEmElemData& lhs, const G4HepEmElemData& rhs)
 {
-  return std::tie(lhs.fZet, lhs.fZet13, lhs.fZet23, lhs.fCoulomb, lhs.fLogZ,
-                  lhs.fZFactor1, lhs.fDeltaMaxLow, lhs.fDeltaMaxHigh,
-                  lhs.fILVarS1, lhs.fILVarS1Cond) ==
-         std::tie(rhs.fZet, rhs.fZet13, rhs.fZet23, rhs.fCoulomb, rhs.fLogZ,
-                  rhs.fZFactor1, rhs.fDeltaMaxLow, rhs.fDeltaMaxHigh,
-                  rhs.fILVarS1, rhs.fILVarS1Cond);
+  if(std::tie(lhs.fZet, lhs.fZet13, lhs.fZet23, lhs.fCoulomb, lhs.fLogZ,
+              lhs.fZFactor1, lhs.fDeltaMaxLow, lhs.fDeltaMaxHigh,
+              lhs.fILVarS1, lhs.fILVarS1Cond, lhs.fKShellBindingEnergy) !=
+     std::tie(rhs.fZet, rhs.fZet13, rhs.fZet23, rhs.fCoulomb, rhs.fLogZ,
+              rhs.fZFactor1, rhs.fDeltaMaxLow, rhs.fDeltaMaxHigh,
+              rhs.fILVarS1, rhs.fILVarS1Cond, rhs.fKShellBindingEnergy))
+  {
+    return false;
+  }
+
+  if(!compare_arrays(lhs.fNumOfSandiaIntervals, lhs.fSandiaEnergies,
+                     rhs.fNumOfSandiaIntervals, rhs.fSandiaEnergies))
+  {
+    return false;
+  }
+
+  if(!compare_arrays(4 * lhs.fNumOfSandiaIntervals, lhs.fSandiaCoefficients,
+                     4 * rhs.fNumOfSandiaIntervals, rhs.fSandiaCoefficients))
+  {
+    return false;
+  }
+
+  return true;
 }
 
 bool operator!=(const G4HepEmElemData& lhs, const G4HepEmElemData& rhs)
@@ -133,12 +150,10 @@ bool operator==(const G4HepEmMatData& lhs, const G4HepEmMatData& rhs)
 {
   if(std::tie(lhs.fG4MatIndex, lhs.fNumOfElement, lhs.fDensity,
               lhs.fDensityCorFactor, lhs.fElectronDensity,
-              lhs.fRadiationLength, lhs.fSandia1Energy, lhs.fSandia2Energy,
-              lhs.fMaxBinding) !=
+              lhs.fRadiationLength) !=
      std::tie(rhs.fG4MatIndex, rhs.fNumOfElement, rhs.fDensity,
               rhs.fDensityCorFactor, rhs.fElectronDensity,
-              rhs.fRadiationLength, rhs.fSandia1Energy, rhs.fSandia2Energy,
-              rhs.fMaxBinding))
+              rhs.fRadiationLength))
   {
     return false;
   }
@@ -155,15 +170,14 @@ bool operator==(const G4HepEmMatData& lhs, const G4HepEmMatData& rhs)
     return false;
   }
 
-  const int numSandiaCof = 4;
-  if(!compare_arrays(numSandiaCof, lhs.fSandia1Cof, numSandiaCof,
-                     rhs.fSandia1Cof))
+  if(!compare_arrays(lhs.fNumOfSandiaIntervals, lhs.fSandiaEnergies,
+                     rhs.fNumOfSandiaIntervals, rhs.fSandiaEnergies))
   {
     return false;
   }
 
-  if(!compare_arrays(numSandiaCof, lhs.fSandia2Cof, numSandiaCof,
-                     rhs.fSandia2Cof))
+  if(!compare_arrays(4 * lhs.fNumOfSandiaIntervals, lhs.fSandiaCoefficients,
+                     4 * rhs.fNumOfSandiaIntervals, rhs.fSandiaCoefficients))
   {
     return false;
   }


### PR DESCRIPTION
This gives cross-section data over a larger energy range and better final state sampling for materials with more than one element. Both changes together result in more accurate energy deposit per material (compared to Geant4) in a simplified sampling calorimeter with PbWO4 and lAr.