### PR TITLE
Rewrite CMake code to allow both shared and static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,17 +56,81 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 # Find Geant4, changing library build type to default Geant4 variant and
 # determining which CLHEP target to use
 find_package(Geant4 REQUIRED)
-if(Geant4_static_FOUND AND NOT Geant4_shared_FOUND)
-  set(BUILD_SHARED_LIBS OFF)
+if(Geant4_static_FOUND)
   set(BUILD_STATIC_LIBS ON)
 endif()
-
-set(G4HepEm_CLHEP_TARGET CLHEP::CLHEP)
-if(TARGET Geant4::G4clhep)
-  set(G4HepEm_CLHEP_TARGET Geant4::G4clhep)
-elseif (TARGET Geant4::G4clhep-static)
-  set(G4HepEm_CLHEP_TARGET Geant4::G4clhep-static)
+if(NOT Geant4_shared_FOUND)
+  set(BUILD_SHARED_LIBS OFF)
 endif()
+
+#----------------------------------------------------------------------------
+# Convenience function to add shared / static libraries as configured.
+#
+# The general idea is as follows:
+#  - if configured, shared libraries are created from a target called ${_name}.
+#  - if configured, static libraries are created from a target always called
+#    ${_name}-static but the final archive name is lib${_name}.a.
+#  - if only static libraries are configured, ALIAS targets ${_name} are added
+#    and exported.
+function(g4hepem_add_library _name)
+  cmake_parse_arguments(_g4hepem "" "" "HEADERS;SOURCES;LINK" ${ARGN})
+
+  # Build shared library, if enabled.
+  if(BUILD_SHARED_LIBS)
+    add_library(${_name} SHARED ${_g4hepem_SOURCES})
+    target_compile_features(${_name} PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+    add_library(${PROJECT_NAME}::${_name} ALIAS ${_name})
+
+    target_include_directories(${_name} PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
+    target_link_libraries(${_name} PUBLIC ${_g4hepem_LINK})
+  endif()
+
+  # Build static library, if enabled.
+  if(BUILD_STATIC_LIBS)
+    add_library(${_name}-static STATIC ${_g4hepem_SOURCES})
+    set_target_properties(${_name}-static PROPERTIES OUTPUT_NAME ${_name})
+    target_compile_features(${_name}-static PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
+    add_library(${PROJECT_NAME}::${_name}-static ALIAS ${_name}-static)
+
+    target_include_directories(${_name}-static PUBLIC
+      $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
+    foreach(_lib ${_g4hepem_LINK})
+      target_link_libraries(${_name}-static PUBLIC ${_lib}-static)
+    endforeach()
+
+    # If only the static library, add alias targets for convenience.
+    if(NOT BUILD_SHARED_LIBS)
+      add_library(${_name} ALIAS ${_name}-static)
+      add_library(${PROJECT_NAME}::${_name} ALIAS ${_name}-static)
+
+      # In that case, also change the name of the exported target.
+      set_target_properties(${_name}-static PROPERTIES EXPORT_NAME ${_name})
+    endif()
+  endif()
+
+  # Install headers.
+  install(FILES ${_g4hepem_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
+
+  # Install libraries, as built.
+  if(BUILD_SHARED_LIBS)
+    install(TARGETS ${_name}
+      EXPORT ${PROJECT_NAME}Targets
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  endif()
+
+  if(BUILD_STATIC_LIBS)
+    install(TARGETS ${_name}-static
+      EXPORT ${PROJECT_NAME}Targets
+      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  endif()
+endfunction()
 
 #----------------------------------------------------------------------------
 # CUDA

--- a/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/CMakeLists.txt
@@ -26,27 +26,7 @@ if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
   )
 endif()
 
-if(BUILD_STATIC_LIBS)
-  add_library(g4HepEm STATIC ${G4HEPEM_sources})
-else()
-  add_library(g4HepEm SHARED ${G4HEPEM_sources})
-endif()
-
-add_library(${PROJECT_NAME}::g4HepEm ALIAS g4HepEm)
-
-target_compile_features(g4HepEm PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
-
-target_include_directories(g4HepEm PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-
-target_link_libraries(g4HepEm PUBLIC g4HepEmData g4HepEmInit g4HepEmRun) # ${Geant4_LIBRARIES})
-
-## ----------------------------------------------------------------------------
-## Install G4HepEm libraries and headers
-install(FILES ${G4HEPEM_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
-install(TARGETS g4HepEm
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+g4hepem_add_library(g4HepEm
+  SOURCES ${G4HEPEM_sources}
+  HEADERS ${G4HEPEM_headers}
+  LINK g4HepEmData g4HepEmInit g4HepEmRun)

--- a/G4HepEm/G4HepEmData/CMakeLists.txt
+++ b/G4HepEm/G4HepEmData/CMakeLists.txt
@@ -20,30 +20,15 @@ set(G4HEPEMDATA_CXX_sources
   src/G4HepEmSBTableData.cc
 )
 
-if(BUILD_STATIC_LIBS)
-  add_library(g4HepEmData STATIC ${G4HEPEMDATA_CXX_sources})
-else()
-  add_library(g4HepEmData SHARED ${G4HEPEMDATA_CXX_sources})
+g4hepem_add_library(g4HepEmData SOURCES ${G4HEPEMDATA_CXX_sources} HEADERS ${G4HEPEMDATA_headers})
+
+if(BUILD_SHARED_LIBS)
+  target_compile_definitions(g4HepEmData PUBLIC $<$<BOOL:${G4HepEm_CUDA_BUILD}>:G4HepEm_CUDA_BUILD>)
+  target_link_libraries(g4HepEmData PRIVATE $<$<BOOL:${G4HepEm_CUDA_BUILD}>:CUDA::cudart>)
 endif()
 
-add_library(${PROJECT_NAME}::g4HepEmData ALIAS g4HepEmData)
-
-target_compile_definitions(g4HepEmData PUBLIC $<$<BOOL:${G4HepEm_CUDA_BUILD}>:G4HepEm_CUDA_BUILD>)
-
-target_compile_features(g4HepEmData PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
-
-target_include_directories(g4HepEmData PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-
- # TODO: Determine when/if to use CUDA::cudart_static
-target_link_libraries(g4HepEmData PRIVATE $<$<BOOL:${G4HepEm_CUDA_BUILD}>:CUDA::cudart>)
-
-## ----------------------------------------------------------------------------
-## Install G4HepEm libraries and headers
-install(FILES ${G4HEPEMDATA_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
-install(TARGETS g4HepEmData
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+if(BUILD_STATIC_LIBS)
+  target_compile_definitions(g4HepEmData-static PUBLIC $<$<BOOL:${G4HepEm_CUDA_BUILD}>:G4HepEm_CUDA_BUILD>)
+  # TODO: Determine when/if to use CUDA::cudart_static
+  target_link_libraries(g4HepEmData-static PRIVATE $<$<BOOL:${G4HepEm_CUDA_BUILD}>:CUDA::cudart>)
+endif()

--- a/G4HepEm/G4HepEmDataJsonIO/CMakeLists.txt
+++ b/G4HepEm/G4HepEmDataJsonIO/CMakeLists.txt
@@ -5,29 +5,7 @@ set(G4HEPEMDATAJSONIO_CXX_sources
   src/G4HepEmDataJsonIO.cc
 )
 
-if(BUILD_STATIC_LIBS)
-  add_library(g4HepEmDataJsonIO STATIC ${G4HEPEMDATAJSONIO_CXX_sources})
-else()
-  add_library(g4HepEmDataJsonIO SHARED ${G4HEPEMDATAJSONIO_CXX_sources})
-endif()
-
-add_library(${PROJECT_NAME}::g4HepEmDataJsonIO ALIAS g4HepEmDataJsonIO)
-
-target_compile_features(g4HepEmDataJsonIO PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
-
-target_include_directories(g4HepEmDataJsonIO PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>
-  PRIVATE
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>)
-
-target_link_libraries(g4HepEmDataJsonIO PUBLIC g4HepEmData)
-
-## ----------------------------------------------------------------------------
-## Install G4HepEm libraries and headers
-install(FILES ${G4HEPEMDATAJSONIO_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
-install(TARGETS g4HepEmDataJsonIO
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+g4hepem_add_library(g4HepEmDataJsonIO
+  SOURCES ${G4HEPEMDATAJSONIO_CXX_sources}
+  HEADERS ${G4HEPEMDATAJSONIO_headers}
+  LINK g4HepEmData)

--- a/G4HepEm/G4HepEmInit/CMakeLists.txt
+++ b/G4HepEm/G4HepEmInit/CMakeLists.txt
@@ -21,25 +21,14 @@ set(G4HEPEMInit_sources
   src/G4HepEmStateInit.cc
 )
 
-if(BUILD_STATIC_LIBS)
-  add_library(g4HepEmInit STATIC ${G4HEPEMInit_sources})
-else()
-  add_library(g4HepEmInit SHARED ${G4HEPEMInit_sources})
-endif()
+set(G4HEPEMInit_Geant4_LIBRARIES
+  Geant4::G4global
+  Geant4::G4materials
+  Geant4::G4particles
+  Geant4::G4processes
+)
 
-add_library(${PROJECT_NAME}::g4HepEmInit ALIAS g4HepEmInit)
-
-target_compile_features(g4HepEmInit PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
-target_include_directories(g4HepEmInit PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(g4HepEmInit PUBLIC g4HepEmData ${Geant4_LIBRARIES})
-
-## ----------------------------------------------------------------------------
-## Install G4HepEm libraries and headers
-install(FILES ${G4HEPEMInit_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
-install(TARGETS g4HepEmInit
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+g4hepem_add_library(g4HepEmInit
+  SOURCES ${G4HEPEMInit_sources}
+  HEADERS ${G4HEPEMInit_headers}
+  LINK g4HepEmData ${G4HEPEMInit_Geant4_LIBRARIES})

--- a/G4HepEm/G4HepEmRun/CMakeLists.txt
+++ b/G4HepEm/G4HepEmRun/CMakeLists.txt
@@ -42,29 +42,35 @@ set(G4HEPEmRun_sources
 
 # See Issue #11 and discussion...
 set_source_files_properties(${G4HEPEmRun_impl_headers} PROPERTIES LANGUAGE CXX)
-if(BUILD_STATIC_LIBS)
-  add_library(g4HepEmRun STATIC ${G4HEPEmRun_sources} ${G4HEPEmRun_impl_headers})
-else()
-  add_library(g4HepEmRun SHARED ${G4HEPEmRun_sources} ${G4HEPEmRun_impl_headers})
-endif()
 
-set_target_properties(g4HepEmRun PROPERTIES COMPILE_FLAGS "-x c++ ${CMAKE_CXX_FLAGS}")
+g4hepem_add_library(g4HepEmRun
+  SOURCES ${G4HEPEmRun_sources} ${G4HEPEmRun_impl_headers}
+  HEADERS ${G4HEPEMRun_headers} ${G4HEPEmRun_impl_headers}
+  LINK g4HepEmData)
+
 # Make the Geant4 version number available even where we don't depend on Geant4
-target_compile_definitions(g4HepEmRun PUBLIC G4VERSION_NUM=${Geant4_VERSION_MAJOR}${Geant4_VERSION_MINOR}${Geant4_VERSION_PATCH})
+set(_g4version_num ${Geant4_VERSION_MAJOR}${Geant4_VERSION_MINOR}${Geant4_VERSION_PATCH})
 
-add_library(${PROJECT_NAME}::g4HepEmRun ALIAS g4HepEmRun)
+if(BUILD_SHARED_LIBS)
+  set_target_properties(g4HepEmRun PROPERTIES COMPILE_FLAGS "-x c++ ${CMAKE_CXX_FLAGS}")
 
-target_compile_features(g4HepEmRun PUBLIC cxx_std_${CMAKE_CXX_STANDARD})
-target_include_directories(g4HepEmRun PUBLIC
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
-target_link_libraries(g4HepEmRun g4HepEmData ${G4HepEm_CLHEP_TARGET}) # only SystemOfUnits is used from CLHEP
+  target_compile_definitions(g4HepEmRun PUBLIC G4VERSION_NUM=${_g4version_num})
 
-## ----------------------------------------------------------------------------
-## Install G4HepEm libraries and headers
-install(FILES ${G4HEPEmRun_headers} ${G4HEPEmRun_impl_headers} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}")
-install(TARGETS g4HepEmRun
-  EXPORT ${PROJECT_NAME}Targets
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
+  if(TARGET Geant4::G4clhep)
+    target_link_libraries(g4HepEmRun PUBLIC Geant4::G4clhep)
+  elseif(TARGET CLHEP::CLHEP)
+    target_link_libraries(g4HepEmRun PUBLIC CLHEP::CLHEP)
+  endif()
+endif()
+if(BUILD_STATIC_LIBS)
+  set_target_properties(g4HepEmRun-static PROPERTIES COMPILE_FLAGS "-x c++ ${CMAKE_CXX_FLAGS}")
+
+  target_compile_definitions(g4HepEmRun-static PUBLIC G4VERSION_NUM=${_g4version_num})
+
+  if(TARGET Geant4::G4clhep-static)
+    target_link_libraries(g4HepEmRun-static PUBLIC Geant4::G4clhep-static)
+  elseif(TARGET CLHEP::CLHEP)
+    # Not a typo, Geant4 also takes what it can get from CLHEP.
+    target_link_libraries(g4HepEmRun-static PUBLIC CLHEP::CLHEP)
+  endif()
+endif()


### PR DESCRIPTION
This is required for integration into experiments.

The general idea is that the targets for static libraries are always suffixed with `-static`, but `ALIAS` targets are added unless we also build shared libraries.