### PR TITLE
Adding energy loss fluctuation. 

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
@@ -57,6 +57,9 @@ struct G4HepEmMatData {
   double    fElectronDensity = 0.0;
   /** Radiation length. */
   double    fRadiationLength = 0.0;
+  /** Mean excition energy and its logarithm */
+  double    fMeanExEnergy    = 0.0;
+  double    fLogMeanExEnergy = 0.0;
   //
   /** Number of intervals in the Sandia table */
   int       fNumOfSandiaIntervals = 0;

--- a/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMaterialData.hh
@@ -57,9 +57,8 @@ struct G4HepEmMatData {
   double    fElectronDensity = 0.0;
   /** Radiation length. */
   double    fRadiationLength = 0.0;
-  /** Mean excition energy and its logarithm */
+  /** Mean excition energy */
   double    fMeanExEnergy    = 0.0;
-  double    fLogMeanExEnergy = 0.0;
   //
   /** Number of intervals in the Sandia table */
   int       fNumOfSandiaIntervals = 0;

--- a/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
@@ -117,7 +117,6 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
       matData.fElectronDensity         = mat->GetElectronDensity();
       matData.fRadiationLength         = mat->GetRadlen();
       matData.fMeanExEnergy            = mat->GetIonisation()->GetMeanExcitationEnergy();
-      matData.fLogMeanExEnergy         = mat->GetIonisation()->GetLogMeanExcEnergy();
 
       // go for some U-msc related data per materials
       const double zeff                = mat->GetIonisation()->GetZeffective();

--- a/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
@@ -116,6 +116,8 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
       matData.fDensityCorFactor        = 4.0*CLHEP::pi*CLHEP::classic_electr_radius*CLHEP::electron_Compton_length*CLHEP::electron_Compton_length*mat->GetElectronDensity();
       matData.fElectronDensity         = mat->GetElectronDensity();
       matData.fRadiationLength         = mat->GetRadlen();
+      matData.fMeanExEnergy            = mat->GetIonisation()->GetMeanExcitationEnergy();
+      matData.fLogMeanExEnergy         = mat->GetIonisation()->GetLogMeanExcEnergy();
 
       // go for some U-msc related data per materials
       const double zeff                = mat->GetIonisation()->GetZeffective();

--- a/G4HepEm/G4HepEmRun/CMakeLists.txt
+++ b/G4HepEm/G4HepEmRun/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(G4HEPEmRun_headers
   include/G4HepEmConstants.hh
+  include/G4HepEmElectronEnergyLossFluctuation.hh
   include/G4HepEmElectronInteractionBrem.hh
   include/G4HepEmElectronInteractionIoni.hh
   include/G4HepEmElectronInteractionUMSC.hh
@@ -21,6 +22,7 @@ set(G4HEPEmRun_headers
   include/G4HepEmTrack.hh
 )
 set(G4HEPEmRun_impl_headers
+  include/G4HepEmElectronEnergyLossFluctuation.icc
   include/G4HepEmElectronInteractionBrem.icc
   include/G4HepEmElectronInteractionIoni.icc
   include/G4HepEmElectronInteractionUMSC.icc

--- a/G4HepEm/G4HepEmRun/include/G4HepEmConstants.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmConstants.hh
@@ -5,24 +5,26 @@
 #include "CLHEP/Units/SystemOfUnits.h"
 #include "CLHEP/Units/PhysicalConstants.h"
 
-static constexpr double kPi             = CLHEP::pi;                 // e- m_0c^2 in [MeV]
-static constexpr double k2Pi            = CLHEP::twopi;              // e- m_0c^2 in [MeV]
+static constexpr double kPi                = CLHEP::pi;                 // e- m_0c^2 in [MeV]
+static constexpr double k2Pi               = CLHEP::twopi;              // e- m_0c^2 in [MeV]
 
-static constexpr double kElectronMassC2 = CLHEP::electron_mass_c2;   // e- m_0c^2 in [MeV]
+static constexpr double kElectronMassC2    = CLHEP::electron_mass_c2;   // e- m_0c^2 in [MeV]
 
-static constexpr double kAlpha          = CLHEP::fine_structure_const;
+static constexpr double kInvElectronMassC2 = 1.0 / kElectronMassC2;   // e- 1/(m_0c^2) in [1/MeV]
 
-/** \f$ \pi r_0^2\f$ */ 
-static constexpr double kPir02          = CLHEP::pi*CLHEP::classic_electr_radius*CLHEP::classic_electr_radius;
+static constexpr double kAlpha             = CLHEP::fine_structure_const;
+
+/** \f$ \pi r_0^2\f$ */
+static constexpr double kPir02             = CLHEP::pi*CLHEP::classic_electr_radius*CLHEP::classic_electr_radius;
 
 /** Migdal's constant: \f$ 4\pi r_0*[\hbar c/(m_0c^2)]^2 \f$ */
-static constexpr double kMigdalConst    = 4.0 * CLHEP::pi * CLHEP::classic_electr_radius * CLHEP::electron_Compton_length * CLHEP::electron_Compton_length;
+static constexpr double kMigdalConst       = 4.0 * CLHEP::pi * CLHEP::classic_electr_radius * CLHEP::electron_Compton_length * CLHEP::electron_Compton_length;
 
 /** LPM constant: \f$ \alpha(m_0c^2)^2/(4\pi*\hbar c) \f$ */
-static constexpr double kLPMconstant    = CLHEP::fine_structure_const * CLHEP::electron_mass_c2 * CLHEP::electron_mass_c2 / (4.0 * CLHEP::pi * CLHEP::hbarc);
+static constexpr double kLPMconstant       = CLHEP::fine_structure_const * CLHEP::electron_mass_c2 * CLHEP::electron_mass_c2 / (4.0 * CLHEP::pi * CLHEP::hbarc);
 
 
-static constexpr double kALargeValue    = 1.0E+20;
+static constexpr double kALargeValue       = 1.0E+20;
 
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.hh
@@ -1,0 +1,35 @@
+
+#ifndef G4HepEmElectronEnergyLossFluctuation_HH
+#define G4HepEmElectronEnergyLossFluctuation_HH
+
+#include "G4HepEmMacros.hh"
+
+class G4HepEmRandomEngine;
+
+/**
+ * @file    G4HepEmElectronEnergyLossFluctuation.hh
+ * @class   G4HepEmElectronEnergyLossFluctuation
+ * @author  M. Novak
+ * @date    2022
+ *
+ * @brief Urban universal model for e-/e+ energy loss fluctuation (as in 25-02-2022).
+ */
+
+class G4HepEmElectronEnergyLossFluctuation {
+private:
+  G4HepEmElectronEnergyLossFluctuation() = delete;
+
+public:
+  G4HepEmHostDevice
+  static double SampleEnergyLossFLuctuation(double ekin, double tcut, double tmax, double excEner,
+                                            double  logExcEner, double stepLength, double meanELoss,
+                                            G4HepEmRandomEngine* rnge);
+
+
+  //
+  G4HepEmHostDevice
+  static double SampleGaussianLoss(double meanx, double sig2x, G4HepEmRandomEngine* rnge);
+
+};
+
+#endif // G4HepEmElectronEnergyLossFluctuation_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.hh
@@ -22,8 +22,7 @@ private:
 public:
   G4HepEmHostDevice
   static double SampleEnergyLossFLuctuation(double ekin, double tcut, double tmax, double excEner,
-                                            double  logExcEner, double stepLength, double meanELoss,
-                                            G4HepEmRandomEngine* rnge);
+                                            double stepLength, double meanELoss, G4HepEmRandomEngine* rnge);
 
 
   //

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.icc
@@ -9,14 +9,13 @@
 
 
 double G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(double ekin, double tcut, double tmax,
-       double excEner, double  logExcEner, double stepLength, double meanELoss, G4HepEmRandomEngine* rnge) {
+       double excEner, double stepLength, double meanELoss, G4HepEmRandomEngine* rnge) {
   const double scaling  = G4HepEmMin(1. + 5.E-4/tcut, 1.5);
   const double meanLoss = meanELoss/scaling;
 
   const double kFluctParRate     = 0.56;
   const double kFluctParE0       = 1.E-5; // 10 eV
   const double kFluctParNMaxCont = 8.;
-
 
   const double w1 = tcut/kFluctParE0;
   double a3 = meanLoss*(tcut - kFluctParE0)/(kFluctParE0*tcut*G4HepEmLog(w1));
@@ -25,18 +24,19 @@ double G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(double 
   double eloss = 0.0;
   // 1. excittaion part
   if (tcut > excEner) {
-    const double gamma = ekin*kInvElectronMassC2 + 1.;
-    const double gam2  = gamma*gamma;
-    const double beta  = ekin < 511. ? std::sqrt(1. - 1./gam2) : 1.;
-    const double beta2 = beta*beta;
-
-    const double w2    = G4HepEmLog(2.*kElectronMassC2*beta2*gam2) - beta2;
     const double a1Tmp = meanLoss*(1. - kFluctParRate)/excEner;
+    // NOTE: this corresponds to G4UniversalFluctuation as in G4-v11.p01
     const double kFluctParA0 = 42.;
-    const double kFluctParFw = 4.;
+    const double kFluctParFw =  4.;
     const double dum0  = a1Tmp < kFluctParA0
                          ? .1 + (kFluctParFw - .1)*std::sqrt(a1Tmp/kFluctParA0)
                          : kFluctParFw;
+    // NOTE: this corresponds to G4UniversalFluctuation as in G4-v11.00
+    // const double kFluctParA0 = 15.;
+    // const double kFluctParFw =  5.;
+    // const double dum0  = a1Tmp < kFluctParA0
+    //                      ? kFluctParFw*a1Tmp/kFluctParA0
+    //                      : kFluctParFw;
     a1  = a1Tmp/dum0;
     e1 *= dum0;
     a3 *= kFluctParRate;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.icc
@@ -1,0 +1,111 @@
+
+#include "G4HepEmElectronEnergyLossFluctuation.hh"
+
+
+#include "G4HepEmRandomEngine.hh"
+
+#include "G4HepEmConstants.hh"
+#include "G4HepEmMath.hh"
+
+
+double G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(double ekin, double tcut, double tmax,
+       double excEner, double  logExcEner, double stepLength, double meanELoss, G4HepEmRandomEngine* rnge) {
+  const double scaling  = G4HepEmMin(1. + 5.E-4/tcut, 1.5);
+  const double meanLoss = meanELoss/scaling;
+
+  const double kFluctParRate     = 0.56;
+  const double kFluctParE0       = 1.E-5; // 10 eV
+  const double kFluctParNMaxCont = 8.;
+
+
+  const double w1 = tcut/kFluctParE0;
+  double a3 = meanLoss*(tcut - kFluctParE0)/(kFluctParE0*tcut*G4HepEmLog(w1));
+  double a1 = 0.;
+  double e1 = excEner;
+  double eloss = 0.0;
+  // 1. excittaion part
+  if (tcut > excEner) {
+    const double gamma = ekin*kInvElectronMassC2 + 1.;
+    const double gam2  = gamma*gamma;
+    const double beta  = ekin < 511. ? std::sqrt(1. - 1./gam2) : 1.;
+    const double beta2 = beta*beta;
+
+    const double w2    = G4HepEmLog(2.*kElectronMassC2*beta2*gam2) - beta2;
+    const double a1Tmp = meanLoss*(1. - kFluctParRate)/excEner;
+    const double kFluctParA0 = 42.;
+    const double kFluctParFw = 4.;
+    const double dum0  = a1Tmp < kFluctParA0
+                         ? .1 + (kFluctParFw - .1)*std::sqrt(a1Tmp/kFluctParA0)
+                         : kFluctParFw;
+    a1  = a1Tmp/dum0;
+    e1 *= dum0;
+    a3 *= kFluctParRate;
+    //
+    // add excition (a1 > 0)
+    if (a1 > kFluctParNMaxCont) {
+      // Gaussian
+      const double emean = a1*e1;
+      const double sig2e = emean*e1;
+      eloss = SampleGaussianLoss(emean, sig2e, rnge);
+    } else {
+      // small number --> sampling from Poisson
+      const int p = rnge->Poisson(a1);
+      eloss = p > 0 ? ((p + 1) - 2.*rnge->flat())*e1 : 0.;
+    }
+  }
+  //
+  // 2. ionisation part
+  if (a3 > 0.) {
+    double   p3 = a3;
+    double alfa = 1.;
+    if (a3 > kFluctParNMaxCont) {
+      alfa = w1*(kFluctParNMaxCont + a3)/(w1*kFluctParNMaxCont + a3);
+      const double alfa1  = alfa*G4HepEmLog(alfa)/(alfa - 1.);
+      const double namean = a3*w1*(alfa - 1.)/((w1 - 1.)*alfa);
+      const double emean  = namean*kFluctParE0*alfa1;
+      const double sig2e  = kFluctParE0*kFluctParE0*namean*(alfa - alfa1*alfa1);
+      eloss += SampleGaussianLoss(emean, sig2e, rnge);
+      p3 = a3 - namean;
+    }
+    //
+    const double w3 = alfa*kFluctParE0;
+    if (tcut > w3) {
+      const double w = (tcut - w3)/tcut;
+      const int  nnb = rnge->Poisson(p3);
+      if (nnb > 0) {
+        const int kBlockSize = 8;
+        const int nBlocks    = nnb/kBlockSize;
+        //
+        double rndm[kBlockSize];
+        for (int ib=0; ib<nBlocks; ++ib) {
+          rnge->flatArray(kBlockSize, rndm);
+          for (int i=0; i<kBlockSize; ++i) {
+            eloss += w3/(1.-w*rndm[i]);
+          }
+        }
+        const int nTail = nnb - nBlocks*kBlockSize;
+        rnge->flatArray(nTail, rndm);
+        for (int i=0; i<nTail; ++i) {
+          eloss += w3/(1.-w*rndm[i]);
+        }
+      }
+    }
+  }
+  //
+  // deliver result
+  return eloss*scaling;
+}
+
+
+double G4HepEmElectronEnergyLossFluctuation::SampleGaussianLoss(double meane, double sig2e, G4HepEmRandomEngine* rnge) {
+  const double twom = 2.*meane;
+  if (meane*meane < 0.0625*sig2e) {
+    return twom*rnge->flat();
+  }
+  const double sig = std::sqrt(sig2e);
+  double eloss;
+  do {
+    eloss = rnge->Gauss(meane, sig);
+  } while (eloss < 0. || eloss > twom);
+  return eloss;
+}

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionIoni.icc
@@ -53,7 +53,7 @@ double G4HepEmElectronInteractionIoni::SampleETransferMoller(const double elCut,
   const double tmax    = 0.5*primEkin;
   const double xmin    = tmin / primEkin;
   const double xmax    = tmax / primEkin;
-  const double gamma   = primEkin / kElectronMassC2 + 1.0;
+  const double gamma   = primEkin * kInvElectronMassC2 + 1.0;
   const double gamma2  = gamma * gamma;
   const double xminmax = xmin * xmax;
   // Moller (e-e-) scattering
@@ -79,7 +79,7 @@ double G4HepEmElectronInteractionIoni::SampleETransferBhabha(const double elCut,
   const double tmax    = primEkin;
   const double xmin    = tmin / primEkin;
   const double xmax    = tmax / primEkin;
-  const double gamma   = primEkin / kElectronMassC2 + 1.0;
+  const double gamma   = primEkin * kInvElectronMassC2 + 1.0;
   const double gamma2  = gamma * gamma;
   const double beta2   = 1. - 1. / gamma2;
   const double xminmax = xmin * xmax;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
@@ -263,7 +263,7 @@ double G4HepEmElectronInteractionUMSC::Theta0PositronCorrection(double eekin, do
   const double ff = 1. + zeff*(1.84035E-4*zeff - 1.86427E-2) + 0.41125;
   const double  a = 0.994 - 4.08E-3*zeff;
   const double  b = 7.16 + (52.6 + 365./zeff)/zeff;
-  const double tu = std::sqrt(eekin)/kElectronMassC2;
+  const double tu = std::sqrt(eekin)*kInvElectronMassC2;
   const double  x = std::sqrt(tu*(tu + 2.)/((tu + 1.)*(tu + 1.)));
   //
   const double xl = 0.6;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -20,6 +20,7 @@
 #include "G4HepEmGammaTrack.hh"
 #include "G4HepEmElectronInteractionIoni.hh"
 #include "G4HepEmElectronInteractionBrem.hh"
+#include "G4HepEmElectronEnergyLossFluctuation.hh"
 #include "G4HepEmElectronInteractionUMSC.hh"
 #include "G4HepEmPositronInteractionAnnihilation.hh"
 
@@ -255,17 +256,42 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     const double postStepRange = theRange - pStepLength;
     eloss = theEkin - GetInvRange(elData, theIMC, postStepRange);
   }
+  eloss = G4HepEmMax(eloss, 0.0);
+  // keep the mean energy loss
+  const double meanELoss = eloss;
+  bool isActiveEnergyLossFluctuation = false;
+  if (eloss >= theEkin) {
+    eloss = theEkin;
+  } else {
+    // sample energy loss fluctuations
+    const double kFluctParMinEnergy  = 1.E-5; // 10 eV
+    if (meanELoss > kFluctParMinEnergy) {
+      isActiveEnergyLossFluctuation = true;
+      const G4HepEmMCCData& theMatCutData = hepEmData->fTheMatCutData->fMatCutData[theIMC];
+      const double elCut   = theMatCutData.fSecElProdCutE;
+      const int    theImat = theMatCutData.fHepEmMatIndex;
+      const G4HepEmMatData& theMatData =  hepEmData->fTheMaterialData->fMaterialData[theImat];
+      const double meanExcEnergy       = theMatData.fMeanExEnergy;
+      const double meanExcEnergyLog    = theMatData.fLogMeanExEnergy;
+      //
+      const double tmax = isElectron ? 0.5*theEkin : theEkin;
+      const double tcut = G4HepEmMin(elCut, tmax);
+      eloss = G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(theEkin, tcut, tmax,
+                                                    meanExcEnergy, meanExcEnergyLog, pStepLength, meanELoss, rnge);
+    }
+  }
+  eloss = G4HepEmMax(eloss, 0.0);
+  //
   // 3/3. check if final kinetic energy drops below the tracking cut and stop
   double finalEkin = theEkin - eloss;
   if (finalEkin <= hepEmPars->fElectronTrackingCut) {
     eloss     = theEkin;
     finalEkin = 0.0;
-    eloss = G4HepEmMax(eloss, 0.0);
     theTrack->SetEKin(finalEkin);
     theTrack->SetEnergyDeposit(eloss);
     return true;
   }
-  eloss = G4HepEmMax(eloss, 0.0);
+  //
   theTrack->SetEKin(finalEkin);
   theTrack->SetEnergyDeposit(eloss);
 
@@ -284,8 +310,10 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     double postStepEkin  = theEkin;
     double postStepLEkin = theLEkin;
     if (pStepLength > theRange*0.01) {
-      postStepEkin  = theTrack->GetEKin();
-      postStepLEkin = theTrack->GetLogEKin();
+      // meanELoss = eloss when the energy loss fluct. is NOT active so postStepEkin = finalEkin in that
+      // case which can save a log call for us since we can get the log-finalEkin now from the track
+      postStepEkin  = theEkin - meanELoss;
+      postStepLEkin = isActiveEnergyLossFluctuation ? G4HepEmLog(postStepEkin) : theTrack->GetLogEKin();
     }
     // sample msc scattering:
     // - compute the fist transport mean free path at the post-step energy point

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -469,7 +469,7 @@ double  G4HepEmElectronManager::GetTransportMFP(const struct G4HepEmElectronData
 
 double G4HepEmElectronManager::ComputeMacXsecAnnihilation(const double ekin, const double electronDensity) {
   // Heitler model for e+e- -> 2g annihilation
-  const double tau   = ekin/kElectronMassC2;
+  const double tau   = ekin*kInvElectronMassC2;
   const double gam   = tau + 1.0;
   const double gam2  = gam*gam;
   const double bg2   = tau * (tau+2.0);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -270,14 +270,12 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
       const G4HepEmMCCData& theMatCutData = hepEmData->fTheMatCutData->fMatCutData[theIMC];
       const double elCut   = theMatCutData.fSecElProdCutE;
       const int    theImat = theMatCutData.fHepEmMatIndex;
-      const G4HepEmMatData& theMatData =  hepEmData->fTheMaterialData->fMaterialData[theImat];
-      const double meanExcEnergy       = theMatData.fMeanExEnergy;
-      const double meanExcEnergyLog    = theMatData.fLogMeanExEnergy;
+      const double meanExE = hepEmData->fTheMaterialData->fMaterialData[theImat].fMeanExEnergy;
       //
       const double tmax = isElectron ? 0.5*theEkin : theEkin;
       const double tcut = G4HepEmMin(elCut, tmax);
       eloss = G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(theEkin, tcut, tmax,
-                                                    meanExcEnergy, meanExcEnergyLog, pStepLength, meanELoss, rnge);
+                                                    meanExE, pStepLength, meanELoss, rnge);
     }
   }
   eloss = G4HepEmMax(eloss, 0.0);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionCompton.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionCompton.icc
@@ -67,7 +67,7 @@ void G4HepEmGammaInteractionCompton::Perform(G4HepEmTLData* tlData, struct G4Hep
 double G4HepEmGammaInteractionCompton::SamplePhotonEnergyAndDirection(
     const double thePrimGmE, double* thePrimGmDir, const double* theOrgPrimGmDir, G4HepEmRandomEngine* rnge) {
   // sample the post interaction reduced photon energy according to the KN DCS
-  const double kappa = thePrimGmE / kElectronMassC2;
+  const double kappa = thePrimGmE * kInvElectronMassC2;
   const double eps0  = 1. / (1. + 2. * kappa);
   const double eps02 = eps0 * eps0;
   const double al1   = -G4HepEmLog(eps0);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaInteractionPhotoelectric.icc
@@ -81,7 +81,7 @@ void G4HepEmGammaInteractionPhotoelectric::SamplePhotoElectronDirection(const do
   // Initial algorithm according Penelope 2008 manual and
   // F.Sauter Ann. Physik 9, 217(1931); 11, 454(1931).
   // Modified according Penelope 2014 manual
-  const double tau = kinE/kElectronMassC2;
+  const double tau = kinE * kInvElectronMassC2;
   const double gamma = 1.0 + tau;
   const double beta = std::sqrt(tau*(tau + 2.0))/gamma;
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmInteractionUtils.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmInteractionUtils.icc
@@ -10,7 +10,7 @@
 G4HepEmHostDevice
 double SampleCostModifiedTsai(const double thePrimEkin, G4HepEmRandomEngine* rnge) {
   // sample photon direction (modified Tsai sampling):
-  const double uMax = 2.0*(1.0 + thePrimEkin/kElectronMassC2);
+  const double uMax = 2.0*(1.0 + thePrimEkin*kInvElectronMassC2);
   double rndm3[3];
   double u;
   do {

--- a/G4HepEm/G4HepEmRun/include/G4HepEmPositronInteractionAnnihilation.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmPositronInteractionAnnihilation.icc
@@ -52,7 +52,7 @@ void G4HepEmPositronInteractionAnnihilation::SampleEnergyAndDirectionsInFlight(
     const double thePrimEkin, const double *thePrimDir, double *theGamma1Ekin, double *theGamma1Dir,
     double *theGamma2Ekin, double *theGamma2Dir, G4HepEmRandomEngine* rnge) {
   // compute kinetic limits
-  const double tau     = thePrimEkin/kElectronMassC2;
+  const double tau     = thePrimEkin*kInvElectronMassC2;
   const double gam     = tau + 1.0;
   const double tau2    = tau + 2.0;
   const double sqgrate = std::sqrt(tau/tau2)*0.5;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
@@ -4,6 +4,7 @@
 
 #include "G4HepEmMacros.hh"
 #include "G4HepEmMath.hh"
+#include "G4HepEmConstants.hh"
 
 #include <cmath>
 
@@ -57,6 +58,33 @@ public:
 
   G4HepEmHostDevice
   void DiscardGauss() { fIsGauss = false; }
+
+
+  G4HepEmHostDevice
+  int Poisson(double mean) {
+    const int   border = 16;
+    const double limit = 2.E+9;
+
+    int number = 0;
+    if(mean <= border) {
+      const double position = flat();
+      double poissonValue   = G4HepEmExp(-mean);
+      double poissonSum     = poissonValue;
+      while(poissonSum <= position) {
+        ++number;
+        poissonValue *= mean/number;
+        poissonSum   += poissonValue;
+      }
+      return number;
+    }  // the case of mean <= 16
+    //
+    double rnd[2];
+    flatArray(2, rnd);
+    const double t = std::sqrt(-2.*G4HepEmLog(rnd[0])) * std::cos(k2Pi*rnd[1]);
+    double value = mean + t*std::sqrt(mean) + 0.5;
+    return value < 0.     ?  0 :
+           value >= limit ? static_cast<int>(limit) : static_cast<int>(value);
+  }
 
 
 private:

--- a/apps/examples/TestEm3/src/PhysListG4Em.cc
+++ b/apps/examples/TestEm3/src/PhysListG4Em.cc
@@ -56,7 +56,6 @@ PhysListG4Em::PhysListG4Em(const G4String& name)
   param->SetDefaults();
 
   param->SetMscRangeFactor(0.04);
-  param->SetLossFluctuations(false);
 
   SetPhysicsType(bElectromagnetic);
 }

--- a/apps/examples/TestEm3/src/PhysListG4EmTracking.cc
+++ b/apps/examples/TestEm3/src/PhysListG4EmTracking.cc
@@ -17,7 +17,6 @@ PhysListG4EmTracking::PhysListG4EmTracking(const G4String& name)
   param->SetDefaults();
 
   param->SetMscRangeFactor(0.04);
-  param->SetLossFluctuations(false);
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......


### PR DESCRIPTION
The Laszlo's universal model for energy loss fluctuation has been implemented for e-/e+ in `G4HepEm`. The implemented model corresponds to the `G4UniversalFluctuation` model as it is in `Geant4-v11.p01` (its latest public release version, i.e. `Geant4-v11.00`, can also be used for comparisons: see [`G4HepEmElectronEnergyLossFluctuation.icc`](https://github.com/mnovak42/g4hepem/blob/addElossFluct/G4HepEm/G4HepEmRun/include/G4HepEmElectronEnergyLossFluctuation.icc#28) ).