### PR TITLE
This adds the capability to the HepEm tracking manger of handling Geant4 fast simulation processes.

### DIFF
--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -9,6 +9,7 @@ class G4HepEmRandomEngine;
 class G4HepEmNoProcess;
 class G4SafetyHelper;
 class G4Step;
+class G4VProcess;
 
 #include <vector>
 
@@ -36,6 +37,10 @@ private:
   void TrackElectron(G4Track *aTrack);
   void TrackGamma(G4Track *aTrack);
 
+  // Checks if the particles has fast simulation maanger process attached and
+  // stores in the local `fFastSimProcess` array (indexed by HepEm particle ID)
+  void InitFastSimRelated(int particleID);
+
   G4HepEmRunManager *fRunManager;
   G4HepEmRandomEngine *fRandomEngine;
   G4SafetyHelper *fSafetyHelper;
@@ -53,6 +58,11 @@ private:
   std::vector<G4HepEmNoProcess *> fElectronNoProcessVector;
   std::vector<G4HepEmNoProcess *> fGammaNoProcessVector;
   G4HepEmNoProcess *fTransportNoProcess;
+
+  // Pointers to the fast simulation manager processes of the 3 particles if any
+  // [0] e-; [1] e+; [2] gamma; nullptr: no fast sim manager process attached
+  G4VProcess* fFastSimProcess[3];
+
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -7,6 +7,7 @@
 class G4HepEmRunManager;
 class G4HepEmRandomEngine;
 class G4HepEmNoProcess;
+class G4HepEmTLData;
 class G4SafetyHelper;
 class G4Step;
 class G4VProcess;
@@ -36,6 +37,11 @@ public:
 private:
   void TrackElectron(G4Track *aTrack);
   void TrackGamma(G4Track *aTrack);
+
+  // Stacks secondaries created by HepEm physics (if any) and returns with the
+  // energy deposit while stacking due to applying secondary production cuts
+  double StackSecondaries(G4HepEmTLData* aTLData, G4Track* aG4PrimaryTrack,
+                          const G4VProcess* aG4CreatorProcess, int aG4IMC);
 
   // Checks if the particles has fast simulation maanger process attached and
   // stores in the local `fFastSimProcess` array (indexed by HepEm particle ID)


### PR DESCRIPTION
Geant4 fast simulation manager processes, attached to e-/e+ and gamma by the user, were ignored so far in the tracking manager implementation of the stepping loops. These are included now. 

The gamma tracking has been reimplemented without using the stacking manger helper in order to be able to call the fast simulation process and handle that properly during the gamma tracking. 

The code, used both in the e-/e+ and gamma tracking to stack secondaries created by the HepEm physics, is factored now and reused in both places.    