### PR TITLE
Do not delete NoProcess instances in G4HepEmProcess

### DIFF
--- a/G4HepEm/G4HepEm/src/G4HepEmProcess.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmProcess.cc
@@ -62,12 +62,6 @@ G4HepEmProcess::G4HepEmProcess()
 }
 
 G4HepEmProcess::~G4HepEmProcess() {
-  for (auto *proc : fElectronNoProcessVector) {
-    delete proc;
-  }
-  for (auto *proc : fGammaNoProcessVector) {
-    delete proc;
-  }
   delete fTheG4HepEmRunManager;
   delete fTheG4HepEmRandomEngine;
 }


### PR DESCRIPTION
As described in the message of commit ac88af775a, processes are owned by the `G4ProcessTable` and should not be deleted manually. This worked by accident for the `G4HepEmProcess` because it is a process itself which the table deletes before the `G4HepEmNoProcess`es.