### PR TITLE
Add possibility of MSC stepping to HepEmTrackingManager

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -125,6 +125,48 @@ public:
   G4HepEmHostDevice
   static void HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge);
 
+  /** Function that updates the physical step length after the geometry step.
+    *
+    * If MSC is active and we hit a boundary, convert the geometry step length
+    * to a true step length.
+    */
+  G4HepEmHostDevice
+  static void UpdatePStepLength(G4HepEmElectronTrack* theElTrack);
+
+  /** Update the number-of-interaction-left according to the physical step length.
+    *
+    * @param theElTrack pointer to the input and output information of the track.
+    */
+  G4HepEmHostDevice
+  static void UpdateNumIALeft(G4HepEmElectronTrack* theElTrack);
+
+  /** Apply the mean energy loss along the physical step length.
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input and output information of the track.
+    */
+  G4HepEmHostDevice
+  static bool ApplyMeanEnergyLoss(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack);
+
+  /** Sample MSC direction change and displacement.
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input and output information of the track.
+    */
+  G4HepEmHostDevice
+  static void SampleMSC(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge);
+
+  /** Sample loss fluctuations for the mean energy loss.
+    * 
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input and output information of the track.
+    */
+  G4HepEmHostDevice
+  static bool SampleLossFluctuations(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge);
+
   /** Functions that performs all continuous physics interactions for a given e-/e+ particle.
     *
     * This functions can be invoked when the particle is propagated to its post-step point to perform all

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -73,6 +73,44 @@ public:
   /** Function that provides the information regarding how far a given e-/e+ particle goes.
     *
     * This function provides the information regarding how far a given e-/e+ particle goes
+    * till it's needed to be stopped again because a discrete interaction needs to be performed.
+    * The input/primary e-/e+ particle track is provided as G4HepEmElectronTrack which must have sampled
+    * `number-of-interaction-left`. The computed physics step length is written directly into the input
+    * track. There is no local (state) variable used in the computation.
+    *
+    * Note: This function does *not* involve multiple scattering!
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input information of the track. The data structure must have all entries
+    *   `number-of-interaction-left` sampled and is also used to deliver the results of the function call, i.e.
+    *   the computed physics step limit is written into its fPStepLength member.
+    */
+  G4HepEmHostDevice
+  static void HowFarToDiscreteInteraction(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack);
+
+  /** Function that provides the information regarding how far a given e-/e+ particle goes.
+    *
+    * This function provides the information regarding how far a given e-/e+ particle goes
+    * till it's needed to be stopped again because of a MSC step limit.
+    * The input/primary e-/e+ particle track is provided as G4HepEmElectronTrack which must have sampled
+    * `number-of-interaction-left`. The computed physics step length is written directly into the input
+    * track. There is no local (state) variable used in the computation.
+    *
+    * Note: This function does *not* involve multiple scattering!
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param theElTrack pointer to the input information of the track, used to deliver the results of
+    *   the function call, i.e.the computed physics step limit is written into its fPStepLength and
+    *   fGStepLength member.
+    */
+  G4HepEmHostDevice
+  static void HowFarToMSC(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge);
+
+  /** Function that provides the information regarding how far a given e-/e+ particle goes.
+    *
+    * This function provides the information regarding how far a given e-/e+ particle goes
     * till it's needed to be stopped again because some physics interaction(s) needs to be performed.
     * The input/primary e-/e+ particle track is provided as G4HepEmElectronTrack which must have sampled
     * `number-of-interaction-left`. The computed physics step length is written directly into the input

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -194,6 +194,17 @@ public:
   G4HepEmHostDevice
   static bool CheckDelta(struct G4HepEmData* hepEmData, G4HepEmTrack* theTrack, double rand);
 
+  /** Functions that performs the discrete interaction for a given e-/e+ particle.
+    *
+    * @param hepEmData pointer to the top level, global, G4HepEmData structure.
+    * @param hepEmPars pointer to the global, G4HepEmParameters structure.
+    * @param tlData    pointer to a worker-local, G4HepEmTLData object. The corresonding object
+    *   is assumed to contain all the required input information in its primary G4HepEmTLData::fElectronTrack
+    *   member. All the results of this function call, i.e. the primary particle updated to its post-interaction(s)
+    *   state as well as the possible secondary particles, are also delivered through this G4HepEmTLData.
+    */
+  static void PerformDiscrete(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData);
+
   /** Functions that performs all physics interactions for a given e-/e+ particle.
     *
     * This functions can be invoked when the particle is propagated to its post-step point to perform all

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -408,6 +408,39 @@ bool G4HepEmElectronManager::CheckDelta(struct G4HepEmData* hepEmData, G4HepEmTr
   return mxsec <= 0.0 || rand > mxsec*theTrack->GetMFP(iDProc);
 }
 
+void G4HepEmElectronManager::PerformDiscrete(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
+  G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
+  G4HepEmTrack*   theTrack = theElTrack->GetTrack();
+  const bool isElectron = (theTrack->GetCharge() < 0.0);
+
+  // 1. check if discrete process limited the step return otherwise (i.e. if
+  //      continous or boundary process limited the step)
+  const int iDProc = theTrack->GetWinnerProcessIndex();
+  if (iDProc < 0 || theTrack->GetOnBoundary()) {
+    return;
+  }
+  // reset number of interaction left for the winner discrete process
+  theTrack->SetNumIALeft(-1.0, iDProc);
+
+  // 2. check if delta interaction happens instead of the real discrete process
+  if (CheckDelta(hepEmData, theTrack, tlData->GetRNGEngine()->flat())) {
+    return;
+  }
+
+  // 3. perform the discrete part of the winner interaction
+  const double theEkin = theTrack->GetEKin();
+  switch (iDProc) {
+    case 0: // invoke ioni (for e-/e+):
+            G4HepEmElectronInteractionIoni::Perform(tlData, hepEmData, isElectron);
+            break;
+    case 1: // invoke brem (for e-/e+): either SB- or Rel-Brem
+            G4HepEmElectronInteractionBrem::Perform(tlData, hepEmData, isElectron, theEkin < hepEmPars->fElectronBremModelLim);
+            break;
+    case 2: // invoke annihilation (in-flight) for e+
+            G4HepEmPositronInteractionAnnihilation::Perform(tlData, false);
+            break;
+  }
+}
 
 void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmTLData* tlData) {
   G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
@@ -430,33 +463,7 @@ void G4HepEmElectronManager::Perform(struct G4HepEmData* hepEmData, struct G4Hep
   }
 
   // === 4. Discrete part of the interaction (if any)
-  // 4/1. check if discrete process limited the step return otherwise (i.e. if
-  //      continous or boundary process limited the step)
-  const int iDProc = theTrack->GetWinnerProcessIndex();
-  if (iDProc < 0 || theTrack->GetOnBoundary()) {
-    return;
-  }
-  // reset number of interaction left for the winner discrete process
-  theTrack->SetNumIALeft(-1.0, iDProc);
-
-  // 4/2. check if delta interaction happens instead of the real discrete process
-  if (CheckDelta(hepEmData, theTrack, tlData->GetRNGEngine()->flat())) {
-    return;
-  }
-
-  // 4/3. perform the discrete part of the winner interaction
-  const double theEkin = theTrack->GetEKin();
-  switch (iDProc) {
-    case 0: // invoke ioni (for e-/e+):
-            G4HepEmElectronInteractionIoni::Perform(tlData, hepEmData, isElectron);
-            break;
-    case 1: // invoke brem (for e-/e+): either SB- or Rel-Brem
-            G4HepEmElectronInteractionBrem::Perform(tlData, hepEmData, isElectron, theEkin < hepEmPars->fElectronBremModelLim);
-            break;
-    case 2: // invoke annihilation (in-flight) for e+
-            G4HepEmPositronInteractionAnnihilation::Perform(tlData, false);
-            break;
-  }
+  PerformDiscrete(hepEmData, hepEmPars, tlData);
 }
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -45,7 +45,7 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
 }
 
 
-void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
+void G4HepEmElectronManager::HowFarToDiscreteInteraction(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack) {
   int indxWinnerProcess = -1;  // init to continous
   // === 1. Continuous energy loss limit
   double pStepLength     = kALargeValue;
@@ -92,6 +92,13 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
       indxWinnerProcess = ip;
     }
   }
+
+  theElTrack->SetPStepLength(pStepLength);
+  theTrack->SetWinnerProcessIndex(indxWinnerProcess);
+  theTrack->SetGStepLength(pStepLength);
+}
+
+void G4HepEmElectronManager::HowFarToMSC(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
   //
   // Now MSC is called to see:
   // - if it limits the (true, i.e. physical) step length further
@@ -104,6 +111,20 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
   // the physical -->  geometric (i.e. true to geom.) conversion.
   //
 #ifndef NOMSC
+  double pStepLength     = theElTrack->GetPStepLength();
+  const double range     = theElTrack->GetRange();
+  G4HepEmTrack* theTrack = theElTrack->GetTrack();
+  const double   theEkin = theTrack->GetEKin();
+  const double  theLEkin = theTrack->GetLogEKin();
+  const int       theIMC = theTrack->GetMCIndex();
+  const bool  isElectron = (theTrack->GetCharge() < 0.0);
+
+  const G4HepEmElectronData* theElectronData = isElectron
+                                               ? hepEmData->fTheElectronData
+                                               : hepEmData->fThePositronData;
+
+  const int theImat = (hepEmData->fTheMatCutData->fMatCutData[theIMC]).fHepEmMatIndex;
+
   G4HepEmMSCTrackData* mscData = theElTrack->GetMSCTrackData();
   // init some mscData for the case if we skipp calling msc due to very small step
   mscData->fTrueStepLength      = pStepLength;
@@ -128,22 +149,20 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
     // check now if msc limited the step:
     const double mscTruStepLength = mscData->fTrueStepLength;
     if (mscTruStepLength < pStepLength) {
-       // indicate continuous step limit as msc limited the step and set the new pStepLengt
-      indxWinnerProcess = -2;
+      // indicate continuous step limit as msc limited the step and set the new pStepLength
+      theTrack->SetWinnerProcessIndex(-2);
       pStepLength = mscTruStepLength;
+      theElTrack->SetPStepLength(pStepLength);
     }
+    // set geometrical step length (protect agains wrong conversion, i.e. if gL > pL)
+    theTrack->SetGStepLength(G4HepEmMin(mscData->fZPathLength, pStepLength));
   }
-  // set geometrical step length (protect agains wrong conversion, i.e. if gL > pL)
-  theTrack->SetGStepLength(G4HepEmMin(mscData->fZPathLength, pStepLength));
-
-  // finally set the true (physical) step length and the winner process index of this primary track
-  theElTrack->SetPStepLength(pStepLength);
-  theTrack->SetWinnerProcessIndex(indxWinnerProcess);
-#else
-  theElTrack->SetPStepLength(pStepLength);
-  theTrack->SetWinnerProcessIndex(indxWinnerProcess);
-  theTrack->SetGStepLength(pStepLength);
 #endif
+}
+
+void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
+  HowFarToDiscreteInteraction(hepEmData, hepEmPars, theElTrack);
+  HowFarToMSC(hepEmData, hepEmPars, theElTrack, rnge);
 }
 
 // Here I can have my own transportation to be called BUT at the moment I cannot

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -252,50 +252,17 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     eloss = theEkin - GetInvRange(elData, theIMC, postStepRange);
   }
   eloss = G4HepEmMax(eloss, 0.0);
-#if !defined(NOMSC) || !defined(NOFLUCTUATION)
-  // keep the mean energy loss
-  const double meanELoss = eloss;
-#endif
-#ifndef NOMSC
-  bool isActiveEnergyLossFluctuation = false;
-#endif
   if (eloss >= theEkin) {
     eloss = theEkin;
-  } else {
-#ifndef NOFLUCTUATION
-    // sample energy loss fluctuations
-    const double kFluctParMinEnergy  = 1.E-5; // 10 eV
-    if (meanELoss > kFluctParMinEnergy) {
-#ifndef NOMSC
-      isActiveEnergyLossFluctuation = true;
-#endif
-      const G4HepEmMCCData& theMatCutData = hepEmData->fTheMatCutData->fMatCutData[theIMC];
-      const double elCut   = theMatCutData.fSecElProdCutE;
-      const int    theImat = theMatCutData.fHepEmMatIndex;
-      const double meanExE = hepEmData->fTheMaterialData->fMaterialData[theImat].fMeanExEnergy;
-      //
-      const double tmax = isElectron ? 0.5*theEkin : theEkin;
-      const double tcut = G4HepEmMin(elCut, tmax);
-      eloss = G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(theEkin, tcut, tmax,
-                                                    meanExE, pStepLength, meanELoss, rnge);
-    }
-#endif
-  }
-  eloss = G4HepEmMax(eloss, 0.0);
-  //
-  // 3/3. check if final kinetic energy drops below the tracking cut and stop
-  double finalEkin = theEkin - eloss;
-  if (finalEkin <= hepEmPars->fElectronTrackingCut) {
-    eloss     = theEkin;
-    finalEkin = 0.0;
-    theTrack->SetEKin(finalEkin);
+    theTrack->SetEKin(0);
     theTrack->SetEnergyDeposit(eloss);
     return true;
   }
-  //
-  theTrack->SetEKin(finalEkin);
-  theTrack->SetEnergyDeposit(eloss);
-
+  // Compute the energy after the mean energy loss. This is used for MSC and,
+  // in case energy loss fluctuations are not active, it is also the final
+  // energy after this method.
+  double theEkinAfterMeanEloss = theEkin - eloss;
+  theTrack->SetEKin(theEkinAfterMeanEloss);
 
 #ifndef NOMSC
   //
@@ -311,16 +278,11 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     double postStepEkin  = theEkin;
     double postStepLEkin = theLEkin;
     if (pStepLength > theRange*0.01) {
-      // meanELoss = eloss when the energy loss fluct. is NOT active so postStepEkin = finalEkin in that
-      // case which can save a log call for us since we can get the log-finalEkin now from the track
-      if (!isActiveEnergyLossFluctuation) {
-        postStepEkin  = theTrack->GetEKin();
-        postStepLEkin = theTrack->GetLogEKin();
-      } else {
-        // Otherwise subtract the mean energy loss and compute the logarithm.
-        postStepEkin  = theEkin - meanELoss;
-        postStepLEkin = G4HepEmLog(postStepEkin);
-      }
+      // At this point, we have only computed the mean energy loss. Query the
+      // track and if energy loss fluctuations are *not* active, we safe a log
+      // call in the next step.
+      postStepEkin  = theTrack->GetEKin();
+      postStepLEkin = theTrack->GetLogEKin();
     }
     // sample msc scattering:
     // - compute the fist transport mean free path at the post-step energy point
@@ -344,6 +306,37 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     }
   }
 #endif
+
+  double finalEkin = theEkinAfterMeanEloss;
+  // sample energy loss fluctuations
+#ifndef NOFLUCTUATION
+  const double kFluctParMinEnergy  = 1.E-5; // 10 eV
+  if (eloss > kFluctParMinEnergy) {
+    const G4HepEmMCCData& theMatCutData = hepEmData->fTheMatCutData->fMatCutData[theIMC];
+    const double elCut   = theMatCutData.fSecElProdCutE;
+    const int    theImat = theMatCutData.fHepEmMatIndex;
+    const double meanExE = hepEmData->fTheMaterialData->fMaterialData[theImat].fMeanExEnergy;
+    //
+    const double tmax = isElectron ? 0.5*theEkin : theEkin;
+    const double tcut = G4HepEmMin(elCut, tmax);
+    eloss = G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(theEkin, tcut, tmax,
+                                                  meanExE, pStepLength, eloss, rnge);
+    eloss = G4HepEmMax(eloss, 0.0);
+    // Update the final kinetic energy after loss fluctuations.
+    finalEkin = theEkin - eloss;
+  }
+#endif
+  //
+  // Check if the final kinetic energy drops below the tracking cut and stop.
+  if (finalEkin <= hepEmPars->fElectronTrackingCut) {
+    eloss     = theEkin;
+    finalEkin = 0.0;
+    theTrack->SetEKin(finalEkin);
+    theTrack->SetEnergyDeposit(eloss);
+    return true;
+  }
+  theTrack->SetEKin(finalEkin);
+  theTrack->SetEnergyDeposit(eloss);
   return false;
 
 }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -187,31 +187,6 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
       isScattering = false;
     }
   }
-
-/*
-  if (isScattering) {
-    const G4HepEmElectronData* elData0 = isElectron
-                                        ? hepEmData->fTheElectronData
-                                        : hepEmData->fThePositronData;
-
-    const double postStepRange = theRange - pStepLength;
-    double eloss0 = theEkin - GetInvRange(elData0, theTrack->GetMCIndex(), postStepRange);
-
-    G4HepEmElectronInteractionMSC::SampleScattering(hepEmData, mscData, pStepLength, theEkin, eloss0, theTrack->GetMCIndex(), isElectron, rnge);
-    // NOTE: displacement will be applied in the caller where we have access to the required Geant4 functionality
-    //       (and if its length is longer than a small minimal length and we are not ended up on boundary)
-    //
-    // rotate direction and displacement vectors (if any) and update new direction of the primary
-    if (!(mscData->fIsNoScatteringInMSC)) {
-      RotateToReferenceFrame(mscData->fDirection, theTrack->GetDirection());
-      if (!(mscData->fIsNoDisplace)) {
-        RotateToReferenceFrame(mscData->fDisplacement, theTrack->GetDirection());
-      }
-      // upadte new direction
-      theTrack->SetDirection(mscData->fDirection);
-    }
-  }
-*/
 #else
     double pStepLength = theTrack->GetGStepLength();
 #endif

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -165,31 +165,19 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
   HowFarToMSC(hepEmData, hepEmPars, theElTrack, rnge);
 }
 
-// Here I can have my own transportation to be called BUT at the moment I cannot
-// skip the G4Transportation if I do it by myself !!!
-
-// Note: energy deposit will be set here i.e. this is the first access to it that
-//       will clear the previous step value.
-bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
-  //
-  // === 1. MSC should be invoked to obtain the physics step Length
+void G4HepEmElectronManager::UpdatePStepLength(G4HepEmElectronTrack* theElTrack) {
   G4HepEmTrack*   theTrack = theElTrack->GetTrack();
+  const double gStepLength = theTrack->GetGStepLength();
+  double pStepLength       = gStepLength;
   // call MSC::ConvertGeometricToTrueLength that will provide the true (i.e. physical)
   // step length in the G4HepEmMSCTrackData::fTrueStepLength member.
   // NOTE: in case the step was NOT limited by boundary, we know the true step length since
   //       the particle went as far as we expected.
-  const bool        isElectron = (theTrack->GetCharge() < 0.0);
-  const double        theEkin  = theTrack->GetEKin();
-  const double        theRange = theElTrack->GetRange();
-
 #ifndef NOMSC
-  const double gStepLength = theTrack->GetGStepLength();
-  double pStepLength = gStepLength;
-  bool isScattering = false;
+  const double        theRange = theElTrack->GetRange();
   G4HepEmMSCTrackData* mscData = theElTrack->GetMSCTrackData();
   if (mscData->fIsActive) {
     pStepLength = mscData->fTrueStepLength;
-    isScattering = true;
     // if we hit boundary or stopped before we wanted for any reasons: convert geom. -> true
     if (gStepLength < mscData->fZPathLength) {
       // the converted geom --> true step Length will be written into mscData::fTrueStepLength
@@ -203,33 +191,32 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     // optimisation: do not sample msc and dispalcement in case of last (rangeing out) or short steps
     const double kGeomMinLength = 5.E-8; // 0.05 [nm]
     if (pStepLength <= kGeomMinLength || theRange <= pStepLength) {
-      isScattering = false;
+      mscData->fIsActive = false;
     }
   }
-#else
-    double pStepLength = theTrack->GetGStepLength();
 #endif
   // set the results of the geom ---> true in the primary e- etrack
   theElTrack->SetPStepLength(pStepLength);
-  //
-  if (pStepLength<=0.0) {
-    return false;
-  }
-  // compute the energy loss first based on the new step length: it will be needed in the
-  // MSC scatteirng and displacement computation here as well (that is done only if not
-  // the last step with the particle).
-  // But update the number of interaction length left before.
-  //
-  // === 2. The `number-of-interaction-left` needs to be updated based on the actual
-  //        physical step Length
+}
+
+void G4HepEmElectronManager::UpdateNumIALeft(G4HepEmElectronTrack* theElTrack) {
+  const double pStepLength = theElTrack->GetPStepLength();
+  G4HepEmTrack*   theTrack = theElTrack->GetTrack();
   double*    numInterALeft = theTrack->GetNumIALeft();
   double*       preStepMFP = theTrack->GetMFP();
   numInterALeft[0] -= pStepLength/preStepMFP[0];
   numInterALeft[1] -= pStepLength/preStepMFP[1];
   numInterALeft[2] -= pStepLength/preStepMFP[2];
-  //
-  // === 3. Continuous energy loss needs to be computed
-  // 3./1. stop tracking when reached the end (i.e. it has been ranged out by the limit)
+}
+
+bool G4HepEmElectronManager::ApplyMeanEnergyLoss(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack) {
+  const double pStepLength = theElTrack->GetPStepLength();
+
+  G4HepEmTrack* theTrack = theElTrack->GetTrack();
+  const bool  isElectron = (theTrack->GetCharge() < 0.0);
+  const double   theEkin = theTrack->GetEKin();
+  const double  theRange = theElTrack->GetRange();
+  // 0. stop tracking when reached the end (i.e. it has been ranged out by the limit)
   // @TODO: actually the tracking cut is around 1 keV and the min-table energy is 100 eV so the second should never
   //        under standard EM constructor configurations
   if (pStepLength >= theRange || theEkin <= hepEmPars->fMinLossTableEnergy) {
@@ -238,7 +225,7 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     theTrack->SetEKin(0.0);
     return true;
   }
-  // 3/1. try linear energy loss approximation:
+  // 1. try linear energy loss approximation:
   const G4HepEmElectronData* elData = isElectron
                                       ? hepEmData->fTheElectronData
                                       : hepEmData->fThePositronData;
@@ -246,7 +233,7 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
   const int      theIMC = theTrack->GetMCIndex();
   const double theLEkin = theTrack->GetLogEKin();
   double eloss = pStepLength*GetRestDEDX(elData, theIMC, theEkin, theLEkin);
-  // 3/2. use integral if linear energy loss is over the limit fraction
+  // 2. use integral if linear energy loss is over the limit fraction
   if (eloss > theEkin*hepEmPars->fLinELossLimit) {
     const double postStepRange = theRange - pStepLength;
     eloss = theEkin - GetInvRange(elData, theIMC, postStepRange);
@@ -258,13 +245,27 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     theTrack->SetEnergyDeposit(eloss);
     return true;
   }
-  // Compute the energy after the mean energy loss. This is used for MSC and,
-  // in case energy loss fluctuations are not active, it is also the final
-  // energy after this method.
+  // 3. Compute the energy after the mean energy loss.
   double theEkinAfterMeanEloss = theEkin - eloss;
   theTrack->SetEKin(theEkinAfterMeanEloss);
+  theTrack->SetEnergyDeposit(eloss);
+  return false;
+}
 
+void G4HepEmElectronManager::SampleMSC(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
 #ifndef NOMSC
+  const double pStepLength = theElTrack->GetPStepLength();
+  G4HepEmTrack*   theTrack = theElTrack->GetTrack();
+  const bool    isElectron = (theTrack->GetCharge() < 0.0);
+  const int         theIMC = theTrack->GetMCIndex();
+  const double preStepEkin = theElTrack->GetPreStepEKin();
+  const double    theRange = theElTrack->GetRange();
+
+  const G4HepEmElectronData* elData = isElectron
+                                      ? hepEmData->fTheElectronData
+                                      : hepEmData->fThePositronData;
+
+  //
   //
   // Complete here the MSC part by computing the net angular deflection and dispalcement
   //
@@ -273,10 +274,11 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
   // mscData::fDisplacement.
   const double kTLimitMinfix = 1.0E-8; // 0.01 [nm] 1.0E-8 [mm]
   const double kTauSmall     = 1.0e-16;
-  if (isScattering && (pStepLength > G4HepEmMax(kTLimitMinfix, kTauSmall*mscData->fLambtr1))) {
+  G4HepEmMSCTrackData* mscData = theElTrack->GetMSCTrackData();
+  if (mscData->fIsActive && (pStepLength > G4HepEmMax(kTLimitMinfix, kTauSmall*mscData->fLambtr1))) {
     // only to make sure that we also use E2 = E1 under the same condition as in G4
-    double postStepEkin  = theEkin;
-    double postStepLEkin = theLEkin;
+    double postStepEkin  = preStepEkin;
+    double postStepLEkin = theElTrack->GetPreStepLogEKin();
     if (pStepLength > theRange*0.01) {
       // At this point, we have only computed the mean energy loss. Query the
       // track and if energy loss fluctuations are *not* active, we safe a log
@@ -290,7 +292,7 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     const double postStepTr1mfp = GetTransportMFP(elData, theImat, postStepEkin, postStepLEkin);
     // - sample scattering: including net angular deflection and lateral dispacement that will be
     //                      written into mscData::fDirection and mscData::fDisplacement
-    G4HepEmElectronInteractionUMSC::SampleScattering(hepEmData, mscData, pStepLength, theEkin, mscData->fLambtr1, postStepEkin, postStepTr1mfp,
+    G4HepEmElectronInteractionUMSC::SampleScattering(hepEmData, mscData, pStepLength, preStepEkin, mscData->fLambtr1, postStepEkin, postStepTr1mfp,
                                     theImat, isElectron, rnge);
     // NOTE: displacement will be applied in the caller where we have access to the required Geant4 functionality
     //       (and if its length is longer than a small minimal length and we are not ended up on boundary)
@@ -306,8 +308,20 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     }
   }
 #endif
+}
 
-  double finalEkin = theEkinAfterMeanEloss;
+bool G4HepEmElectronManager::SampleLossFluctuations(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
+  const double pStepLength = theElTrack->GetPStepLength();
+  G4HepEmTrack*   theTrack = theElTrack->GetTrack();
+  const bool    isElectron = (theTrack->GetCharge() < 0.0);
+  const int         theIMC = theTrack->GetMCIndex();
+
+  const double thePreStepEkin = theElTrack->GetPreStepEKin();
+
+  // Previously ApplyMeanEnergyLoss computed the mean energy loss and stored the
+  // result into the track.
+  double finalEkin = theTrack->GetEKin();
+  double eloss     = theTrack->GetEnergyDeposit();
   // sample energy loss fluctuations
 #ifndef NOFLUCTUATION
   const double kFluctParMinEnergy  = 1.E-5; // 10 eV
@@ -317,19 +331,19 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
     const int    theImat = theMatCutData.fHepEmMatIndex;
     const double meanExE = hepEmData->fTheMaterialData->fMaterialData[theImat].fMeanExEnergy;
     //
-    const double tmax = isElectron ? 0.5*theEkin : theEkin;
+    const double tmax = isElectron ? 0.5*thePreStepEkin : thePreStepEkin;
     const double tcut = G4HepEmMin(elCut, tmax);
-    eloss = G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(theEkin, tcut, tmax,
+    eloss = G4HepEmElectronEnergyLossFluctuation::SampleEnergyLossFLuctuation(thePreStepEkin, tcut, tmax,
                                                   meanExE, pStepLength, eloss, rnge);
     eloss = G4HepEmMax(eloss, 0.0);
     // Update the final kinetic energy after loss fluctuations.
-    finalEkin = theEkin - eloss;
+    finalEkin = thePreStepEkin - eloss;
   }
 #endif
   //
   // Check if the final kinetic energy drops below the tracking cut and stop.
   if (finalEkin <= hepEmPars->fElectronTrackingCut) {
-    eloss     = theEkin;
+    eloss     = thePreStepEkin;
     finalEkin = 0.0;
     theTrack->SetEKin(finalEkin);
     theTrack->SetEnergyDeposit(eloss);
@@ -338,7 +352,43 @@ bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, st
   theTrack->SetEKin(finalEkin);
   theTrack->SetEnergyDeposit(eloss);
   return false;
+}
 
+// Here I can have my own transportation to be called BUT at the moment I cannot
+// skip the G4Transportation if I do it by myself !!!
+
+// Note: energy deposit will be set here i.e. this is the first access to it that
+//       will clear the previous step value.
+bool G4HepEmElectronManager::PerformContinuous(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge) {
+  theElTrack->SavePreStepEKin();
+  //
+  // === 1. MSC should be invoked to obtain the physics step Length
+  UpdatePStepLength(theElTrack);
+  const double pStepLength = theElTrack->GetPStepLength();
+
+  if (pStepLength<=0.0) {
+    return false;
+  }
+  // compute the energy loss first based on the new step length: it will be needed in the
+  // MSC scatteirng and displacement computation here as well (that is done only if not
+  // the last step with the particle).
+  // But update the number of interaction length left before.
+  //
+  // === 2. The `number-of-interaction-left` needs to be updated based on the actual
+  //        physical step Length
+  UpdateNumIALeft(theElTrack);
+  //
+  // === 3. Continuous energy loss needs to be computed
+  bool stopped = ApplyMeanEnergyLoss(hepEmData, hepEmPars, theElTrack);
+  if (stopped) {
+    return true;
+  }
+
+  // === 4. Sample MSC direction change and displacement.
+  SampleMSC(hepEmData, hepEmPars, theElTrack, rnge);
+
+  // === 5. Sample loss fluctuations.
+  return SampleLossFluctuations(hepEmData, hepEmPars, theElTrack, rnge);
 }
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronTrack.hh
@@ -57,6 +57,17 @@ public:
   G4HepEmHostDevice
   double  GetPStepLength()             { return fPStepLength; }
 
+  G4HepEmHostDevice
+  void SavePreStepEKin()  {
+    fPreStepEKin    = fTrack.GetEKin();;
+    fPreStepLogEKin = fTrack.GetLogEKin();
+  }
+
+  G4HepEmHostDevice
+  double GetPreStepEKin() const { return fPreStepEKin; }
+  G4HepEmHostDevice
+  double GetPreStepLogEKin() const { return fPreStepLogEKin; }
+
   // Reset all member values
   G4HepEmHostDevice
   void ReSet() {
@@ -72,6 +83,8 @@ private:
   G4HepEmMSCTrackData fMSCData;
   double              fRange;
   double              fPStepLength;  // physical step length >= fTrack.fGStepLength
+  double              fPreStepEKin;
+  double              fPreStepLogEKin;
 };
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronTrack.hh
@@ -59,8 +59,13 @@ public:
 
   G4HepEmHostDevice
   void SavePreStepEKin()  {
-    fPreStepEKin    = fTrack.GetEKin();;
+    fPreStepEKin    = fTrack.GetEKin();
     fPreStepLogEKin = fTrack.GetLogEKin();
+  }
+  G4HepEmHostDevice
+  void SetPreStepEKin(double ekin, double lekin) {
+    fPreStepEKin    = ekin;
+    fPreStepLogEKin = lekin;
   }
 
   G4HepEmHostDevice

--- a/G4HepEm/include/HepEmTrackingManager.hh
+++ b/G4HepEm/include/HepEmTrackingManager.hh
@@ -23,6 +23,13 @@ public:
 
   void HandOverOneTrack(G4Track *aTrack) override;
 
+  void SetMultipleSteps(G4bool val) {
+    fMultipleSteps = val;
+  }
+  G4bool MultipleSteps() const {
+    return fMultipleSteps;
+  }
+
 private:
   void TrackElectron(G4Track *aTrack);
   void TrackPositron(G4Track *aTrack);
@@ -36,6 +43,7 @@ private:
   const std::vector<G4double> *theCutsElectron = nullptr;
   const std::vector<G4double> *theCutsPositron = nullptr;
   G4bool applyCuts = false;
+  G4bool fMultipleSteps = true;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/G4HepEm/src/TrackingManagerHelper.hh
+++ b/G4HepEm/src/TrackingManagerHelper.hh
@@ -37,11 +37,16 @@
 #ifndef TrackingManagerHelper_hh
 #define TrackingManagerHelper_hh 1
 
+#include "G4ThreeVector.hh"
 #include "G4TrackVector.hh"
 #include "globals.hh"
 
 class G4Step;
 class G4Track;
+
+class G4Navigator;
+class G4PropagatorInField;
+class G4SafetyHelper;
 
 class TrackingManagerHelper
 {
@@ -92,6 +97,43 @@ class TrackingManagerHelper
                               G4double physicalStep) = 0;
 
     virtual void FinishStep(G4Track& track, G4Step& step) = 0;
+  };
+
+  class ChargedNavigation final : public Navigation
+  {
+   public:
+    inline ChargedNavigation();
+    inline G4double MakeStep(G4Track& track, G4Step& step,
+                             G4double physicalStep) override;
+    inline void FinishStep(G4Track& track, G4Step& step) override;
+
+   private:
+    G4Navigator* fLinearNavigator;
+    G4PropagatorInField* fFieldPropagator;
+    G4SafetyHelper* fSafetyHelper;
+    G4ThreeVector fSafetyOrigin;
+    G4double fSafety         = 0;
+    G4double fPostStepSafety = 0;
+    G4double kCarTolerance;
+    G4bool fGeometryLimitedStep;
+  };
+
+  class NeutralNavigation final : public Navigation
+  {
+   public:
+    inline NeutralNavigation();
+    inline G4double MakeStep(G4Track& track, G4Step& step,
+                             G4double physicalStep) override;
+    inline void FinishStep(G4Track& track, G4Step& step) override;
+
+   private:
+    G4Navigator* fLinearNavigator;
+    G4SafetyHelper* fSafetyHelper;
+    G4ThreeVector fSafetyOrigin;
+    G4double fSafety         = 0;
+    G4double fPostStepSafety = 0;
+    G4double kCarTolerance;
+    G4bool fGeometryLimitedStep;
   };
 
   template <typename PhysicsImpl, typename NavigationImpl>

--- a/G4HepEm/src/TrackingManagerHelper.icc
+++ b/G4HepEm/src/TrackingManagerHelper.icc
@@ -245,352 +245,327 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, PhysicsImpl& physics,
   step.DeleteSecondaryVector();
 }
 
+TrackingManagerHelper::ChargedNavigation::ChargedNavigation()
+{
+  auto* transMgr   = G4TransportationManager::GetTransportationManager();
+  fLinearNavigator = transMgr->GetNavigatorForTracking();
+  fFieldPropagator = transMgr->GetPropagatorInField();
+  fSafetyHelper    = transMgr->GetSafetyHelper();
+  kCarTolerance =
+    0.5 * G4GeometryTolerance::GetInstance()->GetSurfaceTolerance();
+
+  // Reset sstate of field propagator and all chord finders.
+  fFieldPropagator->ClearPropagatorState();
+
+  auto* fieldMgrStore = G4FieldManagerStore::GetInstance();
+  fieldMgrStore->ClearAllChordFindersState();
+}
+
+G4double TrackingManagerHelper::ChargedNavigation::MakeStep(
+    G4Track& track, G4Step& step, G4double physicalStep)
+{
+  G4ThreeVector pos          = track.GetPosition();
+  G4ThreeVector dir          = track.GetMomentumDirection();
+  G4StepPoint& postStepPoint = *step.GetPostStepPoint();
+
+  bool fieldExertsForce = false;
+  if(auto* fieldMgr =
+       fFieldPropagator->FindAndSetFieldManager(track.GetVolume()))
+  {
+    fieldMgr->ConfigureForTrack(&track);
+    if(const G4Field* ptrField = fieldMgr->GetDetectorField())
+    {
+      fieldExertsForce = true;
+    }
+  }
+
+  G4double endpointDistance;
+  G4double safety = 0.0;
+  // Setting a fallback value for safety is required in case of where very
+  // short steps where the field propagator returns immediately without
+  // calling geometry.
+  const G4double shiftSquare = (pos - fSafetyOrigin).mag2();
+  if(shiftSquare < sqr(fSafety))
+  {
+    safety = fSafety - std::sqrt(shiftSquare);
+  }
+
+  if(fieldExertsForce)
+  {
+    const G4DynamicParticle* pParticle = track.GetDynamicParticle();
+    const G4double particleCharge      = pParticle->GetCharge();
+    const G4double particleMass        = pParticle->GetMass();
+    const G4double magneticMoment      = pParticle->GetMagneticMoment();
+    const G4ThreeVector particleSpin   = pParticle->GetPolarization();
+    const G4double kineticEnergy       = pParticle->GetKineticEnergy();
+    const auto pParticleDef            = pParticle->GetDefinition();
+    const auto particlePDGSpin         = pParticleDef->GetPDGSpin();
+    const auto particlePDGMagM = pParticleDef->GetPDGMagneticMoment();
+
+    auto equationOfMotion = fFieldPropagator->GetCurrentEquationOfMotion();
+    equationOfMotion->SetChargeMomentumMass(
+      G4ChargeState(particleCharge, magneticMoment, particlePDGSpin),
+      pParticle->GetTotalMomentum(), particleMass);
+
+    const G4ThreeVector startPosition  = pos;
+    const G4ThreeVector startDirection = dir;
+    G4FieldTrack aFieldTrack(startPosition,
+                             track.GetGlobalTime(),  // Lab.
+                             dir, kineticEnergy, particleMass,
+                             particleCharge, particleSpin, particlePDGMagM,
+                             0.0,  // Length along track
+                             particlePDGSpin);
+
+    // Do the Transport in the field (non recti-linear)
+    //
+    fGeometryLimitedStep            = false;
+    const G4double lengthAlongCurve = fFieldPropagator->ComputeStep(
+      aFieldTrack, physicalStep, safety, track.GetVolume(),
+      kineticEnergy < 250.0);
+    if(lengthAlongCurve < physicalStep)
+    {
+      physicalStep         = lengthAlongCurve;
+      fGeometryLimitedStep = true;
+    }
+    fSafetyHelper->SetCurrentSafety(safety, pos);
+    fSafetyOrigin = pos;
+    fSafety       = safety;
+
+    if(fFieldPropagator->IsParticleLooping())
+    {
+      track.SetTrackStatus(fStopAndKill);
+    }
+
+    pos = aFieldTrack.GetPosition();
+    dir = aFieldTrack.GetMomentumDir();
+
+    postStepPoint.SetPosition(pos);
+    postStepPoint.SetMomentumDirection(dir);
+
+    endpointDistance = (startPosition - pos).mag();
+  }
+  else
+  {
+    fGeometryLimitedStep = false;
+    G4double linearStepLength =
+      fLinearNavigator->ComputeStep(pos, dir, physicalStep, safety);
+    if(linearStepLength < physicalStep)
+    {
+      physicalStep         = linearStepLength;
+      fGeometryLimitedStep = true;
+    }
+    fSafetyHelper->SetCurrentSafety(safety, pos);
+    fSafetyOrigin = pos;
+    fSafety       = safety;
+
+    // Update the position.
+    pos += physicalStep * dir;
+    postStepPoint.SetPosition(pos);
+
+    endpointDistance = physicalStep;
+  }
+
+  // Update global, local, and proper time.
+  double velocity  = track.GetVelocity();
+  double deltaTime = 0;
+  if(velocity > 0)
+  {
+    deltaTime = physicalStep / velocity;
+  }
+
+  postStepPoint.AddGlobalTime(deltaTime);
+  postStepPoint.AddLocalTime(deltaTime);
+
+  double restMass        = track.GetDynamicParticle()->GetMass();
+  double deltaProperTime = deltaTime * (restMass / track.GetTotalEnergy());
+  postStepPoint.AddProperTime(deltaProperTime);
+
+  // Compute safety, including the call to safetyHelper, but don't set the
+  // safety in the post-step point to mimick the generic stepping loop.
+  if(safety > physicalStep)
+  {
+    safety -= physicalStep;
+  }
+  else if(safety < endpointDistance)
+  {
+    safety = fLinearNavigator->ComputeSafety(pos);
+    fSafetyHelper->SetCurrentSafety(safety, pos);
+    fSafetyOrigin = pos;
+    fSafety       = safety;
+  }
+  else
+  {
+    safety = 0;
+  }
+  if(safety < kCarTolerance)
+  {
+    fPostStepSafety = kCarTolerance;
+  }
+  else
+  {
+    fPostStepSafety = safety;
+  }
+
+  return physicalStep;
+}
+
+void TrackingManagerHelper::ChargedNavigation::FinishStep(G4Track& track,
+                                                          G4Step& step)
+{
+  // Now set the safety that was computed in MakeStep.
+  G4StepPoint& postStepPoint = *step.GetPostStepPoint();
+  postStepPoint.SetSafety(fPostStepSafety);
+
+  G4TouchableHandle touchableHandle = track.GetTouchableHandle();
+  const G4ThreeVector& pos          = track.GetPosition();
+  if(fGeometryLimitedStep)
+  {
+    // Relocate the particle.
+    fLinearNavigator->SetGeometricallyLimitedStep();
+    fLinearNavigator->LocateGlobalPointAndUpdateTouchableHandle(
+      pos, track.GetMomentumDirection(), touchableHandle, true);
+    const G4VPhysicalVolume* newVolume = touchableHandle->GetVolume();
+    if(newVolume == nullptr)
+    {
+      postStepPoint.SetStepStatus(fWorldBoundary);
+    }
+    else
+    {
+      postStepPoint.SetStepStatus(fGeomBoundary);
+    }
+  }
+  else
+  {
+    // Move the Navigator's location.
+    fLinearNavigator->LocateGlobalPointWithinVolume(pos);
+  }
+
+  postStepPoint.SetTouchableHandle(touchableHandle);
+  track.SetNextTouchableHandle(touchableHandle);
+}
+
 template <typename PhysicsImpl>
 void TrackingManagerHelper::TrackChargedParticle(G4Track* aTrack,
                                                  PhysicsImpl& physics)
 {
-  class ChargedNavigation final : public Navigation
-  {
-   public:
-    ChargedNavigation()
-    {
-      auto* transMgr   = G4TransportationManager::GetTransportationManager();
-      fLinearNavigator = transMgr->GetNavigatorForTracking();
-      fFieldPropagator = transMgr->GetPropagatorInField();
-      fSafetyHelper    = transMgr->GetSafetyHelper();
-      kCarTolerance =
-        0.5 * G4GeometryTolerance::GetInstance()->GetSurfaceTolerance();
-
-      // Reset sstate of field propagator and all chord finders.
-      fFieldPropagator->ClearPropagatorState();
-
-      auto* fieldMgrStore = G4FieldManagerStore::GetInstance();
-      fieldMgrStore->ClearAllChordFindersState();
-    }
-
-    G4double MakeStep(G4Track& track, G4Step& step,
-                      G4double physicalStep) override
-    {
-      G4ThreeVector pos          = track.GetPosition();
-      G4ThreeVector dir          = track.GetMomentumDirection();
-      G4StepPoint& postStepPoint = *step.GetPostStepPoint();
-
-      bool fieldExertsForce = false;
-      if(auto* fieldMgr =
-           fFieldPropagator->FindAndSetFieldManager(track.GetVolume()))
-      {
-        fieldMgr->ConfigureForTrack(&track);
-        if(const G4Field* ptrField = fieldMgr->GetDetectorField())
-        {
-          fieldExertsForce = true;
-        }
-      }
-
-      G4double endpointDistance;
-      G4double safety = 0.0;
-      // Setting a fallback value for safety is required in case of where very
-      // short steps where the field propagator returns immediately without
-      // calling geometry.
-      const G4double shiftSquare = (pos - fSafetyOrigin).mag2();
-      if(shiftSquare < sqr(fSafety))
-      {
-        safety = fSafety - std::sqrt(shiftSquare);
-      }
-
-      if(fieldExertsForce)
-      {
-        const G4DynamicParticle* pParticle = track.GetDynamicParticle();
-        const G4double particleCharge      = pParticle->GetCharge();
-        const G4double particleMass        = pParticle->GetMass();
-        const G4double magneticMoment      = pParticle->GetMagneticMoment();
-        const G4ThreeVector particleSpin   = pParticle->GetPolarization();
-        const G4double kineticEnergy       = pParticle->GetKineticEnergy();
-        const auto pParticleDef            = pParticle->GetDefinition();
-        const auto particlePDGSpin         = pParticleDef->GetPDGSpin();
-        const auto particlePDGMagM = pParticleDef->GetPDGMagneticMoment();
-
-        auto equationOfMotion = fFieldPropagator->GetCurrentEquationOfMotion();
-        equationOfMotion->SetChargeMomentumMass(
-          G4ChargeState(particleCharge, magneticMoment, particlePDGSpin),
-          pParticle->GetTotalMomentum(), particleMass);
-
-        const G4ThreeVector startPosition  = pos;
-        const G4ThreeVector startDirection = dir;
-        G4FieldTrack aFieldTrack(startPosition,
-                                 track.GetGlobalTime(),  // Lab.
-                                 dir, kineticEnergy, particleMass,
-                                 particleCharge, particleSpin, particlePDGMagM,
-                                 0.0,  // Length along track
-                                 particlePDGSpin);
-
-        // Do the Transport in the field (non recti-linear)
-        //
-        fGeometryLimitedStep            = false;
-        const G4double lengthAlongCurve = fFieldPropagator->ComputeStep(
-          aFieldTrack, physicalStep, safety, track.GetVolume(),
-          kineticEnergy < 250.0);
-        if(lengthAlongCurve < physicalStep)
-        {
-          physicalStep         = lengthAlongCurve;
-          fGeometryLimitedStep = true;
-        }
-        fSafetyHelper->SetCurrentSafety(safety, pos);
-        fSafetyOrigin = pos;
-        fSafety       = safety;
-
-        if(fFieldPropagator->IsParticleLooping())
-        {
-          track.SetTrackStatus(fStopAndKill);
-        }
-
-        pos = aFieldTrack.GetPosition();
-        dir = aFieldTrack.GetMomentumDir();
-
-        postStepPoint.SetPosition(pos);
-        postStepPoint.SetMomentumDirection(dir);
-
-        endpointDistance = (startPosition - pos).mag();
-      }
-      else
-      {
-        fGeometryLimitedStep = false;
-        G4double linearStepLength =
-          fLinearNavigator->ComputeStep(pos, dir, physicalStep, safety);
-        if(linearStepLength < physicalStep)
-        {
-          physicalStep         = linearStepLength;
-          fGeometryLimitedStep = true;
-        }
-        fSafetyHelper->SetCurrentSafety(safety, pos);
-        fSafetyOrigin = pos;
-        fSafety       = safety;
-
-        // Update the position.
-        pos += physicalStep * dir;
-        postStepPoint.SetPosition(pos);
-
-        endpointDistance = physicalStep;
-      }
-
-      // Update global, local, and proper time.
-      double velocity  = track.GetVelocity();
-      double deltaTime = 0;
-      if(velocity > 0)
-      {
-        deltaTime = physicalStep / velocity;
-      }
-
-      postStepPoint.AddGlobalTime(deltaTime);
-      postStepPoint.AddLocalTime(deltaTime);
-
-      double restMass        = track.GetDynamicParticle()->GetMass();
-      double deltaProperTime = deltaTime * (restMass / track.GetTotalEnergy());
-      postStepPoint.AddProperTime(deltaProperTime);
-
-      // Compute safety, including the call to safetyHelper, but don't set the
-      // safety in the post-step point to mimick the generic stepping loop.
-      if(safety > physicalStep)
-      {
-        safety -= physicalStep;
-      }
-      else if(safety < endpointDistance)
-      {
-        safety = fLinearNavigator->ComputeSafety(pos);
-        fSafetyHelper->SetCurrentSafety(safety, pos);
-        fSafetyOrigin = pos;
-        fSafety       = safety;
-      }
-      else
-      {
-        safety = 0;
-      }
-      if(safety < kCarTolerance)
-      {
-        fPostStepSafety = kCarTolerance;
-      }
-      else
-      {
-        fPostStepSafety = safety;
-      }
-
-      return physicalStep;
-    }
-
-    void FinishStep(G4Track& track, G4Step& step) override
-    {
-      // Now set the safety that was computed in MakeStep.
-      G4StepPoint& postStepPoint = *step.GetPostStepPoint();
-      postStepPoint.SetSafety(fPostStepSafety);
-
-      G4TouchableHandle touchableHandle = track.GetTouchableHandle();
-      const G4ThreeVector& pos          = track.GetPosition();
-      if(fGeometryLimitedStep)
-      {
-        // Relocate the particle.
-        fLinearNavigator->SetGeometricallyLimitedStep();
-        fLinearNavigator->LocateGlobalPointAndUpdateTouchableHandle(
-          pos, track.GetMomentumDirection(), touchableHandle, true);
-        const G4VPhysicalVolume* newVolume = touchableHandle->GetVolume();
-        if(newVolume == nullptr)
-        {
-          postStepPoint.SetStepStatus(fWorldBoundary);
-        }
-        else
-        {
-          postStepPoint.SetStepStatus(fGeomBoundary);
-        }
-      }
-      else
-      {
-        // Move the Navigator's location.
-        fLinearNavigator->LocateGlobalPointWithinVolume(pos);
-      }
-
-      postStepPoint.SetTouchableHandle(touchableHandle);
-      track.SetNextTouchableHandle(touchableHandle);
-    }
-
-   private:
-    G4Navigator* fLinearNavigator;
-    G4PropagatorInField* fFieldPropagator;
-    G4SafetyHelper* fSafetyHelper;
-    G4ThreeVector fSafetyOrigin;
-    G4double fSafety         = 0;
-    G4double fPostStepSafety = 0;
-    G4double kCarTolerance;
-    G4bool fGeometryLimitedStep;
-  };
-
   ChargedNavigation navigation;
   TrackParticle(aTrack, physics, navigation);
+}
+
+TrackingManagerHelper::NeutralNavigation::NeutralNavigation()
+{
+  auto* transMgr   = G4TransportationManager::GetTransportationManager();
+  fLinearNavigator = transMgr->GetNavigatorForTracking();
+  fSafetyHelper    = transMgr->GetSafetyHelper();
+  kCarTolerance =
+    0.5 * G4GeometryTolerance::GetInstance()->GetSurfaceTolerance();
+}
+
+G4double TrackingManagerHelper::NeutralNavigation::MakeStep(
+    G4Track& track, G4Step& step, G4double physicalStep)
+{
+  G4ThreeVector pos          = track.GetPosition();
+  G4ThreeVector dir          = track.GetMomentumDirection();
+  G4StepPoint& postStepPoint = *step.GetPostStepPoint();
+
+  G4double safety            = 0.0;
+  const G4double shiftSquare = (pos - fSafetyOrigin).mag2();
+  if(shiftSquare < sqr(fSafety))
+  {
+    safety = fSafety - std::sqrt(shiftSquare);
+  }
+
+  fGeometryLimitedStep = false;
+  G4double linearStepLength =
+    fLinearNavigator->ComputeStep(pos, dir, physicalStep, safety);
+  if(linearStepLength < physicalStep)
+  {
+    physicalStep         = linearStepLength;
+    fGeometryLimitedStep = true;
+  }
+  fSafetyHelper->SetCurrentSafety(safety, pos);
+  fSafetyOrigin = pos;
+  fSafety       = safety;
+
+  // Update the position.
+  pos += physicalStep * dir;
+  postStepPoint.SetPosition(pos);
+
+  // Update global, local, and proper time.
+  double velocity  = track.GetVelocity();
+  double deltaTime = 0;
+  if(velocity > 0)
+  {
+    deltaTime = physicalStep / velocity;
+  }
+  postStepPoint.AddGlobalTime(deltaTime);
+  postStepPoint.AddLocalTime(deltaTime);
+
+  double restMass        = track.GetDynamicParticle()->GetMass();
+  double deltaProperTime = deltaTime * (restMass / track.GetTotalEnergy());
+  postStepPoint.AddProperTime(deltaProperTime);
+
+  // Compute safety, but don't set the safety in the post-step point to
+  // mimick the generic stepping loop.
+  if(safety > physicalStep)
+  {
+    safety -= physicalStep;
+  }
+  else
+  {
+    safety = 0;
+  }
+  if(safety < kCarTolerance)
+  {
+    fPostStepSafety = kCarTolerance;
+  }
+  else
+  {
+    fPostStepSafety = safety;
+  }
+
+  return physicalStep;
+}
+
+void TrackingManagerHelper::NeutralNavigation::FinishStep(G4Track& track,
+                                                          G4Step& step)
+{
+  // Now set the safety that was computed in MakeStep.
+  G4StepPoint& postStepPoint = *step.GetPostStepPoint();
+  postStepPoint.SetSafety(fPostStepSafety);
+
+  G4TouchableHandle touchableHandle = track.GetTouchableHandle();
+  const G4ThreeVector& pos          = track.GetPosition();
+  if(fGeometryLimitedStep)
+  {
+    // Relocate the particle.
+    fLinearNavigator->SetGeometricallyLimitedStep();
+    fLinearNavigator->LocateGlobalPointAndUpdateTouchableHandle(
+      pos, track.GetMomentumDirection(), touchableHandle, true);
+    const G4VPhysicalVolume* newVolume = touchableHandle->GetVolume();
+    if(newVolume == nullptr)
+    {
+      postStepPoint.SetStepStatus(fWorldBoundary);
+    }
+    else
+    {
+      postStepPoint.SetStepStatus(fGeomBoundary);
+    }
+  }
+  else
+  {
+    // Move the Navigator's location.
+    fLinearNavigator->LocateGlobalPointWithinVolume(pos);
+  }
+
+  postStepPoint.SetTouchableHandle(touchableHandle);
+  track.SetNextTouchableHandle(touchableHandle);
 }
 
 template <typename PhysicsImpl>
 void TrackingManagerHelper::TrackNeutralParticle(G4Track* aTrack,
                                                  PhysicsImpl& physics)
 {
-  class NeutralNavigation final : public Navigation
-  {
-   public:
-    NeutralNavigation()
-    {
-      auto* transMgr   = G4TransportationManager::GetTransportationManager();
-      fLinearNavigator = transMgr->GetNavigatorForTracking();
-      fSafetyHelper    = transMgr->GetSafetyHelper();
-      kCarTolerance =
-        0.5 * G4GeometryTolerance::GetInstance()->GetSurfaceTolerance();
-    }
-
-    G4double MakeStep(G4Track& track, G4Step& step,
-                      G4double physicalStep) override
-    {
-      G4ThreeVector pos          = track.GetPosition();
-      G4ThreeVector dir          = track.GetMomentumDirection();
-      G4StepPoint& postStepPoint = *step.GetPostStepPoint();
-
-      G4double safety            = 0.0;
-      const G4double shiftSquare = (pos - fSafetyOrigin).mag2();
-      if(shiftSquare < sqr(fSafety))
-      {
-        safety = fSafety - std::sqrt(shiftSquare);
-      }
-
-      fGeometryLimitedStep = false;
-      G4double linearStepLength =
-        fLinearNavigator->ComputeStep(pos, dir, physicalStep, safety);
-      if(linearStepLength < physicalStep)
-      {
-        physicalStep         = linearStepLength;
-        fGeometryLimitedStep = true;
-      }
-      fSafetyHelper->SetCurrentSafety(safety, pos);
-      fSafetyOrigin = pos;
-      fSafety       = safety;
-
-      // Update the position.
-      pos += physicalStep * dir;
-      postStepPoint.SetPosition(pos);
-
-      // Update global, local, and proper time.
-      double velocity  = track.GetVelocity();
-      double deltaTime = 0;
-      if(velocity > 0)
-      {
-        deltaTime = physicalStep / velocity;
-      }
-      postStepPoint.AddGlobalTime(deltaTime);
-      postStepPoint.AddLocalTime(deltaTime);
-
-      double restMass        = track.GetDynamicParticle()->GetMass();
-      double deltaProperTime = deltaTime * (restMass / track.GetTotalEnergy());
-      postStepPoint.AddProperTime(deltaProperTime);
-
-      // Compute safety, but don't set the safety in the post-step point to
-      // mimick the generic stepping loop.
-      if(safety > physicalStep)
-      {
-        safety -= physicalStep;
-      }
-      else
-      {
-        safety = 0;
-      }
-      if(safety < kCarTolerance)
-      {
-        fPostStepSafety = kCarTolerance;
-      }
-      else
-      {
-        fPostStepSafety = safety;
-      }
-
-      return physicalStep;
-    }
-
-    void FinishStep(G4Track& track, G4Step& step) override
-    {
-      // Now set the safety that was computed in MakeStep.
-      G4StepPoint& postStepPoint = *step.GetPostStepPoint();
-      postStepPoint.SetSafety(fPostStepSafety);
-
-      G4TouchableHandle touchableHandle = track.GetTouchableHandle();
-      const G4ThreeVector& pos          = track.GetPosition();
-      if(fGeometryLimitedStep)
-      {
-        // Relocate the particle.
-        fLinearNavigator->SetGeometricallyLimitedStep();
-        fLinearNavigator->LocateGlobalPointAndUpdateTouchableHandle(
-          pos, track.GetMomentumDirection(), touchableHandle, true);
-        const G4VPhysicalVolume* newVolume = touchableHandle->GetVolume();
-        if(newVolume == nullptr)
-        {
-          postStepPoint.SetStepStatus(fWorldBoundary);
-        }
-        else
-        {
-          postStepPoint.SetStepStatus(fGeomBoundary);
-        }
-      }
-      else
-      {
-        // Move the Navigator's location.
-        fLinearNavigator->LocateGlobalPointWithinVolume(pos);
-      }
-
-      postStepPoint.SetTouchableHandle(touchableHandle);
-      track.SetNextTouchableHandle(touchableHandle);
-    }
-
-   private:
-    G4Navigator* fLinearNavigator;
-    G4SafetyHelper* fSafetyHelper;
-    G4ThreeVector fSafetyOrigin;
-    G4double fSafety         = 0;
-    G4double fPostStepSafety = 0;
-    G4double kCarTolerance;
-    G4bool fGeometryLimitedStep;
-  };
-
   NeutralNavigation navigation;
   TrackParticle(aTrack, physics, navigation);
 }


### PR DESCRIPTION
If a step is only limited by MSC, the `HepEmTrackingManager` can re-try the step with the remaining distance to the discrete interaction, without applying energy loss fluctuations and re-computing the cross sections. This option is enabled by default because it provides a small performance benefit, but can be turned off to get results identical to the `G4HepEmProcess`.