### PR TITLE
Providing information regarding the processes that determined/limited the step inside G4HepEm

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -123,7 +123,7 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
     const double mscTruStepLength = mscData->fTrueStepLength;
     if (mscTruStepLength < pStepLength) {
        // indicate continuous step limit as msc limited the step and set the new pStepLengt
-      indxWinnerProcess = -1;
+      indxWinnerProcess = -2;
       pStepLength = mscTruStepLength;
     }
   }

--- a/G4HepEm/include/G4HepEmNoProcess.hh
+++ b/G4HepEm/include/G4HepEmNoProcess.hh
@@ -1,0 +1,70 @@
+
+#ifndef G4HepEmNoProcess_h
+#define G4HepEmNoProcess_h 1
+
+#include "G4VProcess.hh"
+
+/**
+ * @file    G4HepEmNoProcess.hh
+ * @class   G4HepEmNoProcess
+ * @author  M. Novak
+ * @date    2021
+ *
+ * An empty G4VProcess with configurable name.
+ *
+ * This process should not be assigned to any particles since it's empty. It's
+ * used only to provide infomation to the `Geant4` framework regarding the name
+ * of the processes that determined the step. 
+ */
+
+class G4HepEmNoProcess : public G4VProcess {
+  public:
+
+    G4HepEmNoProcess(const G4String& name) : G4VProcess( name, fGeneral ) {};
+
+   ~G4HepEmNoProcess() override {};
+
+    // This process should not be set to any particle
+    G4bool IsApplicable(const G4ParticleDefinition&) override { return false; }
+
+    //  no operations in any GPIL or DoIt
+    G4double PostStepGetPhysicalInteractionLength(
+                             const G4Track&,
+                             G4double,
+                             G4ForceCondition*
+                            ) override { return -1.0; };
+
+    G4VParticleChange* PostStepDoIt(
+                             const G4Track& ,
+                             const G4Step&
+                            ) override {return nullptr;};
+
+    G4double AtRestGetPhysicalInteractionLength(
+                             const G4Track& ,
+                             G4ForceCondition*
+                            ) override { return -1.0; };
+
+    G4VParticleChange* AtRestDoIt(
+                             const G4Track& ,
+                             const G4Step&
+                            ) override {return nullptr;};
+
+    G4double AlongStepGetPhysicalInteractionLength(
+                             const G4Track&,
+                             G4double  ,
+                             G4double  ,
+                             G4double& ,
+                             G4GPILSelection*
+                            ) override { return -1.0; };
+
+    G4VParticleChange* AlongStepDoIt(
+                             const G4Track& ,
+                             const G4Step&
+                            ) override {return nullptr;};
+
+    G4HepEmNoProcess(G4HepEmNoProcess&) = delete;
+    G4HepEmNoProcess& operator=(const G4HepEmNoProcess& right) = delete;
+
+};
+
+#endif

--- a/G4HepEm/include/G4HepEmProcess.hh
+++ b/G4HepEm/include/G4HepEmProcess.hh
@@ -5,11 +5,14 @@
 
 #include "G4VProcess.hh"
 
+
 class  G4HepEmRunManager;
 class  G4HepEmRandomEngine;
+class  G4HepEmNoProcess;
 
 class  G4ParticleChange;
 class  G4SafetyHelper;
+
 
 #include <vector>
 
@@ -93,7 +96,12 @@ public:
      return nullptr;
    }
 
-
+   //
+   // Method to obtain a pointer to an empty process with the given name.
+   // NOTE: the same process pointers will be set as step-limiter process
+   //       whenever the given `process` limited the step. (Keep in mind,
+   //       there ar eno real processes in G4hepEm but user codes need this.)
+   G4VProcess* GetProcess(const G4String& procname);
 
    void StreamInfo(std::ostream& out, const G4ParticleDefinition& part) const;
 
@@ -101,16 +109,21 @@ public:
 
 private:
   // the top level interface to the G4HepEm functionalities
-  G4HepEmRunManager*       fTheG4HepEmRunManager;
-  G4HepEmRandomEngine*     fTheG4HepEmRandomEngine;
+  G4HepEmRunManager*           fTheG4HepEmRunManager;
+  G4HepEmRandomEngine*         fTheG4HepEmRandomEngine;
 
-  G4ParticleChange* fParticleChange;
-  G4SafetyHelper* fSafetyHelper;
+  G4ParticleChange*            fParticleChange;
+  G4SafetyHelper*              fSafetyHelper;
 
   const std::vector<G4double>* theCutsGamma = nullptr;
   const std::vector<G4double>* theCutsElectron = nullptr;
   const std::vector<G4double>* theCutsPositron = nullptr;
   G4bool applyCuts = false;
+
+  // a set of empty processes with the correct names just to be able to set them
+  // as process limited the step as some user codes relies on this information
+  std::vector<G4HepEmNoProcess*> fElectronNoProcessVector;
+  std::vector<G4HepEmNoProcess*> fGammaNoProcessVector;
 };
 
 #endif


### PR DESCRIPTION
Some user codes and/or the `Geant4` tracking verbose depend on some information that is set in the `G4Track` during the stepping by the `G4SteppingManager` such as the process that determined the given step, etc. 
Since `G4HepEm` has no individual processes and covers several processes while only the single `G4HepEmProcess` is seen by the `Geant4` framework, the limiter process is always set to this. 

This has been resolved by overwriting the `G4Track` field (actually its post step point field) with a dummy `G4VProcess` pointer that is empty but contains the correct (i.e. same as the real `Geant4`) process names. 

Additional functionality, to obtain these process pointers by name has also been added.  