### PR TITLE
Refactor spline calculations into single functions

### DIFF
--- a/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.hh
@@ -16,7 +16,9 @@ void RotateToReferenceFrame(double &u, double &v, double &w, const double* refDi
 G4HepEmHostDevice
 void RotateToReferenceFrame(double* dir, const double* refDir);
 
-
+// get spline interpolation of y(x) between (x1, x2) given y_N = y(x_N), y''N(x_N) 
+G4HepEmHostDevice
+double GetSpline(double x1, double x2, double y1, double y2, double secderiv1, double secderiv2, double x);
 
 // get spline interpolation over a log-spaced xgrid previously prepared by
 // PrepareSpline (separate storrage of ydata and second deriavtive)
@@ -54,7 +56,6 @@ double GetSpline(double* xdata, double* ydata, double x, int idx);
 // ydata and second deriavtive in data
 G4HepEmHostDevice
 double GetSpline(double* data, double x, int idx);
-
 
 // finds the lower index of the x-bin in an ordered, increasing x-grid such
 // that x[i] <= x < x[i+1]

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.icc
@@ -45,6 +45,20 @@ void RotateToReferenceFrame(double* dir, const double* refDir) {
   }
 }
 
+// use the improved, robust spline interpolation that I put in G4 10.6
+double GetSpline(double x1, double x2, double y1, double y2, double secderiv1, double secderiv2, double x)
+{
+  // Unchecked precondition: x1 < x < x2
+  const double dl = x2 - x1;
+  // note: all corner cases of the previous methods are covered and eventually
+  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
+  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
+  const double  b = G4HepEmMax(0., G4HepEmMin(1., (x - x1)/dl));
+  const double os = 0.166666666667; // 1./6.
+  const double c0 = (2.0 - b)*secderiv1;
+  const double c1 = (1.0 + b)*secderiv2;
+  return y1 + b*(y2 - y1) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
+}
 
 // use the improved, robust spline interpolation that I put in G4 10.6
 double GetSplineLog(int ndata, double* xdata, double* ydata, double* secderiv, double x, double logx, double logxmin, double invLDBin) {
@@ -52,20 +66,7 @@ double GetSplineLog(int ndata, double* xdata, double* ydata, double* secderiv, d
   const double xv = G4HepEmMax(xdata[0], G4HepEmMin(xdata[ndata-1], x));
   // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
   const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
-  // perform the interpolation
-  const double x1 = xdata[idx];
-  const double x2 = xdata[idx+1];
-  const double dl = x2-x1;
-  // note: all corner cases of the previous methods are covered and eventually
-  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
-  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
-  const double  b = G4HepEmMax(0., G4HepEmMin(1., (xv - x1)/dl));
-  //
-  const double os = 0.166666666667; // 1./6.
-  const double c0 = (2.0 - b)*secderiv[idx];
-  const double c1 = (1.0 + b)*secderiv[idx+1];
-  return ydata[idx] + b*(ydata[idx+1]-ydata[idx]) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
-
+  return GetSpline(xdata[idx], xdata[idx+1], ydata[idx], ydata[idx+1], secderiv[idx], secderiv[idx+1], xv);
 }
 
 // same as above but both ydata and secderiv are stored in ydata array
@@ -74,20 +75,8 @@ double GetSplineLog(int ndata, double* xdata, double* ydata, double x, double lo
   const double xv = G4HepEmMax(xdata[0], G4HepEmMin(xdata[ndata-1], x));
   // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
   const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
-  const int  idx2 = 2*idx;
-  // perform the interpolation
-  const double x1 = xdata[idx];
-  const double x2 = xdata[idx+1];
-  const double dl = x2-x1;
-  // note: all corner cases of the previous methods are covered and eventually
-  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
-  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
-  const double  b = G4HepEmMax(0., G4HepEmMin(1., (xv - x1)/dl));
-  //
-  const double os = 0.166666666667; // 1./6.
-  const double c0 = (2.0 - b)*ydata[idx2+1];
-  const double c1 = (1.0 + b)*ydata[idx2+3];
-  return ydata[idx2] + b*(ydata[idx2+2]-ydata[idx2]) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
+  const int  idx2 = 2*idx; 
+  return GetSpline(xdata[idx], xdata[idx+1], ydata[idx2], ydata[idx2+2], ydata[idx2+1], ydata[idx2+3], xv);
 }
 
 
@@ -98,77 +87,25 @@ double GetSplineLog(int ndata, double* data, double x, double logx, double logxm
   // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
   const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
   const int  idx3 = 3*idx;
-  // perform the interpolation
-  const double x1 = data[idx3];
-  const double x2 = data[idx3+3];
-  const double dl = x2-x1;
-  // note: all corner cases of the previous methods are covered and eventually
-  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
-  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
-  const double  b = G4HepEmMax(0., G4HepEmMin(1., (xv - x1)/dl));
-  //
-  const double os = 0.166666666667; // 1./6.
-  const double c0 = (2.0 - b)*data[idx3+2];
-  const double c1 = (1.0 + b)*data[idx3+5];
-  return data[idx3+1] + b*(data[idx3+4]-data[idx3+1]) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
+  return GetSpline(data[idx3], data[idx3+3], data[idx3+1], data[idx3+4], data[idx3+2], data[idx3+5], xv);
 }
-
-
-
 
 
 // this is used for getting inverse-range on host
 double GetSpline(double* xdata, double* ydata, double* secderiv, double x, int idx, int step) {
-  // perform the interpolation
-  const double x1 = xdata[step*idx];
-  const double x2 = xdata[step*(idx+1)];
-  const double dl = x2-x1;
-  // note: all corner cases of the previous methods are covered and eventually
-  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
-  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
-  const double  b = G4HepEmMax(0., G4HepEmMin(1., (x - x1)/dl));
-  //
-  const double os = 0.166666666667; // 1./6.
-  const double c0 = (2.0 - b)*secderiv[idx];
-  const double c1 = (1.0 + b)*secderiv[idx+1];
-  return ydata[idx] + b*(ydata[idx+1]-ydata[idx]) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
-
+  return GetSpline(xdata[step*idx], xdata[step*(idx+1)], ydata[idx], ydata[idx+1], secderiv[idx], secderiv[idx+1], x);
 }
 
 // same as above but both ydata and secderiv are stored in ydata array
 double GetSpline(double* xdata, double* ydata, double x, int idx) {
   const int  idx2 = 2*idx;
-  // perform the interpolation
-  const double x1 = xdata[idx];
-  const double x2 = xdata[idx+1];
-  const double dl = x2-x1;
-  // note: all corner cases of the previous methods are covered and eventually
-  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
-  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
-  const double  b = G4HepEmMax(0., G4HepEmMin(1., (x - x1)/dl));
-  //
-  const double os = 0.166666666667; // 1./6.
-  const double c0 = (2.0 - b)*ydata[idx2+1];
-  const double c1 = (1.0 + b)*ydata[idx2+3];
-  return ydata[idx2] + b*(ydata[idx2+2]-ydata[idx2]) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
+  return GetSpline(xdata[idx], xdata[idx+1], ydata[idx2], ydata[idx2+2], ydata[idx2+1], ydata[idx2+3], x);
 }
 
 // same as above but both xdata, ydata and secderiv are stored in data array
 double GetSpline(double* data, double x, int idx) {
   const int  idx3 = 3*idx;
-  // perform the interpolation
-  const double x1 = data[idx3];
-  const double x2 = data[idx3+3];
-  const double dl = x2-x1;
-  // note: all corner cases of the previous methods are covered and eventually
-  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
-  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
-  const double  b = G4HepEmMax(0., G4HepEmMin(1., (x - x1)/dl));
-  //
-  const double os = 0.166666666667; // 1./6.
-  const double c0 = (2.0 - b)*data[idx3+2];
-  const double c1 = (1.0 + b)*data[idx3+5];
-  return data[idx3+1] + b*(data[idx3+4]-data[idx3+1]) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
+  return GetSpline(data[idx3], data[idx3+3], data[idx3+1], data[idx3+4], data[idx3+2], data[idx3+5], x);
 }
 
 // this is used to get index for inverse range on host


### PR DESCRIPTION
Very much along the lines of #93, this separates the spline calculation part of `GetSpline/GetSplineLog` in `G4HepEmInit` and `G4HepEmRun` from the operations extracting the required `x,y,y"` data from the input array(s). These are of course separate libraries, with `G4HepEMRun` required to run on device, so no further unification is intended - the code duplication is fine here, and the current changes reduce that a lot(*). The signature of the new function was chosen to match as close as possible the existing ones, but can easily be changed if wanted.

It should, I hope, also help with future changes to the data layout, as only the extraction of the needed data from the arrays needs to be modified.

I have not done detailed performance tests yet, though the simplicity and likely inlining of the new function in `G4HepEmRun` will I hope not impact that...

(*) `G4HepEmRun` uses the spline calculation from Geant4 11 (see #68), but `G4HepEmInit` is still using an earlier version. May not be critical, and left things as-is for now, but I can make sure both functions are the same if that is needed.