### PR TITLE
Extend the Urban MSC implementation with the support of G4.10.6.p03 like stepping.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,9 @@ elseif (TARGET Geant4::G4clhep-static)
   set(G4HepEm_CLHEP_TARGET Geant4::G4clhep-static)
 endif()
 
+# make the Geant4 version number available even where we don't depend on Geant4
+add_compile_definitions (G4VERSION_NUM=${Geant4_VERSION_MAJOR}${Geant4_VERSION_MINOR}${Geant4_VERSION_PATCH})
+
 #----------------------------------------------------------------------------
 # CUDA
 option(G4HepEm_CUDA_BUILD "BUILD with CUDA support" OFF)

--- a/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
@@ -9,6 +9,7 @@
 #include "G4HepEmElementData.hh"
 
 // g4 includes
+#include "G4Version.hh"
 #include "G4ProductionCutsTable.hh"
 #include "G4SandiaTable.hh"
 #include "G4MaterialCutsCouple.hh"
@@ -126,9 +127,17 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
       matData.fZeff23                  = zeff13*zeff13;
       matData.fZeffSqrt                = std::sqrt(zeff);
       //
+// these parameters are taken from Geant4-11.0 (below are the values used before)
+// See G4HepEmElectronInteractionUMSC::StepLimit for further details on this.
+#if G4VERSION_NUMBER >= 1100
       matData.fUMSCPar                 = 9.62800E-1 - 8.4848E-2*matData.fZeffSqrt + 4.3769E-3*zeff;
       matData.fUMSCStepMinPars[0]      = 2.7725E+1/(1.0 + 2.03E-1*zeff);
       matData.fUMSCStepMinPars[1]      = 6.152    /(1.0 + 1.11E-1*zeff);
+#else // G4 version before 11.0
+      matData.fUMSCPar                 = 1.2 - zeff*(1.62e-2 - 9.22e-5*zeff);
+      matData.fUMSCStepMinPars[0]      = 15.99/(1. + 0.119*zeff);
+      matData.fUMSCStepMinPars[1]      = 4.390/(1. + 0.079*zeff);
+#endif
       const double dum0                = 9.90395E-1 + zeff16*(-1.68386E-1 + zeff16*9.3286E-2);
       matData.fUMSCThetaCoeff[0]       = dum0*(1.0 - 8.7780E-2/zeff);
       matData.fUMSCThetaCoeff[1]       = dum0*(4.0780E-2 + 1.7315E-4*zeff);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
@@ -49,10 +49,23 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
                                    : hepEmPars->fMSCRangeFactor;
     // note: `ekin` below is the kinetic energy in MeV;
     const double stepMin = lambdaTr1*1.0E-3/(2.0E-3 + ekin*(matData.fUMSCStepMinPars[0] + ekin*matData.fUMSCStepMinPars[1]));
+
+    // there is some difference in the algorithm from G4.11.0 that (together with
+    // the differences in the fUMSCPar, fUMSCStepMinPars[0,1] parameter values) gives
+    // 2-3 % lower number of HITS (e.g. lower number of steps) in ATLAS when using
+    // G4.11.0 compred to older G4 versions such as G4.10.6.p03.
+    // We include this to ease validation though this is an improvment of G4 11.0
+#if G4VERSION_NUM < 1100
+    // G4 version before 11
+    mscData->fTlimitMin  = G4HepEmMax(0.70*matData.fZeffSqrt*stepMin, kTLimitMinfix);
+#else
+    // this is like in Geant4.11.0
     const double dum0    = iselectron ? 0.87*matData.fZeff23 : 0.70*matData.fZeffSqrt;
     // note `tlow` = 5 [keV] ==> 5.0E-3 [MeV] ==> 1/tlow = 200 [1/MeV]
     const double dum1    = ekin > 5.0E-3 ? dum0*stepMin : dum0*stepMin*0.5*(1.0 + ekin*200.0);
     mscData->fTlimitMin  = G4HepEmMax(dum1, kTLimitMinfix);
+#endif
+
     // reset first step flag (if any)
     mscData->fIsFirstStep = false;
   }


### PR DESCRIPTION
This extends the Urban MSC implementation with the support of the slightly different stepping (some parameter values and a small difference in the algorithm itself) used in G4.10.6p03 compared to G4.11. Using the latter cased 2-3% difference in the ATLAS HITS, e.g. number of steps with e-/e+ during the validation. Note, this is actually an improvement of Laszlo's
model in G4.11 that lets the e-/e+ make slightly longer steps without (hopefully) causing any visible difference. So we introduce this switch to be able to use the stepping that corresponds to G4.10.6.p03 strictly to ease the validation process in ATLAS.  