### PR TITLE
Finalise the implementation of incorporation the ATLAS specific XTR process.

### DIFF
--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -35,6 +35,13 @@ public:
     return fMultipleSteps;
   }
 
+  // ATLAS XTR RELATED:
+  // Set the names of the ATLAS specific transition radiation process and
+  // radiator region (only for ATLAS and only if different than init.ed below)
+  void SetXTRProcessName(const std::string& name) { fXTRProcessName = name; }
+  void SetXTRRegionName(const std::string& name)  { fXTRRegionName  = name; }
+
+
 private:
   void TrackElectron(G4Track *aTrack);
   void TrackGamma(G4Track *aTrack);
@@ -84,7 +91,9 @@ private:
   // detector region that contain the tradiator volumes
   G4VProcess* fXTRProcess;
   G4Region*   fXTRRegion;
-
+  // The names that will be used to find the XTR process and detector region.
+  std::string fXTRProcessName = {"XTR"};
+  std::string fXTRRegionName  = {"TRT_RADIATOR"};
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -109,6 +109,8 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
     fRunManager->Initialize(fRandomEngine, particleID);
     // Find the fast simulation manager process for e- (if has been attached)
     InitFastSimRelated(particleID);
+    // Find the ATLAS specific trans. rad. (XTR) process (if has been attached)
+    InitXTRRelated();
   } else if (&part == G4Positron::Definition()) {
     int particleID = 1;
     fRunManager->Initialize(fRandomEngine, particleID);
@@ -1044,17 +1046,24 @@ void G4HepEmTrackingManager::InitXTRRelated() {
   //       that everything works fine also outside ATLAS Athena
   // NOTE: after the suggested changes in Athena, the region name should be
   //       `TRT_RADIATOR` but till that it's `DefaultRegionForTheWorld`
-  const std::string nameTRTDetectorRegion = "TRT_RADIATOR";
-  fXTRRegion = G4RegionStore::GetInstance()->GetRegion(nameTRTDetectorRegion);
-  // Try to get the pointer to the TRTTransitionRadiation process
+  fXTRRegion = G4RegionStore::GetInstance()->GetRegion(fXTRRegionName);
+  // Try to get the pointer to the TRTTransitionRadiation process (same for e-/e+)
   // NOTE: stays `nullptr` if gamma dosen't have process with the name ensuring
   //       that everything works fine also outside ATLAS Athena
-  const std::string nameXTRProcess = "XTR";
-  const G4ProcessVector* processVector = G4Gamma::Definition()->GetProcessManager()->GetProcessList();
+  const G4ProcessVector* processVector = G4Electron::Definition()->GetProcessManager()->GetProcessList();
   for (std::size_t ip=0; ip<processVector->entries(); ip++) {
-    if( (*processVector)[ip]->GetProcessName()==nameXTRProcess) {
+    if( (*processVector)[ip]->GetProcessName()==fXTRProcessName) {
       fXTRProcess = (*processVector)[ip];
       break;
     }
+  }
+  // Print information if the XTR process was found (enable to check)
+  if (fXTRProcess != nullptr) {
+    std::cout << " G4HepEmTrackingManager: found the ATLAS specific "
+              << fXTRProcess->GetProcessName() << " process";
+    if (fXTRRegion != nullptr) {
+      std::cout << " with the " << fXTRRegion->GetName() << " region.";
+    }
+    std::cout << std::endl;
   }
 }


### PR DESCRIPTION
Setters, for the name of the transition radiation process and the radiator detector region, have been added (flexibility). Finding the process during the initialisation is activated now. Ready to be used.