### PR TITLE
Remove declaration of `G4HepEmTrackingManager::TrackPositron`

### DIFF
--- a/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -34,7 +34,6 @@ public:
 
 private:
   void TrackElectron(G4Track *aTrack);
-  void TrackPositron(G4Track *aTrack);
   void TrackGamma(G4Track *aTrack);
 
   G4HepEmRunManager *fRunManager;


### PR DESCRIPTION
We use `TrackElectron` for both electrons and positrons since their processes are very similar and both go via `G4HepEmElectronManager`.