### PR TITLE
Modifications required for using G4HepEm through the G4HepEmTrackingManager inside ATLAS Athena.

### DIFF
--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -162,6 +162,11 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     aTrack->SetNextTouchableHandle(touchableHandle);
   }
 
+  // Set OriginTouchableHandle for primary track(set at stacking for secondaries)
+  if (aTrack->GetParentID() == 0) {
+    aTrack->SetOriginTouchableHandle(aTrack->GetTouchableHandle());
+  }
+
   // Set vertex information: in normal tracking this is done in
   //  `G4TrackingManager::ProcessOneTrack` when calling
   //  `G4SteppingManager::SetInitialStep`

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -208,6 +208,7 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
 
   const G4DynamicParticle *theG4DPart = aTrack->GetDynamicParticle();
   const G4int trackID = aTrack->GetTrackID();
+  const G4double trackWeight = aTrack->GetWeight();
 
   // Init state that never changes for a track.
   const double charge = aTrack->GetParticleDefinition()->GetPDGCharge();
@@ -508,6 +509,7 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
         aG4Track->SetParentID(trackID);
         aG4Track->SetCreatorProcess(proc);
         aG4Track->SetTouchableHandle(touchableHandle);
+        aG4Track->SetWeight(trackWeight);
         secondaries.push_back(aG4Track);
       }
       theTLData->ResetNumSecondaryElectronTrack();
@@ -530,6 +532,7 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
         aG4Track->SetParentID(trackID);
         aG4Track->SetCreatorProcess(proc);
         aG4Track->SetTouchableHandle(touchableHandle);
+        aG4Track->SetWeight(trackWeight);
         secondaries.push_back(aG4Track);
       }
       theTLData->ResetNumSecondaryGammaTrack();
@@ -714,6 +717,7 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
           aG4Track->SetParentID(track.GetTrackID());
           aG4Track->SetCreatorProcess(proc);
           aG4Track->SetTouchableHandle(theG4TouchableHandle);
+          aG4Track->SetWeight(track.GetWeight());
           secondaries.push_back(aG4Track);
         }
         theTLData->ResetNumSecondaryElectronTrack();
@@ -736,6 +740,7 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
           aG4Track->SetParentID(track.GetTrackID());
           aG4Track->SetCreatorProcess(proc);
           aG4Track->SetTouchableHandle(theG4TouchableHandle);
+          aG4Track->SetWeight(track.GetWeight());
           secondaries.push_back(aG4Track);
         }
         theTLData->ResetNumSecondaryGammaTrack();

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -160,6 +160,16 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     aTrack->SetNextTouchableHandle(touchableHandle);
   }
 
+  // Set vertex information: in normal tracking this is done in
+  //  `G4TrackingManager::ProcessOneTrack` when calling
+  //  `G4SteppingManager::SetInitialStep`
+  if (aTrack->GetCurrentStepNumber() == 0) {
+    aTrack->SetVertexPosition(aTrack->GetPosition());
+    aTrack->SetVertexMomentumDirection(aTrack->GetMomentumDirection());
+    aTrack->SetVertexKineticEnergy(aTrack->GetKineticEnergy());
+    aTrack->SetLogicalVolumeAtVertex(aTrack->GetVolume()->GetLogicalVolume());
+  }
+
   // Prepare data structures used while tracking.
   G4Step &step = *fStep;
   G4TrackVector& secondaries = *step.GetfSecondary();

--- a/G4HepEm/G4HepEm/src/TrackingManagerHelper.icc
+++ b/G4HepEm/G4HepEm/src/TrackingManagerHelper.icc
@@ -102,6 +102,16 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, G4Step* aStep,
     aTrack->SetNextTouchableHandle(touchableHandle);
   }
 
+  // Set vertex information: in normal tracking this is done in
+  //  `G4TrackingManager::ProcessOneTrack` when calling
+  //  `G4SteppingManager::SetInitialStep`
+  if (aTrack->GetCurrentStepNumber() == 0) {
+    aTrack->SetVertexPosition(aTrack->GetPosition());
+    aTrack->SetVertexMomentumDirection(aTrack->GetMomentumDirection());
+    aTrack->SetVertexKineticEnergy(aTrack->GetKineticEnergy());
+    aTrack->SetLogicalVolumeAtVertex(aTrack->GetVolume()->GetLogicalVolume());
+  }
+
   // Prepare data structures used while tracking.
   G4Step &step = *aStep;
   G4TrackVector& secondaries = *step.GetfSecondary();

--- a/G4HepEm/G4HepEm/src/TrackingManagerHelper.icc
+++ b/G4HepEm/G4HepEm/src/TrackingManagerHelper.icc
@@ -104,6 +104,11 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, G4Step* aStep,
     aTrack->SetNextTouchableHandle(touchableHandle);
   }
 
+  // Set OriginTouchableHandle for primary track(set at stacking for secondaries)
+  if (aTrack->GetParentID() == 0) {
+    aTrack->SetOriginTouchableHandle(aTrack->GetTouchableHandle());
+  }
+
   // Set vertex information: in normal tracking this is done in
   //  `G4TrackingManager::ProcessOneTrack` when calling
   //  `G4SteppingManager::SetInitialStep`

--- a/G4HepEm/G4HepEm/src/TrackingManagerHelper.icc
+++ b/G4HepEm/G4HepEm/src/TrackingManagerHelper.icc
@@ -42,6 +42,8 @@
 #include "G4UserSteppingAction.hh"
 #include "G4UserTrackingAction.hh"
 #include "G4VSensitiveDetector.hh"
+#include "G4TrackingManager.hh"
+#include "G4VTrajectory.hh"
 
 #include "G4Field.hh"
 #include "G4FieldManager.hh"
@@ -125,6 +127,12 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, G4Step* aStep,
     userTrackingAction->PreUserTrackingAction(aTrack);
   }
 
+  // Store the trajectory only if the user requested in the G4TrackingManager
+  // and set their own trajectory object (usually in the PreUserTrackingAction).
+  G4TrackingManager* trMgr = evtMgr->GetTrackingManager();
+  G4VTrajectory* theTrajectory = trMgr->GetStoreTrajectory() == 0
+                                 ? nullptr : trMgr->GimmeTrajectory();
+
   physics.StartTracking(aTrack);
 
   while(aTrack->GetTrackStatus() == fAlive)
@@ -206,6 +214,11 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, G4Step* aStep,
     {
       regionalAction->UserSteppingAction(&step);
     }
+
+    // Append the trajectory if it was requested.
+    if (theTrajectory != nullptr) {
+      theTrajectory->AppendStep(&step);
+    }
   }
 
   if(aTrack->GetTrackStatus() == fStopButAlive &&
@@ -240,6 +253,11 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, G4Step* aStep,
     {
       regionalAction->UserSteppingAction(&step);
     }
+
+    // Append the trajectory if it was requested.
+    if (theTrajectory != nullptr) {
+      theTrajectory->AppendStep(&step);
+    }
   }
 
   // End of tracking: Inform processes and user.
@@ -248,6 +266,11 @@ void TrackingManagerHelper::TrackParticle(G4Track* aTrack, G4Step* aStep,
   if(userTrackingAction)
   {
     userTrackingAction->PostUserTrackingAction(aTrack);
+  }
+
+  // Delete the trajectory object (if the user set any)
+  if (theTrajectory != nullptr) {
+    delete theTrajectory;
   }
 
   evtMgr->StackTracks(&secondaries);


### PR DESCRIPTION
These are the changes to the `G4HepEmTrackingManager` that are required to provide all functionalities/information for a complete ATLAS Athena simulation. With these modifications, the `G4HepEmTrackingManager` provides e-/e+ and gamma transport simulation inside Athena that agrees well with using the native Geant4 (Atlas patched version of `Geant4-11.2.2`) standard EM physics. This has been checked and verified by performing an ATLAS full physics validation: based on `30 000 ttbar` events simulated in Athena using the native Geant4 standard physics as in production (as ref) v.s. using `G4HepEm`
through this version of the `G4HepEmTrackingManager` (as test).

Some additional modifications are also required though beyond this version of the `G4HepEmTrackingManager` to be used inside ATLAS Athena. However, those are on the Athena side so I provide them there: 
 - the TRT SD code requires a pointer to the photoelectric process that is obtained by scarping the process manager of the gamma particle. This can be eliminated easily leading to a cleaner and more robust code by relying of the process type instead. I provide the related changes to Athena.
 - the ATLAS specific `TRTTransitionRadiation` process is attached to e-/e+ on the Athena side. As this is very ATLAS specific, even specific to their TRT detector, this won't be implemented in `G4HepEm`. I provide a special, ATLAS specific version of the `G4HepEmTrackingManager` instead, that properly accounts this XTR process, inside Athena (must be there as that tracking manager depends on the TRTTransitionRadiation process).
