### PR TITLE
Create function for creation of logarithmic energy grids

### DIFF
--- a/G4HepEm/G4HepEmInit/include/G4HepEmInitUtils.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmInitUtils.hh
@@ -60,6 +60,22 @@ public:
   // finds the lower index of the x-bin in an ordered, increasing x-grid such 
   // that x[i] <= x < x[i+1]
   static int    FindLowerBinIndex(double* xdata, int num, double x, int step=1);
+
+   /**
+   * Fills a pre-existing array with doubles uniformly spaced in log(x)
+   *
+   * @param[in] emin Inclusive lower bound
+   * @param[in] emax Inclusive upper bound
+   * @param[in] npoints Number of points in array, including upper/lower bounds
+   * @param[out] log_min_value Logarithm of @param emin
+   * @param[out] inverse_log_delta Inverse of logarithmic spacing between points
+   * @param[out] grid pointer to array
+   *
+   * @pre @param grid must not by `nullptr` and have capacity for at least @param npoints `double`s
+   * @post The [0,npoints-1] elements of @param grid will contain the data
+   */
+  static void FillLogarithmicGrid(const double emin, const double emax, const int npoints,
+                                  double& log_min_value, double& inverse_log_delta, double* grid);
 }; 
 
 #endif //  G4HepEmInitUtils_HH

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -44,25 +44,13 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
                                        : hepEmData->fThePositronData;
   //
   // generate the enegry grid (common for all mat-cuts)
+  delete [] elData->fELossEnergyGrid;
+  elData->fELossEnergyGrid = new double[numELoss]{};
   const int numELoss = hepEmParams->fNumLossTableBins+1;
   elData->fELossEnergyGridSize = numELoss;
-//  elData->fELossMinEnergy      = hepEmParams->fMinLossTableEnergy;
-//  elData->fELossMaxEnergy      = hepEmParams->fMaxLossTableEnergy;
-  // allocate arrays for the loss table energy grid and for the loss data
-  if (elData->fELossEnergyGrid) {
-    delete[] elData->fELossEnergyGrid;
-  }
-  elData->fELossEnergyGrid     = new double[numELoss]{};
-  elData->fELossLogMinEkin     = std::log(hepEmParams->fMinLossTableEnergy);
-  const double delta           = std::log(hepEmParams->fMaxLossTableEnergy/hepEmParams->fMinLossTableEnergy)/(numELoss-1.0);
-  elData->fELossEILDelta       = 1.0/delta;
-  // fill in
-  elData->fELossEnergyGrid[0]          = hepEmParams->fMinLossTableEnergy;
-  elData->fELossEnergyGrid[numELoss-1] = hepEmParams->fMaxLossTableEnergy;
-  for (int i=1; i<numELoss-1; ++i) {
-    elData->fELossEnergyGrid[i] = std::exp(elData->fELossLogMinEkin+i*delta);
-  }
-  //
+  G4HepEmInitUtils::FillLogarithmicGrid(hepEmParams->fMinLossTableEnergy, hepEmParams->fMaxLossTableEnergy, numELoss,
+                                        elData->fELossLogMinEkin, elData->fELossEILDelta, elData->fELossEnergyGrid);
+
   // get the g4 particle-definition
   G4ParticleDefinition* g4PartDef = G4Positron::Positron();
   if  (iselectron) {
@@ -246,35 +234,38 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
   // a continuous index
   int indxCont = 0;
   for (int imc=0; imc<numHepEmMCCData; ++imc) {
+    // ====== Common data
     const struct G4HepEmMCCData& mccData = hepEmMCData->fMatCutData[imc];
     const G4MaterialCutsCouple* g4MatCut = theCoupleTable->GetMaterialCutsCouple(mccData.fG4MatCutIndex);
     const double     elCutE = mccData.fSecElProdCutE;  // already includes e- tracking cut
     const double    gamCutE = mccData.fSecGamProdCutE;
+
+    // Energy grid in/out parameters
+    const double       emax = hepEmParams->fMaxLossTableEnergy;
+    const int    numDefEkin = hepEmParams->fNumLossTableBins+1;
+    const double      scale = std::log(hepEmParams->fMaxLossTableEnergy/hepEmParams->fMinLossTableEnergy);
+
+    double logEmin  = -1.0;
+    double invLEDel = -1.0;
+
     //
     // ===== Ionisation
     //
+    // Fill the energy grid for Ioni
     // find out the lowest energy of the ioni Ekin grid and the number of entries
-    const double       emax = hepEmParams->fMaxLossTableEnergy;
     const double   eminIoni = iselectron ? 2*elCutE : elCutE;
-    const int    numDefEkin = hepEmParams->fNumLossTableBins+1;
-    const double      scale = std::log(hepEmParams->fMaxLossTableEnergy/hepEmParams->fMinLossTableEnergy);
     const double  scaleIoni = std::log(emax/eminIoni);
     const int      numEIoni = std::max(4, (int)std::lrint(numDefEkin*scaleIoni/scale)+1);
-    // generate the energy grid for Ioni
-    double          logEmin = std::log(eminIoni);
-    double            delta = scaleIoni/(numEIoni-1);
-    double         invLEDel =  1.0/delta;
+    G4HepEmInitUtils::FillLogarithmicGrid(eminIoni, emax, numEIoni, logEmin, invLEDel, energyGrid);
+
+    // compute macroscopic cross section for Ioni.
+    // track macroscopic cross section max and its energy
     double       macXSecMax = -1.0;
     double   macXSecMaxEner = -1.0;
-    energyGrid[0]           = eminIoni;
-    energyGrid[numEIoni-1]  = emax;
-    for (int ie=1; ie<numEIoni-1; ++ie) {
-      energyGrid[ie] = std::exp(logEmin+ie*delta);
-    }
+
     for (int ie=0; ie<numEIoni; ++ie) {
       const double theEKin  = energyGrid[ie];
       const double theXSec  = std::max(0.0, mbModel->CrossSection(g4MatCut, g4PartDef, theEKin, elCutE, theEKin));
-      // keep track of macroscopic cross section max and its energy
       if (theXSec>macXSecMax) {
         macXSecMax     = theXSec;
         macXSecMaxEner = theEKin;
@@ -297,24 +288,21 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
       xsecData[indxCont++] = macXSec[ie];
       xsecData[indxCont++] = secDerivs[ie];
     }
+
     //
     // ===== Bremsstrahlung
     //
+    // Fill the energy grid for Brem:
     const double   eminBrem = gamCutE;
     const double  scaleBrem = std::log(emax/eminBrem);
     const int      numEBrem = std::max(4, (int)std::lrint(numDefEkin*scaleBrem/scale)+1);
-    // generate the energy grid for Brem: smooth the mac-xsec values between the 2 models
-    logEmin                 = std::log(eminBrem);
-    delta                   = scaleBrem/(numEBrem-1);
-    invLEDel                =  1.0/delta;
+    G4HepEmInitUtils::FillLogarithmicGrid(eminBrem, emax, numEBrem, logEmin, invLEDel, energyGrid);
+
+    // compute macroscopic cross section for Brem: smooth the xsection values between the 2 models
+    // keep track of macroscopic cross section max and its energy
     macXSecMax              = -1.0;
     macXSecMaxEner          = -1.0;
-    energyGrid[0]           = eminBrem;
-    energyGrid[numEBrem-1]  = emax;
-    for (int ie=1; ie<numEBrem-1; ++ie) {
-      energyGrid[ie] = std::exp(logEmin+ie*delta);
-    }
-    // compute macroscopic cross section for Brem: smooth the xsection values between the 2 models
+
     for (int ie=0; ie<numEBrem; ++ie) {
       const double theEKin  = energyGrid[ie];
       double dlta = 0.0;
@@ -327,7 +315,7 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
                         ? std::max(0.0, rbModel->CrossSection(g4MatCut, g4PartDef, theEKin, gamCutE, theEKin))
                         : std::max(0.0, sbModel->CrossSection(g4MatCut, g4PartDef, theEKin, gamCutE, theEKin));
       theXSec *= (1.0+dlta/theEKin);
-      // keep track of macroscopic cross section max and its energy
+
       if (theXSec>macXSecMax) {
         macXSecMax     = theXSec;
         macXSecMaxEner = theEKin;
@@ -615,14 +603,9 @@ int InitElementSelectorEnergyGrid(int binsperdecade, double* egrid, double mine,
     numEnergyBins = 3;
   }
   ++numEnergyBins;
-  double delta = std::log(maxe/mine)/(numEnergyBins-1.0);
-  logMinEnergy = std::log(mine);
-  invLEDelta   = 1.0/delta;
-  egrid[0]     = mine;
-  egrid[numEnergyBins-1] = maxe;
-  for (int i=1; i<numEnergyBins-1; ++i) {
-    egrid[i] = std::exp(logMinEnergy+i*delta);
-  }
+
+  G4HepEmInitUtils::FillLogarithmicGrid(mine, maxe, numEnergyBins, logMinEnergy, invLEDelta, egrid);
+
   return numEnergyBins;
 }
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -44,10 +44,10 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
                                        : hepEmData->fThePositronData;
   //
   // generate the enegry grid (common for all mat-cuts)
-  delete [] elData->fELossEnergyGrid;
-  elData->fELossEnergyGrid = new double[numELoss]{};
   const int numELoss = hepEmParams->fNumLossTableBins+1;
   elData->fELossEnergyGridSize = numELoss;
+  delete [] elData->fELossEnergyGrid;
+  elData->fELossEnergyGrid = new double[numELoss]{};
   G4HepEmInitUtils::FillLogarithmicGrid(hepEmParams->fMinLossTableEnergy, hepEmParams->fMaxLossTableEnergy, numELoss,
                                         elData->fELossLogMinEkin, elData->fELossEILDelta, elData->fELossEnergyGrid);
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -31,42 +31,21 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
   struct G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
   //
   // == Generate the enegry grid for Conversion
-  int numConvEkin = gmData->fConvEnergyGridSize;
-  // allocate array for the kinetic energy grid
-  if (gmData->fConvEnergyGrid) {
-    delete[] gmData->fConvEnergyGrid;
-  }
   double emin = 2.0*CLHEP::electron_mass_c2;
   double emax = 100.0*CLHEP::TeV;
+  int numConvEkin = gmData->fConvEnergyGridSize;
+  delete [] gmData->fConvEnergyGrid;
   gmData->fConvEnergyGrid = new double[numConvEkin]{};
-  gmData->fConvLogMinEkin = std::log(emin);
-  double delta = std::log(emax/emin)/(numConvEkin-1.0);
-  gmData->fConvEILDelta   = 1.0/delta;
-  // fill in
-  gmData->fConvEnergyGrid[0]             = emin;
-  gmData->fConvEnergyGrid[numConvEkin-1] = emax;
-  for (int i=1; i<numConvEkin-1; ++i) {
-    gmData->fConvEnergyGrid[i] = std::exp(gmData->fConvLogMinEkin+i*delta);
-  }
-  //
+  G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numConvEkin, gmData->fConvLogMinEkin, gmData->fConvEILDelta, gmData->fConvEnergyGrid);
+
   // == Generate the enegry grid for Compton
-  int numCompEkin = gmData->fCompEnergyGridSize;
-  // allocate array for the kinetic energy grid
-  if (gmData->fCompEnergyGrid) {
-    delete[] gmData->fCompEnergyGrid;
-  }
   emin = 100.0* CLHEP::eV;
   emax = 100.0*CLHEP::TeV;
+  int numCompEkin = gmData->fCompEnergyGridSize;
+  delete [] gmData->fCompEnergyGrid;
   gmData->fCompEnergyGrid = new double[numCompEkin]{};
-  gmData->fCompLogMinEkin = std::log(emin);
-  delta = std::log(emax/emin)/(numCompEkin-1.0);
-  gmData->fCompEILDelta   = 1.0/delta;
-  // fill in
-  gmData->fCompEnergyGrid[0]             = emin;
-  gmData->fCompEnergyGrid[numCompEkin-1] = emax;
-  for (int i=1; i<numCompEkin-1; ++i) {
-    gmData->fCompEnergyGrid[i] = std::exp(gmData->fCompLogMinEkin+i*delta);
-  }
+  G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numCompEkin, gmData->fCompLogMinEkin, gmData->fCompEILDelta, gmData->fCompEnergyGrid);
+
   //
   // == Compute the macroscopic cross sections: for Conversion and Compton over
   //    all materials
@@ -147,18 +126,10 @@ void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepE
   const double invlog106 = 1.0/(6.0*std::log(10.0));
   int numConvEkin = (int)(G4EmParameters::Instance()->NumberOfBinsPerDecade()*std::log(emax/emin)*invlog106);
   gmData->fElemSelectorConvEgridSize = numConvEkin;
-  // allocate array for the kinetic energy grid
-  gmData->fElemSelectorConvEgrid = new double[numConvEkin]{};
-  double lemin = std::log(emin);
-  double delta = std::log(emax/emin)/(numConvEkin-1.0);
-  gmData->fElemSelectorConvLogMinEkin = lemin;
-  gmData->fElemSelectorConvEILDelta   = 1.0/delta;
-  // fill in
-  gmData->fElemSelectorConvEgrid[0]             = emin;
-  gmData->fElemSelectorConvEgrid[numConvEkin-1] = emax;
-  for (int i=1; i<numConvEkin-1; ++i) {
-    gmData->fElemSelectorConvEgrid[i] = std::exp(lemin+i*delta);
-  }
+  gmData->fElemSelectorConvEgrid = new double[numpConvEkin]{};
+  G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numConvEkin,
+                                        gmData->fElemSelectorConvLogMinEkin, gmData->fElemSelectorConvEILDelta, gmData->fElemSelectorConvEgrid);
+
   //
   // fill in with the element selectors (only for materials with #elemnt > 1)
   // get the G4HepEm material-cuts and material data: allocate memory for the

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -126,7 +126,7 @@ void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepE
   const double invlog106 = 1.0/(6.0*std::log(10.0));
   int numConvEkin = (int)(G4EmParameters::Instance()->NumberOfBinsPerDecade()*std::log(emax/emin)*invlog106);
   gmData->fElemSelectorConvEgridSize = numConvEkin;
-  gmData->fElemSelectorConvEgrid = new double[numpConvEkin]{};
+  gmData->fElemSelectorConvEgrid = new double[numConvEkin]{};
   G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numConvEkin,
                                         gmData->fElemSelectorConvLogMinEkin, gmData->fElemSelectorConvEILDelta, gmData->fElemSelectorConvEgrid);
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmInitUtils.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmInitUtils.cc
@@ -239,4 +239,15 @@ int    G4HepEmInitUtils::FindLowerBinIndex(double* xdata, int num, double x, int
 }
 
 
+void G4HepEmInitUtils::FillLogarithmicGrid(const double emin, const double emax, const int npoints, double& log_min_value, double& inverse_log_delta, double* grid)
+{
+  double delta = std::log(emax/emin) / (npoints - 1);
+  log_min_value = std::log(emin);
+  inverse_log_delta = 1.0 / delta;
+  grid[0] = emin;
+  grid[npoints-1] = emax;
 
+  for (size_t i = 1; i < npoints-1; ++i) {
+    grid[i] = std::exp(log_min_value + i * delta);
+  }
+}


### PR DESCRIPTION
I'm not sure what policy/thoughts on refactoring in G4HepEm are (hence draft status, so feel free to reject!), but this _seemed_ like an obviously one to ensure commonality for the reasonably wide use of energy grids with spacing of points even in `log(E)`. The population of these arrays and ancillary data (log of lower bound, inverse of spacing in `log(E)`) is identical in all the places I could find in `G4HepEmInit`, so that's been factored into a helper function in `G4HepEmInitUtils`, with clients updated to use this. NB: implemented as a `static` function in `G4HepEmInitUtils` in line with #92, but easy to change if needed.

I've only done a rough test using the existing tests for now, but if people think this is useful update I'll check/validate in more depth to be sure.