### PR TITLE
Correct the name of the process that defined the step.

### DIFF
--- a/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/src/G4HepEmProcess.cc
@@ -79,9 +79,9 @@ void G4HepEmProcess::BuildPhysicsTable(const G4ParticleDefinition& partDef) {
     fElectronNoProcessVector[3] = new G4HepEmNoProcess("msc");
   } else if (partDef.GetPDGEncoding()==22) {   // gamma
     fTheG4HepEmRunManager->Initialize(fTheG4HepEmRandomEngine, 2);
-    fGammaNoProcessVector[0]    = new G4HepEmNoProcess("phot");
+    fGammaNoProcessVector[0]    = new G4HepEmNoProcess("conv");
     fGammaNoProcessVector[1]    = new G4HepEmNoProcess("compt");
-    fGammaNoProcessVector[2]    = new G4HepEmNoProcess("conv");
+    fGammaNoProcessVector[2]    = new G4HepEmNoProcess("phot");
   } else {
     std::cerr << " **** ERROR in G4HepEmProcess::BuildPhysicsTable: unknown particle " << std::endl;
     exit(-1);


### PR DESCRIPTION
Note, that there are no real processes in `G4HepEm` but some `Geant4` user codes might need to know the type/name of the `G4VProcess` that defined a given step and possible created some (secondary) tracks. So the `G4HepEmProcess` creates a set of empty `G4VProcess`-es with the correct names (e.g. "phot", "compt" and "conv") and sets the *Process defined step* pointer field of the post-step to the appropriate one. 