### PR TITLE
Correctly initialise GPU pointers.

### DIFF
--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
@@ -91,6 +91,9 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
     gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorIoniData),                sizeof( double ) * numIoniData     ) );
     gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorIoniStartIndexPerMatCut,  onHOST->fElemSelectorIoniStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
     gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorIoniData,                 onHOST->fElemSelectorIoniData,                sizeof( double ) * numIoniData,     cudaMemcpyHostToDevice ) );
+  } else {
+    elDataHTo_d->fElemSelectorIoniStartIndexPerMatCut = nullptr;
+    elDataHTo_d->fElemSelectorIoniData = nullptr;
   }
   // the same for SB brem
   const int numBremSBData = onHOST->fElemSelectorBremSBNumData;
@@ -99,6 +102,9 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
     gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremSBData),                sizeof( double ) * numBremSBData   ) );
     gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremSBStartIndexPerMatCut,  onHOST->fElemSelectorBremSBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
     gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremSBData,                 onHOST->fElemSelectorBremSBData,                sizeof( double ) * numBremSBData,   cudaMemcpyHostToDevice ) );
+  } else {
+    elDataHTo_d->fElemSelectorBremSBStartIndexPerMatCut = nullptr;
+    elDataHTo_d->fElemSelectorBremSBData = nullptr;
   }
   // the same for RB brem
   const int numBremRBData = onHOST->fElemSelectorBremRBNumData;
@@ -107,6 +113,9 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
     gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fElemSelectorBremRBData),                sizeof( double ) * numBremRBData   ) );
     gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut,  onHOST->fElemSelectorBremRBStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
     gpuErrchk ( cudaMemcpy (   elDataHTo_d->fElemSelectorBremRBData,                 onHOST->fElemSelectorBremRBData,                sizeof( double ) * numBremRBData,   cudaMemcpyHostToDevice ) );
+  } else {
+    elDataHTo_d->fElemSelectorBremRBStartIndexPerMatCut = nullptr;
+    elDataHTo_d->fElemSelectorBremRBData = nullptr;
   }
   //
   // Finaly copy the top level, i.e. the main struct with the already

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -71,6 +71,10 @@ void CopyGammaDataToDevice(struct G4HepEmGammaData* onHOST, struct G4HepEmGammaD
     gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvEgrid,  onHOST->fElemSelectorConvEgrid, sizeof( double ) * numElSelE,   cudaMemcpyHostToDevice ) );
     gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fElemSelectorConvData),  sizeof( double ) * numElSelDat ) );
     gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fElemSelectorConvData,   onHOST->fElemSelectorConvData,  sizeof( double ) * numElSelDat, cudaMemcpyHostToDevice ) );
+  } else {
+    gmDataHTo_d->fElemSelectorConvStartIndexPerMat = nullptr;
+    gmDataHTo_d->fElemSelectorConvEgrid = nullptr;
+    gmDataHTo_d->fElemSelectorConvData = nullptr;
   }
   //
   // Finaly copy the top level, i.e. the main struct with the already


### PR DESCRIPTION
When the host data structure is copied during GPU set up, the host
pointers need to be overwritten to obtain correct device pointers.