### PR TITLE
Do not delete NoProcess instances in G4HepEmTrackingManager

### DIFF
--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -77,12 +77,8 @@ G4HepEmTrackingManager::G4HepEmTrackingManager() {
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 G4HepEmTrackingManager::~G4HepEmTrackingManager() {
-  for (auto *proc : fElectronNoProcessVector) {
-    delete proc;
-  }
-  for (auto *proc : fGammaNoProcessVector) {
-    delete proc;
-  }
+  // Per behaviour in Physics Constructors, we do not delete the G4HepEmNoProcess
+  // instances as these are owned by G4ProcessTable.
   delete fRunManager;
   delete fRandomEngine;
   delete fStep;


### PR DESCRIPTION
In testing AdePT "CPU only" mode using G4HepEm, discovered that use of `G4HepEmTrackingManager` in same fashion as the AdePT tracking manager resulted in a segmentation fault at program exit. This was traced to the destructor of `G4HepEmTrackingManager` deleting the `G4HepEmNoProcess` instances it creates. These are important for mapping back to user code information about the process limiting/creating a step. All tracking managers are deleted by `G4RunManager` _after_ the deletion of `G4ProcessTable` which nominally owns all instances of `G4VProcess`.

Remove deletion of `G4HepEmNoProcess` instances in destructor of `G4HepEmTrackingManager`, leaving their deletion of the destructor of G4ProcessTable. This matches the pattern seen in Geant4's physics constructor classes.