### PR TITLE
Convert G4HepEmInitUtils to non-singleton

### DIFF
--- a/G4HepEm/G4HepEmInit/include/G4HepEmInitUtils.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmInitUtils.hh
@@ -8,69 +8,58 @@
 
 class G4HepEmInitUtils {
 public:
-  // public access method
-  static G4HepEmInitUtils& Instance();
-
-  // delete copy CTR and assigment operators
-  G4HepEmInitUtils(const G4HepEmInitUtils&) = delete;
-  G4HepEmInitUtils& operator=(const G4HepEmInitUtils&) = delete;
+  G4HepEmInitUtils() = delete;
 
   // Fills the input vector arguments with `npoints` GL integral abscissas and 
   // weights values (on [0,1] by default)
-  void GLIntegral(int npoints, double* abscissas, double* weights, double min=0.0, double max=1.0);
+  static void GLIntegral(int npoints, double* abscissas, double* weights, double min=0.0, double max=1.0);
                   
   
   
   // receives `npoint` x,y data arrays and fills the `secderiv` array with the 
   // second derivatives that can be used for a spline interpolation
-  void   PrepareSpline(int npoint, double* xdata, double* ydata, double* secderiv);
+  static void   PrepareSpline(int npoint, double* xdata, double* ydata, double* secderiv);
 
   // same as above, but both the ydata and second derivatives are stored in the 
   // ydata array (compact [...,y_i, sd_i, y_{i+1}, sd_{i+1},...] with 2x`npoint`)
-  void   PrepareSpline(int npoint, double* xdata, double* ydata);                
+  static void   PrepareSpline(int npoint, double* xdata, double* ydata);                
 
 
   // get spline interpolation over a log-spaced xgrid previously prepared by 
   // PrepareSpline (separate storrage of ydata and second deriavtive)  
   // use the improved, robust spline interpolation that I put in G4 10.6
-  double GetSplineLog(int ndata, double* xdata, double* ydata, double* secderiv, double x, double logx, double logxmin, double invLDBin);
+  static double GetSplineLog(int ndata, double* xdata, double* ydata, double* secderiv, double x, double logx, double logxmin, double invLDBin);
 
   // get spline interpolation over a log-spaced xgrid previously prepared by 
   // PrepareSpline (compact storrage of ydata and second deriavtive in ydata)  
   // use the improved, robust spline interpolation that I put in G4 10.6
-  double GetSplineLog(int ndata, double* xdata, double* ydata, double x, double logx, double logxmin, double invLDBin);
+  static double GetSplineLog(int ndata, double* xdata, double* ydata, double x, double logx, double logxmin, double invLDBin);
 
   // get spline interpolation over a log-spaced xgrid previously prepared by 
   // PrepareSpline (compact storrage of xdata, ydata and second deriavtive in data)  
   // use the improved, robust spline interpolation that I put in G4 10.6
-  double GetSplineLog(int ndata, double* data, double x, double logx, double logxmin, double invLDBin);
+  static double GetSplineLog(int ndata, double* data, double x, double logx, double logxmin, double invLDBin);
 
 
   // get spline interpolation over any xgrid: idx = i such  xdata[i] <= x < xdata[i+1]
   // and x >= xdata[0] and x<xdata[ndata-1]
   // PrepareSpline (separate storrage of ydata and second deriavtive)  
   // use the improved, robust spline interpolation that I put in G4 10.6
-  double GetSpline(double* xdata, double* ydata, double* secderiv, double x, int idx, int step=1);
+  static double GetSpline(double* xdata, double* ydata, double* secderiv, double x, int idx, int step=1);
 
   // get spline interpolation if it was prepared with compact storrage of ydata 
   // and second deriavtive in ydata
   // use the improved, robust spline interpolation that I put in G4 10.6
-  double GetSpline(double* xdata, double* ydata, double x, int idx);
+  static double GetSpline(double* xdata, double* ydata, double x, int idx);
 
   // get spline interpolation if it was prepared with compact storrage of xdata,
   // ydata and second deriavtive in data
-  double GetSpline(double* data, double x, int idx);
+  static double GetSpline(double* data, double x, int idx);
   
   
   // finds the lower index of the x-bin in an ordered, increasing x-grid such 
   // that x[i] <= x < x[i+1]
-  int    FindLowerBinIndex(double* xdata, int num, double x, int step=1);
-
-                  
-private:
-  // private CTR
-  G4HepEmInitUtils() {}
-
+  static int    FindLowerBinIndex(double* xdata, int num, double x, int step=1);
 }; 
 
 #endif //  G4HepEmInitUtils_HH

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -129,7 +129,7 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
       theDEDXArray[ie] = dedxIoni + std::max(0.0, dedxBrem);
     }
     // set up a spline on the DEDX array for interpolation
-    G4HepEmInitUtils::Instance().PrepareSpline(numELoss, elData->fELossEnergyGrid, theDEDXArray, theDEDXSDArray);
+    G4HepEmInitUtils::PrepareSpline(numELoss, elData->fELossEnergyGrid, theDEDXArray, theDEDXSDArray);
     // integrate the restricted dedx to get the corresponding restricted range:
     // - first set the very first range value i.e. approximate the integral of
     //   the dE/dx on [0, E_0] by assuming that the dE/dx is proportional to $\beta$
@@ -138,7 +138,7 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
     int ngl     = 16;
     double* glX = new double[ngl]{};
     double* glW = new double[ngl]{};
-    G4HepEmInitUtils::Instance().GLIntegral(ngl, glX, glW);
+    G4HepEmInitUtils::GLIntegral(ngl, glX, glW);
     for (int i=0; i<numELoss-1; ++i) {
       // for each E_i, E_i+1 interval apply the GL by substitution
       const double emin  = elData->fELossEnergyGrid[i];
@@ -147,7 +147,7 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
       double res   = 0.0;
       for (int j=0; j<ngl; ++j) {
         const double xi = del*glX[j]+emin;
-        double dedx = G4HepEmInitUtils::Instance().GetSpline(elData->fELossEnergyGrid, theDEDXArray, theDEDXSDArray, xi, i); // i is the low Energy bin index
+        double dedx = G4HepEmInitUtils::GetSpline(elData->fELossEnergyGrid, theDEDXArray, theDEDXSDArray, xi, i); // i is the low Energy bin index
         if (dedx>0.0) {
           res += glW[j]/dedx;
         }
@@ -164,8 +164,8 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
     // prepare final form of the Range, dE/dx, inverse range and their second
     // derivatives for this macc and fill in to the G4HepEmElemData elData struct
     // - set up a spline on the range array for spline interpolation
-    G4HepEmInitUtils::Instance().PrepareSpline(numELoss, elData->fELossEnergyGrid, theRangeArray, theRangeSDArray);
-    G4HepEmInitUtils::Instance().PrepareSpline(numELoss, theRangeArray, elData->fELossEnergyGrid, theInvRangeSDArray);
+    G4HepEmInitUtils::PrepareSpline(numELoss, elData->fELossEnergyGrid, theRangeArray, theRangeSDArray);
+    G4HepEmInitUtils::PrepareSpline(numELoss, theRangeArray, elData->fELossEnergyGrid, theInvRangeSDArray);
     // start index of the [range,sd, dedx, sd, inv-range sd] values for this
     // material-cuts couple in the elData->fELossData array
     int indxStart = 5*numELoss*imc;
@@ -282,7 +282,7 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
       macXSec[ie] = theXSec;
     }
     // prepare for sline by computing the second derivatives
-    G4HepEmInitUtils::Instance().PrepareSpline(numEIoni, energyGrid, macXSec, secDerivs);
+    G4HepEmInitUtils::PrepareSpline(numEIoni, energyGrid, macXSec, secDerivs);
     // fill in into the continuous array:
     // - set the current index as starting point for this material-cust couple
     elData->fResMacXSecStartIndexPerMatCut[imc] = indxCont;
@@ -335,7 +335,7 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
       macXSec[ie] = theXSec;
     }
     // prepare for sline by computing the second derivatives
-    G4HepEmInitUtils::Instance().PrepareSpline(numEBrem, energyGrid, macXSec, secDerivs);
+    G4HepEmInitUtils::PrepareSpline(numEBrem, energyGrid, macXSec, secDerivs);
     // - fill in the number of Brem data, energyOfMaxVal, maxVal, logEmin and 1/log-delta values first
     xsecData[indxCont++] = numEBrem;
     xsecData[indxCont++] = macXSecMaxEner;
@@ -424,7 +424,7 @@ void BuildTransportXSectionTables(G4VEmModel* mscModel, struct G4HepEmData* hepE
       theTr1MXsecSD[ie] = 0.0;
     }
     // set up a spline on the TR1 MXsec array for interpolation
-    G4HepEmInitUtils::Instance().PrepareSpline(numEner, elData->fELossEnergyGrid, theTr1MXsec, theTr1MXsecSD);
+    G4HepEmInitUtils::PrepareSpline(numEner, elData->fELossEnergyGrid, theTr1MXsec, theTr1MXsecSD);
     // write the data into its final location
     int iStart = 2*numEner*im;
     for (int ie=0; ie<numEner; ++ie) {

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -103,7 +103,7 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
       macXSec[ie] = std::max(0.0, ppModel->CrossSection(g4MatCut, g4PartDef, theEKin));
     }
     // prepare for sline by computing the second derivatives
-    G4HepEmInitUtils::Instance().PrepareSpline(numConvEkin, gmData->fConvEnergyGrid, macXSec, secDerivs);
+    G4HepEmInitUtils::PrepareSpline(numConvEkin, gmData->fConvEnergyGrid, macXSec, secDerivs);
     // fill in into the continuous array: index where data for this material starts from
     int mxStartIndx = hepEmMatIndx*2*(numConvEkin + numCompEkin);
     int indxCont    = mxStartIndx;
@@ -119,7 +119,7 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
 //      std::cout << " E = " << theEKin << " [MeV] Sigam-Compton(E) = " << macXSec[ie] << std::endl;
     }
     // prepare for sline by computing the second derivatives
-    G4HepEmInitUtils::Instance().PrepareSpline(numCompEkin, gmData->fCompEnergyGrid, macXSec, secDerivs);
+    G4HepEmInitUtils::PrepareSpline(numCompEkin, gmData->fCompEnergyGrid, macXSec, secDerivs);
     // fill in into the continuous array: the continuous index is used further here
     for (int i=0; i<numCompEkin; ++i) {
       gmData->fConvCompMacXsecData[indxCont++] = macXSec[i];

--- a/G4HepEm/G4HepEmInit/src/G4HepEmInitUtils.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmInitUtils.cc
@@ -4,11 +4,6 @@
 #include <cmath>
 #include <algorithm>
 
-G4HepEmInitUtils& G4HepEmInitUtils::Instance() {
-  static G4HepEmInitUtils instance;
-  return instance;
-}
-
 
 void G4HepEmInitUtils::GLIntegral(int npoints, double* abscissas, double* weights,
                                   double min, double max) {


### PR DESCRIPTION
This class has no state, so does not need to be a singleton. Following practice elsewhere in G4HepEM, convert to non-constructable class with only static member functions. 

No other changes, pure tidy.