### PR TITLE
Adding gamma-nuclear interaction.

### DIFF
--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -11,6 +11,7 @@ class G4HepEmTLData;
 class G4SafetyHelper;
 class G4Step;
 class G4VProcess;
+class G4VParticleChange;
 class G4Region;
 
 #include <vector>
@@ -51,6 +52,14 @@ private:
   double StackSecondaries(G4HepEmTLData* aTLData, G4Track* aG4PrimaryTrack,
                           const G4VProcess* aG4CreatorProcess, int aG4IMC);
 
+  // Stacks secondaries created by Geant4 physics (if any) and returns with the
+  // energy deposit while stacking due to applying secondary production cuts
+  double StackG4Secondaries(G4VParticleChange* particleChange,
+                            G4Track* aG4PrimaryTrack,
+                            const G4VProcess* aG4CreatorProcess, int aG4IMC);
+
+  void InitNuclearProcesses(int particleID);
+
   // Checks if the particles has fast simulation maanger process attached and
   // stores in the local `fFastSimProcess` array (indexed by HepEm particle ID)
   void InitFastSimRelated(int particleID);
@@ -81,6 +90,9 @@ private:
   std::vector<G4HepEmNoProcess *> fElectronNoProcessVector;
   std::vector<G4HepEmNoProcess *> fGammaNoProcessVector;
   G4HepEmNoProcess *fTransportNoProcess;
+
+  // Pointers to the Gamma-nuclear process (if any)
+  G4VProcess* fGNucProcess;
 
   // Pointers to the fast simulation manager processes of the 3 particles if any
   // [0] e-; [1] e+; [2] gamma; nullptr: no fast sim manager process attached

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -1124,6 +1124,9 @@ void G4HepEmTrackingManager::InitNuclearProcesses(int particleID) {
     for (std::size_t ip=0; ip<processVector->entries(); ip++) {
       if( (*processVector)[ip]->GetProcessName()=="photonNuclear") {
         fGNucProcess = (*processVector)[ip];
+        // make sure the process is initialised (element selectors needs to be built)
+        fGNucProcess->PreparePhysicsTable(*partDef);
+        fGNucProcess->BuildPhysicsTable(*partDef);
         break;
       }
     }

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -763,6 +763,10 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
   if (fFastSimProc != nullptr) {
     fFastSimProc->StartTracking(aTrack);
   }
+
+  if (fGNucProcess != nullptr) {
+    fGNucProcess->StartTracking(aTrack);
+  }
   // === StartTracking ===
 
   while (aTrack->GetTrackStatus() == fAlive) {
@@ -902,6 +906,10 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
           // Invoke the gamma-nuclear interaction using the Geant4 process
           G4VParticleChange* particleChangeGNuc = nullptr;
           if (fGNucProcess != nullptr) {
+            // call to set some fields of the process like material, energy etc...
+            G4ForceCondition forceCondition;
+            fGNucProcess->PostStepGetPhysicalInteractionLength(*aTrack, 0.0, &forceCondition);
+            //
             postStepPoint.SetStepStatus(fPostStepDoItProc);
             particleChangeGNuc = fGNucProcess->PostStepDoIt(*aTrack, step);
             // update the track and stack according to the result of the interaction

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -505,10 +505,6 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     // For the XTR process (if any)
     G4VParticleChange* particleChangeXTR = nullptr;
 
-    // Set the true (possible accumulated) step length here as some G4 processes
-    // (e.g. XTR) might need below in their DoIt
-    step.SetStepLength(totalTruePathLength);
-
     const G4VProcess *proc = nullptr;
     if (stopped) {
       // call annihilation for e+ !!!
@@ -563,6 +559,7 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     }
 
     postStepPoint.SetProcessDefinedStep(proc);
+    step.SetStepLength(totalTruePathLength);
 
     // energy, e-depo and status
     const double ekin = thePrimaryTrack->GetEKin();

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -32,6 +32,7 @@
 
 #include "G4VProcess.hh"
 #include "G4EmProcessSubType.hh"
+#include "G4HadronicProcessType.hh"
 #include "G4ProcessType.hh"
 #include "G4TransportationProcessType.hh"
 
@@ -40,6 +41,8 @@
 #include "G4Electron.hh"
 #include "G4Gamma.hh"
 #include "G4Positron.hh"
+
+#include "G4HadXSHelper.hh"
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
@@ -75,8 +78,15 @@ G4HepEmTrackingManager::G4HepEmTrackingManager() {
   fGammaNoProcessVector.push_back(
       new G4HepEmNoProcess("phot", G4ProcessType::fElectromagnetic,
                            G4EmProcessSubType::fPhotoElectricEffect));
+   fGammaNoProcessVector.push_back(
+       new G4HepEmNoProcess("photonNuclear", G4ProcessType::fHadronic,
+                            G4HadronicProcessType::fHadronInelastic));
+
   fTransportNoProcess = new G4HepEmNoProcess(
       "Transportation", G4ProcessType::fTransportation, TRANSPORTATION);
+
+  // Init the gamma-nuclear process
+  fGNucProcess = nullptr;
 
   // Init the fast sim mamanger process ptrs of the 3 particles
   fFastSimProcess[0] = nullptr;
@@ -119,6 +129,8 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
   } else if (&part == G4Gamma::Definition()) {
     int particleID = 2;
     fRunManager->Initialize(fRandomEngine, particleID);
+    // Find the gamma-nuclear process if has been attached
+    InitNuclearProcesses(particleID);
     // Find the fast simulation manager process for gamma (if has been attached)
     InitFastSimRelated(particleID);
   } else {
@@ -505,6 +517,10 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     // For the XTR process (if any)
     G4VParticleChange* particleChangeXTR = nullptr;
 
+    // Set the true (possible accumulated) step length here as some G4 processes
+    // (e.g. XTR) might need below in their DoIt
+    step.SetStepLength(totalTruePathLength);
+
     const G4VProcess *proc = nullptr;
     if (stopped) {
       // call annihilation for e+ !!!
@@ -559,7 +575,6 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     }
 
     postStepPoint.SetProcessDefinedStep(proc);
-    step.SetStepLength(totalTruePathLength);
 
     // energy, e-depo and status
     const double ekin = thePrimaryTrack->GetEKin();
@@ -847,25 +862,63 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
         thePrimaryTrack->SetGStepLength(aTrack->GetStepLength());
         G4HepEmGammaManager::UpdateNumIALeft(thePrimaryTrack);
       } else {
-        // (NOTE: Ekin, MC-index, step-length, onBoundary have all set)
-        G4HepEmGammaManager::Perform(theHepEmData, theHepEmPars, theTLData);
-        proc = fGammaNoProcessVector[thePrimaryTrack->GetWinnerProcessIndex()];
+        double edep = 0.0;
+        // NOTE: gamma-nuclear interaction needs to be done here while others in HepEm
+        const int iDProc = thePrimaryTrack->GetWinnerProcessIndex();
+        if (iDProc != 3) {
+          // Conversion, Compton or photoelectric --> use HepEm for the interaction
+          // (NOTE: Ekin, MC-index, step-length, onBoundary have all set)
+          G4HepEmGammaManager::Perform(theHepEmData, theHepEmPars, theTLData);
+          // energy, e-depo, momentum direction and status
+          const double ekin = thePrimaryTrack->GetEKin();
+          edep = thePrimaryTrack->GetEnergyDeposit();
+          postStepPoint.SetKineticEnergy(ekin);
+          if (ekin <= 0.0) {
+            aTrack->SetTrackStatus(fStopAndKill);
+          }
+          const double *pdir = thePrimaryTrack->GetDirection();
+          postStepPoint.SetMomentumDirection( G4ThreeVector(pdir[0], pdir[1], pdir[2]) );
 
-        // energy, e-depo, momentum direction and status
-        const double ekin = thePrimaryTrack->GetEKin();
-        double edep = thePrimaryTrack->GetEnergyDeposit();
-        postStepPoint.SetKineticEnergy(ekin);
-        if (ekin <= 0.0) {
-          aTrack->SetTrackStatus(fStopAndKill);
+          step.UpdateTrack();
+
+          // Stack secondaries created by the HepEm physics above
+          edep += StackSecondaries(theTLData, aTrack, proc, g4IMC);
+
+        } else {
+          // Gamma-nuclear: --> use Geant4 for the interaction:
+          // NOTE: it's destructive i.e. stopps and kills the gammma when the
+          //    interaction happens so we do not use anymore the primary HepEm
+          //    track thus we should not update the number of interaction length
+          //    left and the others done in G4HepEmGammaManager::Perform before
+          //    the interaction. HOWEVER, the interaction might not happen at
+          //    the end so we do what we need in that case anyway for clarity:
+          // - update the number of interaction length left for all process
+          // - reset the number of interaction lenght left for the winner
+          //   process, i.e. the one that will be invoked (the gamnma nuclear)
+          // - reset the energy deposit to zero
+          G4HepEmGammaManager::UpdateNumIALeft(thePrimaryTrack);
+          thePrimaryTrack->SetNumIALeft(-1.0, iDProc);
+          thePrimaryTrack->SetEnergyDeposit(0.0);
+          // Invoke the gamma-nuclear interaction using the Geant4 process
+          G4VParticleChange* particleChangeGNuc = nullptr;
+          if (fGNucProcess != nullptr) {
+            postStepPoint.SetStepStatus(fPostStepDoItProc);
+            particleChangeGNuc = fGNucProcess->PostStepDoIt(*aTrack, step);
+            // update the track and stack according to the result of the interaction
+            particleChangeGNuc->UpdateStepForPostStep(&step);
+            step.UpdateTrack();
+            aTrack->SetTrackStatus(particleChangeGNuc->GetTrackStatus());
+            // need to add secondaries to the secondary vector of the current track
+            // NOTE: as we use Geant4, we should care only those changes that are
+            //   not included in the above update step and track, i.e. the energy
+            //   deposited due to applying the cut when stacking the secondaries
+            edep = StackG4Secondaries(particleChangeGNuc, aTrack, fGammaNoProcessVector[iDProc], g4IMC);
+            // done: clear the particle change
+            particleChangeGNuc->Clear();
+          }
         }
-        const double *pdir = thePrimaryTrack->GetDirection();
-        postStepPoint.SetMomentumDirection( G4ThreeVector(pdir[0], pdir[1], pdir[2]) );
-
-        step.UpdateTrack();
-
-        // Stack secondaries created by the HepEm physics above
-        edep += StackSecondaries(theTLData, aTrack, proc, g4IMC);
-
+        // Set process defined setp and add edep to the step
+        proc = fGammaNoProcessVector[iDProc];
         step.AddTotalEnergyDeposit(edep);
       } // END if NOT onBoundary
 
@@ -931,8 +984,9 @@ void G4HepEmTrackingManager::HandOverOneTrack(G4Track *aTrack) {
   delete aTrack;
 }
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
+// Helper that can be used to stack secondary e-/e+ and gamma i.e. everything
+// that HepEm physics can produce
 double G4HepEmTrackingManager::StackSecondaries(G4HepEmTLData* aTLData, G4Track* aG4PrimaryTrack, const G4VProcess* aG4CreatorProcess, int aG4IMC) {
   const int numSecElectron = aTLData->GetNumSecondaryElectronTrack();
   const int numSecGamma    = aTLData->GetNumSecondaryGammaTrack();
@@ -1011,7 +1065,71 @@ double G4HepEmTrackingManager::StackSecondaries(G4HepEmTLData* aTLData, G4Track*
   return edep;
 }
 
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
+// Helper that can be used to stack secondary e-/e+ and gamma i.e. everything
+// that HepEm physics can produce
+double G4HepEmTrackingManager::StackG4Secondaries(G4VParticleChange* particleChange, G4Track* aG4PrimaryTrack, const G4VProcess* aG4CreatorProcess, int aG4IMC) {
+  const int numSecondaries = particleChange->GetNumberOfSecondaries();
+  // return early if there are no secondaries created by the physics interaction
+  double edep = 0.0;
+  if (numSecondaries == 0) {
+    return edep;
+  }
+
+  G4Step&        step           = *fStep;
+  G4TrackVector& secondaries    = *step.GetfSecondary();
+  G4StepPoint&   postStepPoint  = *step.GetPostStepPoint();
+
+  const G4ThreeVector&     theG4PostStepPointPosition = postStepPoint.GetPosition();
+  const G4double           theG4PostStepGlobalTime    = postStepPoint.GetGlobalTime();
+  const G4TouchableHandle& theG4TouchableHandle       = aG4PrimaryTrack->GetTouchableHandle();
+  const double             theG4ParentTrackWeight     = aG4PrimaryTrack->GetWeight();
+  const int                theG4ParentTrackID         = aG4PrimaryTrack->GetTrackID();
+
+  for (int isec=0; isec<particleChange->GetNumberOfSecondaries(); ++isec) {
+    G4Track *secTrack = particleChange->GetSecondary(isec);
+    double   secEKin  = secTrack->GetKineticEnergy();
+    const G4ParticleDefinition* secPartDef = secTrack->GetParticleDefinition();
+//    std::cout << "applycutS = " << applyCuts << " Ekin = " << secEKin  << " imc = " << aG4IMC << " par = " << secPartDef->GetParticleName()<<std::endl;
+
+    if (applyCuts) {
+      if (secPartDef == G4Gamma::Definition() && secEKin < (*theCutsGamma)[aG4IMC]) {
+        edep += secEKin;
+        continue;
+      } else if (secPartDef == G4Electron::Definition() && secEKin < (*theCutsElectron)[aG4IMC]) {
+        edep += secEKin;
+        continue;
+      } else if (secPartDef == G4Positron::Definition() && CLHEP::electron_mass_c2 < (*theCutsGamma)[aG4IMC]
+                 && secEKin < (*theCutsPositron)[aG4IMC]) {
+        edep += secEKin + 2 * CLHEP::electron_mass_c2;
+        continue;
+      }
+    }
+    secTrack->SetParentID(theG4ParentTrackID);
+    secTrack->SetCreatorProcess(aG4CreatorProcess);
+    secTrack->SetTouchableHandle(theG4TouchableHandle);
+    secTrack->SetWeight(theG4ParentTrackWeight);
+    secondaries.push_back(secTrack);
+  }
+
+  return edep;
+}
+
+
+// Try to get the nuclear process pointer from the process manager of the particle
+void G4HepEmTrackingManager::InitNuclearProcesses(int particleID) {
+  if (particleID == 2) {
+    G4ParticleDefinition* partDef = G4Gamma::Definition();
+    const G4ProcessVector* processVector = partDef->GetProcessManager()->GetProcessList();
+    for (std::size_t ip=0; ip<processVector->entries(); ip++) {
+      if( (*processVector)[ip]->GetProcessName()=="photonNuclear") {
+        fGNucProcess = (*processVector)[ip];
+        break;
+      }
+    }
+  }
+}
+
 
 // Try to get the fast sim mamanger process for the particle (e- 0, e+ 1, gamma 2)
 void G4HepEmTrackingManager::InitFastSimRelated(int particleID) {

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -42,7 +42,6 @@
 #include "G4Gamma.hh"
 #include "G4Positron.hh"
 
-#include "G4HadXSHelper.hh"
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -35,9 +35,8 @@ struct G4HepEmGammaData {
   double*       fGNucEnergyGrid = nullptr;     // [fGNucEnergyGridSize]
 
 
-  // the macroscopic cross sections for all materials and for [conversion,compton]
+  // the macroscopic cross sections for all materials and for [conversion,compton,gamma-nuclear]
   // at each material
-  double*       fConvCompMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize)]
   double*       fConvCompGNucMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize+fGNucEnergyGridSize)]
 
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -28,9 +28,18 @@ struct G4HepEmGammaData {
   double        fCompEILDelta = 0.0;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
   double*       fCompEnergyGrid = nullptr;     // [fCompEnergyGridSize]
 
+//// === gamma nuclear related data. 146 bins form  2mc^2 - 100 TeV
+  const int     fGNucEnergyGridSize = 147;
+  double        fGNucLogMinEkin = 0.0;     // =  0.021759358706830;  // log(2mc^2)
+  double        fGNucEILDelta = 0.0;       // =  7.935247775833226;  // 1./[log(emax/emin)/146]
+  double*       fGNucEnergyGrid = nullptr;     // [fGNucEnergyGridSize]
+
+
   // the macroscopic cross sections for all materials and for [conversion,compton]
   // at each material
   double*       fConvCompMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize)]
+  double*       fConvCompGNucMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize+fGNucEnergyGridSize)]
+
 
 //// === element selector for conversion (note: KN compton interaction do not know anything about Z)
   int           fElemSelectorConvEgridSize = 0;

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -17,7 +17,9 @@ void FreeGammaData (struct G4HepEmGammaData** theGammaData)  {
   if (*theGammaData != nullptr) {
     delete[] (*theGammaData)->fConvEnergyGrid ;
     delete[] (*theGammaData)->fCompEnergyGrid;
+    delete[] (*theGammaData)->fGNucEnergyGrid;
     delete[] (*theGammaData)->fConvCompMacXsecData;
+    delete[] (*theGammaData)->fConvCompGNucMacXsecData;
     delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
     delete[] (*theGammaData)->fElemSelectorConvEgrid;
     delete[] (*theGammaData)->fElemSelectorConvData;

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -58,10 +58,15 @@ void CopyGammaDataToDevice(struct G4HepEmGammaData* onHOST, struct G4HepEmGammaD
   // allocate memory on _d for the Compton energy grid and copy them form _h
   gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fCompEnergyGrid), sizeof( double ) * numCompData ) );
   gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fCompEnergyGrid,  onHOST->fCompEnergyGrid, sizeof( double ) * numCompData, cudaMemcpyHostToDevice ) );
+  // -- go for the gamma-nuclear related data
+  int numGNucData = onHOST->fGNucEnergyGridSize;
+  // allocate memory on _d for the gamma-nuclear energy grid and copy them form _h
+  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fGNucEnergyGrid), sizeof( double ) * numGNucData ) );
+  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fGNucEnergyGrid,  onHOST->fGNucEnergyGrid, sizeof( double ) * numGNucData, cudaMemcpyHostToDevice ) );
   // allocate memory on _d for the conversion and Compton macroscopic x-section data and copy them form _h
-  int numConvCompData = numHepEmMat*2*(numConvData+numCompData);
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fConvCompMacXsecData), sizeof( double ) * numConvCompData ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fConvCompMacXsecData,  onHOST->fConvCompMacXsecData, sizeof( double ) * numConvCompData, cudaMemcpyHostToDevice ) );
+  int numConvCompGNucData = numHepEmMat*2*(numConvData+numCompData+numGNucData);
+  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fConvCompGNucMacXsecData), sizeof( double ) * numConvCompGNucData ) );
+  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fConvCompGNucMacXsecData,  onHOST->fConvCompGNucMacXsecData, sizeof( double ) * numConvCompGNucData, cudaMemcpyHostToDevice ) );
   //
   // -- go for the conversion element selector related data
   int numElSelE   = onHOST->fElemSelectorConvEgridSize;
@@ -93,10 +98,11 @@ void FreeGammaDataOnDevice(struct G4HepEmGammaData** onDEVICE) {
     // side dynamically allocated memories
     struct G4HepEmGammaData* onHostTo_d = new G4HepEmGammaData;
     gpuErrchk ( cudaMemcpy( onHostTo_d, *onDEVICE, sizeof( struct G4HepEmGammaData ), cudaMemcpyDeviceToHost ) );
-    // conversion and Compton macroscopic x-section related data
+    // conversion, Compton and gamma-nuclear macroscopic x-section related data
     cudaFree( onHostTo_d->fConvEnergyGrid );
     cudaFree( onHostTo_d->fCompEnergyGrid );
-    cudaFree( onHostTo_d->fConvCompMacXsecData );
+    cudaFree( onHostTo_d->fGNucEnergyGrid );
+    cudaFree( onHostTo_d->fConvCompGNucMacXsecData );
     // conversion element selector related data
     cudaFree( onHostTo_d->fElemSelectorConvStartIndexPerMat );
     cudaFree( onHostTo_d->fElemSelectorConvEgrid );

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -18,7 +18,6 @@ void FreeGammaData (struct G4HepEmGammaData** theGammaData)  {
     delete[] (*theGammaData)->fConvEnergyGrid ;
     delete[] (*theGammaData)->fCompEnergyGrid;
     delete[] (*theGammaData)->fGNucEnergyGrid;
-    delete[] (*theGammaData)->fConvCompMacXsecData;
     delete[] (*theGammaData)->fConvCompGNucMacXsecData;
     delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
     delete[] (*theGammaData)->fElemSelectorConvEgrid;

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -737,11 +737,19 @@ namespace nlohmann
         j["fCompEnergyGrid"] =
           make_span(d->fCompEnergyGridSize, d->fCompEnergyGrid);
 
+        //// === compton related data. 84 bins (7 per decades) from 100 eV - 100
+        /// TeV
+        j["fGNucLogMinEkin"] = d->fGNucLogMinEkin;
+        j["fGNucEILDelta"]   = d->fGNucEILDelta;
+        j["fGNucEnergyGrid"] =
+          make_span(d->fGNucEnergyGridSize, d->fGNucEnergyGrid);
+
+
         const int macXsecDataSize =
           d->fNumMaterials * 2 *
-          (d->fConvEnergyGridSize + d->fCompEnergyGridSize);
-        j["fConvCompMacXsecData"] =
-          make_span(macXsecDataSize, d->fConvCompMacXsecData);
+          (d->fConvEnergyGridSize + d->fCompEnergyGridSize + d->fGNucEnergyGridSize);
+        j["fConvCompGNucMacXsecData"] =
+          make_span(macXsecDataSize, d->fConvCompGNucMacXsecData);
 
         //// === element selector for conversion (note: KN compton interaction
         /// do not know anything about Z)
@@ -787,12 +795,20 @@ namespace nlohmann
           j.at("fCompEnergyGrid").get<dynamic_array<double>>();
         d->fCompEnergyGrid = tmpCompEnergyGrid.data;
 
+        j.at("fGNucLogMinEkin").get_to(d->fGNucLogMinEkin);
+        j.at("fGNucEILDelta").get_to(d->fGNucEILDelta);
+        // Get the array but ignore the size (fGNucEnergyGridSize) as this is a
+        // const (at time of writing)
+        auto tmpGNucEnergyGrid =
+          j.at("fGNucEnergyGrid").get<dynamic_array<double>>();
+        d->fGNucEnergyGrid = tmpGNucEnergyGrid.data;
+
         // We don't store the size of the following array, rather should
         // validate that it is expected size: d->fNumMaterials * 2 *
-        // (d->fConvEnergyGridSize + d->fCompEnergyGridSize);
-        auto tmpConvCompXsecData =
-          j.at("fConvCompMacXsecData").get<dynamic_array<double>>();
-        d->fConvCompMacXsecData = tmpConvCompXsecData.data;
+        // (d->fConvEnergyGridSize + d->fCompEnergyGridSize + d->fGNucEnergyGridSize);
+        auto tmpConvCompGNucXsecData =
+          j.at("fConvCompGNucMacXsecData").get<dynamic_array<double>>();
+        d->fConvCompGNucMacXsecData = tmpConvCompGNucXsecData.data;
 
         j.at("fElemSelectorConvLogMinEkin")
           .get_to(d->fElemSelectorConvLogMinEkin);

--- a/G4HepEm/G4HepEmInit/include/G4HepEmGammaTableBuilder.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmGammaTableBuilder.hh
@@ -8,6 +8,7 @@
 //class G4ParticleDefinition;
 class G4PairProductionRelModel;
 class G4KleinNishinaCompton;
+class G4CrossSectionDataStore;
 
 struct G4HepEmData;
 struct G4HepEmParameters;
@@ -16,7 +17,7 @@ struct G4HepEmParameters;
 
 // Should receive pointers to G4 models that are already initialised
 void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton* knModel,
-                     struct G4HepEmData* hepEmData);
+                       G4CrossSectionDataStore* hadGNucXSDataStore, struct G4HepEmData* hepEmData);
 
 void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepEmData* hepEmData);
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -21,7 +21,10 @@
 
 #include "G4VCrossSectionDataSet.hh"
 #include "G4CrossSectionDataSetRegistry.hh"
+#if G4VERSION_NUMBER >= 1100
 #include "G4GammaNuclearXS.hh"
+#endif
+#include "G4PhotoNuclearCrossSection.hh"
 #include "G4CrossSectionDataStore.hh"
 
 #include "G4HepEmMaterialData.hh"
@@ -59,10 +62,18 @@ void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*he
   //
   // 3. The Gamma-nuclear cross section:
   // --- using the `GammaNuclearXS` as the default in Geant4-11.2.2 G4EmExtraPhysics (the alternative is `PhotoNuclearXS`)
+  // The `GammaNuclearXS` is availabel from 10.7 but known by the Registry only from 11.0: use `PhotoNuclearXS` before 11.0
+#if G4VERSION_NUMBER >= 1100
   G4VCrossSectionDataSet* xs = G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet("GammaNuclearXS");
   if (nullptr == xs) {
     xs = new G4GammaNuclearXS();
   }
+#else
+  G4VCrossSectionDataSet* xs = G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet("PhotoNuclearXS");
+  if (nullptr == xs) {
+    xs = new G4PhotoNuclearCrossSection();
+  }
+#endif
   xs->BuildPhysicsTable(*g4PartDef);
   G4CrossSectionDataStore hadGNucXSDataStore;
   hadGNucXSDataStore.AddDataSet(xs);

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -63,6 +63,7 @@ void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*he
   if (nullptr == xs) {
     xs = new G4GammaNuclearXS();
   }
+  xs->BuildPhysicsTable(*g4PartDef);
   G4CrossSectionDataStore hadGNucXSDataStore;
   hadGNucXSDataStore.AddDataSet(xs);
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -57,9 +57,9 @@ void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*he
   modelKN->SetHighEnergyLimit(emModelEMax);
   modelKN->Initialise(g4PartDef, *theElCuts);
   //
-  // 3. ....:
-  // using the `` as in Geant4-11.2.2 G4EmExtraPhysics (the alternative is `PhotoNuclearXS`)
-  G4VCrossSectionDataSet* xs = G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet("PhotoNuclearXS");//("GammaNuclearXS");
+  // 3. The Gamma-nuclear cross section:
+  // --- using the `GammaNuclearXS` as the default in Geant4-11.2.2 G4EmExtraPhysics (the alternative is `PhotoNuclearXS`)
+  G4VCrossSectionDataSet* xs = G4CrossSectionDataSetRegistry::Instance()->GetCrossSectionDataSet("GammaNuclearXS");
   if (nullptr == xs) {
     xs = new G4GammaNuclearXS();
   }

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -34,8 +34,6 @@
 
 #include <iostream>
 
-#include "G4NistManager.hh"
-
 void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/) {
   // clean previous G4HepEmElectronData (if any)
   //
@@ -79,17 +77,6 @@ void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*he
   xs->BuildPhysicsTable(*g4PartDef);
   G4CrossSectionDataStore hadGNucXSDataStore;
   hadGNucXSDataStore.AddDataSet(xs);
-
-//  G4DynamicParticle dGamma(G4Gamma::Definition(), G4ThreeVector(0,0,1), 1.022);
-//  double xsec = hXSDataStore.ComputeCrossSection(&dGamma, G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb"));
-//  std::cout << " xsec (1.022, Pb) = " << xsec << " (reference: 1.37287e-07)"<<std::endl;
-//  dGamma.SetKineticEnergy(7.19686e+07);
-//  xsec = hXSDataStore.ComputeCrossSection(&dGamma, G4NistManager::Instance()->FindOrBuildMaterial("G4_Pb"));
-//  std::cout << " xsec (7.19686e+07, Pb) = " << xsec << " (refrence: 8.69015e-05)"<<std::endl;
-//  then I can use the ComputeCrossSection(dp, mat) of the store to get mac-xsec
-
-
-
   //
   // === Use the G4HepEmGammaTableBuilder to build all data tables used at
   //     run time: macroscopic cross section tables and target element

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -8,6 +8,8 @@
 #include "G4HepEmGammaTableBuilder.hh"
 
 // g4 includes
+#include "G4Version.hh"
+
 #include "G4EmParameters.hh"
 #include "G4ProductionCutsTable.hh"
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -51,7 +51,7 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
   // == Generate the enegry grid for Gamma-nuclear
   emin = 2.0*CLHEP::electron_mass_c2;
   emax = 100.0*CLHEP::TeV;
-  int numGNucEkin = gmData->fConvEnergyGridSize;
+  int numGNucEkin = gmData->fGNucEnergyGridSize;
   delete [] gmData->fGNucEnergyGrid;
   gmData->fGNucEnergyGrid = new double[numGNucEkin]{};
   G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numGNucEkin, gmData->fGNucLogMinEkin, gmData->fGNucEILDelta, gmData->fGNucEnergyGrid);

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -115,13 +115,13 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
       gmData->fConvCompGNucMacXsecData[indxCont++] = secDerivs[i];
     }
     // == Gamma-nuclear
-    std::cout << " ===== Material = " << g4MatCut->GetMaterial()->GetName() << std::endl;
+    // std::cout << " ===== Material = " << g4MatCut->GetMaterial()->GetName() << std::endl;
     G4DynamicParticle* dyGamma = new G4DynamicParticle(g4PartDef, G4ThreeVector(0,0,1), 0);
     for (int ie=0; ie<numGNucEkin; ++ie) {
       const double theEKin = gmData->fGNucEnergyGrid[ie];
       dyGamma->SetKineticEnergy(theEKin);
       macXSec[ie] = std::max(0.0, hadGNucXSDataStore->ComputeCrossSection(dyGamma, g4MatCut->GetMaterial()));
-      std::cout << " E = " << theEKin << " [MeV] Sigam-GNuc(E) = " << macXSec[ie] << std::endl;
+      // std::cout << " E = " << theEKin << " [MeV] Sigam-GNuc(E) = " << macXSec[ie] << std::endl;
     }
     delete dyGamma;
     // prepare for spline by computing the second derivatives

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -128,17 +128,23 @@ double  G4HepEmGammaManager::GetMacXSec(const struct G4HepEmGammaData* gmData, c
   // get number of Conversion and Compton discrete energy grid points
   const int numConvData = gmData->fConvEnergyGridSize;
   const int numCompData = gmData->fCompEnergyGridSize;
-  const int      iStart = imat*2*(numConvData + numCompData);
+  const int numGNucData = gmData->fGNucEnergyGridSize;
+  const int      iStart = imat*2*(numConvData + numCompData + numGNucData);
   // use the G4HepEmRunUtils GetSplineLog function for interpolation
   switch (iprocess) {
     case 0: { // Conversion
-              const double  mxsec = GetSplineLog(numConvData, gmData->fConvEnergyGrid, &(gmData->fConvCompMacXsecData[iStart]) , ekin, lekin, gmData->fConvLogMinEkin, gmData->fConvEILDelta);
+              const double  mxsec = GetSplineLog(numConvData, gmData->fConvEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart]) , ekin, lekin, gmData->fConvLogMinEkin, gmData->fConvEILDelta);
               return G4HepEmMax(0.0, mxsec);
             }
     case 1: { // Compton
-              const double  mxsec = GetSplineLog(numCompData, gmData->fCompEnergyGrid, &(gmData->fConvCompMacXsecData[iStart+2*numConvData]) , ekin, lekin, gmData->fCompLogMinEkin, gmData->fCompEILDelta);
+              const double  mxsec = GetSplineLog(numCompData, gmData->fCompEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*numConvData]) , ekin, lekin, gmData->fCompLogMinEkin, gmData->fCompEILDelta);
               return G4HepEmMax(0.0, mxsec);
             }
+    case 2: { // Gamma-nuclear
+              const double  mxsec = GetSplineLog(numGNucData, gmData->fGNucEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*(numConvData+numCompData)]) , ekin, lekin, gmData->fGNucLogMinEkin, gmData->fGNucEILDelta);
+              return G4HepEmMax(0.0, mxsec);
+            }
+
     default:
             return 0.0;
   }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -28,7 +28,7 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
   G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
   G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
   // Sample the `number-of-interaction-left`
-  for (int ip=0; ip<3; ++ip) {
+  for (int ip=0; ip<4; ++ip) {
     if (theTrack->GetNumIALeft(ip)<=0.) {
       theTrack->SetNumIALeft(-G4HepEmLog(tlData->GetRNGEngine()->flat()), ip);
     }
@@ -45,18 +45,19 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
   // get the Gamma data from the op level data structure
   const G4HepEmGammaData* theGammaData = hepEmData->fTheGammaData;
   // === Gamma has only discrete limits due to Conversion, Compton, and the photoelectric effect.
-  double mxSecs[3];
+  double mxSecs[4];
   // conversion, compton and photoelectric
   mxSecs[0] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 0);
   mxSecs[1] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 1);
   mxSecs[2] = GetMacXSecPE(hepEmData, theMatIndx, theEkin);
+  mxSecs[3] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 2);
   // Remember value of photoelectric effect, needed for selecting the element.
   theGammaTrack->SetPEmxSec(mxSecs[2]);
   // compute mfp and see if we need to sample the `number-of-interaction-left`
   // before we use it to get the current discrete proposed step length
   int indxWinnerProcess = -1;             // init to nothing
   double pStepLength    = kALargeValue;   // init to a large value
-  for (int ip=0; ip<3; ++ip) {
+  for (int ip=0; ip<4; ++ip) {
     const double mxsec = mxSecs[ip];
     const double   mfp = (mxsec>0.) ? 1./mxsec : kALargeValue;
     // save the mac-xsec for the update of the `number-of-interaction-left`:
@@ -64,7 +65,7 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
     theTrack->SetMFP(mfp, ip);
     // sample the proposed step length
     const double dStepLimit = mfp*theTrack->GetNumIALeft(ip);
-//    std::cout << " ip = " << ip << " mxsec = " << mxsec << " dStepLimit = " << dStepLimit << std::endl;
+    // std::cout << " ip = " << ip << " mxsec = " << mxsec << " dStepLimit = " << dStepLimit << std::endl;
     if (dStepLimit<pStepLength) {
       pStepLength = dStepLimit;
       indxWinnerProcess = ip;
@@ -109,7 +110,9 @@ void G4HepEmGammaManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmP
     case 2: // invoke photoelectric process:
             G4HepEmGammaInteractionPhotoelectric::Perform(tlData, hepEmData);
             break;
-
+    case 3: // NOTE: HepEm do not handle Gamma-nuclear interaction. It is done
+            //       in the tracking manager calling the native Geant4 process
+            break;
   }
 }
 
@@ -121,6 +124,7 @@ void   G4HepEmGammaManager::UpdateNumIALeft(G4HepEmTrack* theTrack) {
   numInterALeft[0] -= pStepLength/preStepMFP[0];
   numInterALeft[1] -= pStepLength/preStepMFP[1];
   numInterALeft[2] -= pStepLength/preStepMFP[2];
+  numInterALeft[3] -= pStepLength/preStepMFP[3];
 }
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
@@ -44,10 +44,12 @@ public:
     fMFPs[0]       = o.fMFPs[0];
     fMFPs[1]       = o.fMFPs[1];
     fMFPs[2]       = o.fMFPs[2];
+    fMFPs[3]       = o.fMFPs[3];
 
     fNumIALeft[0] = o.fNumIALeft[0];
     fNumIALeft[1] = o.fNumIALeft[1];
     fNumIALeft[2] = o.fNumIALeft[2];
+    fNumIALeft[3] = o.fNumIALeft[3];
 
     fSafety       = o.fSafety;
 
@@ -220,10 +222,12 @@ public:
     fMFPs[0]      = -1.0;
     fMFPs[1]      = -1.0;
     fMFPs[2]      = -1.0;
+    fMFPs[3]      = -1.0;
 
     fNumIALeft[0] = -1.0;
     fNumIALeft[1] = -1.0;
     fNumIALeft[2] = -1.0;
+    fNumIALeft[3] = -1.0;
 
     fID           =  -1;
     fIDParent     =  -1;
@@ -246,8 +250,8 @@ private:
   double   fCharge;
   double   fEDeposit;
   double   fGStepLength;   // step length along the original direction (straight line)
-  double   fMFPs[3];       // pair, compton, photo-electric in case of photon
-  double   fNumIALeft[3];  // ioni, brem, (e+-e- annihilation) in case of e- (e+)
+  double   fMFPs[4];       // pair, compton, photo-electric, gamma-nuclear in case of photon
+  double   fNumIALeft[4];  // ioni, brem, (e+-e- annihilation) in case of e- (e+)
   double   fSafety;
 
   int      fID;
@@ -255,7 +259,7 @@ private:
 
   int      fMCIndex;
 
-  int      fPIndxWon; // 0-pair, 1-compton, 2-photo-electric for photon
+  int      fPIndxWon; // 0-pair, 1-compton, 2-photo-electric, 3-gamma-nuclear for photon
                       // 0-ioni, 1-brem,  (2-annihilation) for e- (e+)
   bool     fOnBoundary;
 };

--- a/apps/examples/TestEm3/include/PhysicsList.hh
+++ b/apps/examples/TestEm3/include/PhysicsList.hh
@@ -54,7 +54,6 @@ public:
     virtual void ConstructProcess();
 
     void AddPhysicsList(const G4String& name);
-    void AddStepMax();
 
 private:
 
@@ -62,8 +61,7 @@ private:
 
     G4String fEmName;
     G4VPhysicsConstructor*  fEmPhysicsList;
-    G4VPhysicsConstructor*  fDecayPhysics;
-
+    G4VPhysicsConstructor*  fEmExtraPhysics;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -47,20 +47,10 @@
 #include "G4EmStandardPhysics.hh"
 #include "G4EmStandardPhysics_option1.hh"
 #include "G4EmStandardPhysics_option2.hh"
-#include "G4EmStandardPhysics_option3.hh"
-#include "G4EmStandardPhysics_option4.hh"
-#include "G4EmStandardPhysicsWVI.hh"
-#include "G4EmStandardPhysicsGS.hh"
-#include "G4EmStandardPhysicsSS.hh"
 
-#include "G4EmLivermorePhysics.hh"
-#include "G4EmPenelopePhysics.hh"
-#include "G4EmLowEPPhysics.hh"
+#include "G4EmExtraPhysics.hh"
 
 #include "G4LossTableManager.hh"
-
-#include "G4DecayPhysics.hh"
-#include "StepMax.hh"
 
 #include "G4UnitsTable.hh"
 #include "G4SystemOfUnits.hh"
@@ -93,6 +83,13 @@ PhysicsList::PhysicsList() : G4VModularPhysicsList(),
   // EM physics: set to HepEm by def.
   fEmName        = G4String("HepEm");
   fEmPhysicsList = new PhysListHepEm(fEmName);
+
+  // Create the G4EmExtraPhysics to add gamma and lepton nuclear interactions
+  G4EmExtraPhysics* emExtra = new G4EmExtraPhysics();
+  // During the development: deactiavte electron nuclear till we don't have in HepEm
+  emExtra->ElectroNuclear(false);
+  fEmExtraPhysics = emExtra;
+
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -100,6 +97,7 @@ PhysicsList::PhysicsList() : G4VModularPhysicsList(),
 PhysicsList::~PhysicsList()
 {
   delete fEmPhysicsList;
+  delete fEmExtraPhysics;
   delete fMessenger;
 }
 
@@ -124,11 +122,11 @@ void PhysicsList::ConstructParticle()
 
     G4ShortLivedConstructor pShortLivedConstructor;
     pShortLivedConstructor.ConstructParticle();
+
+    fEmExtraPhysics->ConstructParticle();
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-#include "G4ProcessManager.hh"
 
 void PhysicsList::ConstructProcess()
 {
@@ -136,12 +134,9 @@ void PhysicsList::ConstructProcess()
   AddTransportation();
   // Electromagnetic Physics List
   fEmPhysicsList->ConstructProcess();
-  // Other processes but only if not HepEm physics list is used
-  if (fEmName!="HepEm" && fEmName!="HepEmTracking" && fEmName!="G4Em" && fEmName!="G4EmTracking") {
-    fDecayPhysics = new G4DecayPhysics(1);
-    fDecayPhysics->ConstructProcess();
-    AddStepMax();
-  }
+  // EM extra physics, i.e. gamma end lepton nuclear
+  fEmExtraPhysics->ConstructProcess();
+
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -200,60 +195,6 @@ void PhysicsList::AddPhysicsList(const G4String& name)
     delete fEmPhysicsList;
     fEmPhysicsList = new G4EmStandardPhysics_option1();
 
-  } else if (name == "emstandard_opt2") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmStandardPhysics_option2();
-
-  } else if (name == "emstandard_opt3") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmStandardPhysics_option3();
-
-  } else if (name == "emstandard_opt4") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmStandardPhysics_option4();
-
-  } else if (name == "emstandardWVI") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmStandardPhysicsWVI();
-
-  } else if (name == "emstandardGS") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmStandardPhysicsGS();
-
-  } else if (name == "emstandardSS") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmStandardPhysicsSS();
-
-  } else if (name == "emlivermore") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmLivermorePhysics();
-
-  } else if (name == "empenelope") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmPenelopePhysics();
-
-  } else if (name == "emlowenergy") {
-
-    fEmName = name;
-    delete fEmPhysicsList;
-    fEmPhysicsList = new G4EmLowEPPhysics();
-
   } else {
 
     G4cout << "PhysicsList::AddPhysicsList: <" << name << ">"
@@ -261,25 +202,3 @@ void PhysicsList::AddPhysicsList(const G4String& name)
            << G4endl;
   }
 }
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
-
-void PhysicsList::AddStepMax()
-{
-  // Step limitation seen as a process
-  StepMax* stepMaxProcess = new StepMax();
-
-  auto particleIterator=GetParticleIterator();
-  particleIterator->reset();
-  while ((*particleIterator)()){
-    G4ParticleDefinition* particle = particleIterator->value();
-    G4ProcessManager* pmanager = particle->GetProcessManager();
-
-    if (stepMaxProcess->IsApplicable(*particle))
-      {
-        pmanager ->AddDiscreteProcess(stepMaxProcess);
-      }
-  }
-}
-
-//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -88,6 +88,10 @@ PhysicsList::PhysicsList() : G4VModularPhysicsList(),
   G4EmExtraPhysics* emExtra = new G4EmExtraPhysics();
   // During the development: deactiavte electron nuclear till we don't have in HepEm
   emExtra->ElectroNuclear(false);
+  // Turn off muon nuclear as well (not improtant as no muon production but
+  // remove it as we don't have in HepEm)
+  emExtra->MuonNuclear(false);
+
   fEmExtraPhysics = emExtra;
 
 }

--- a/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
+++ b/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
@@ -117,7 +117,12 @@ void G4HepEmGammaDataTester(G4HepEmGammaData* d) {
   // Energy grid has a fixed size, but dynamic allocation
   EXPECT_EQ(d->fCompEnergyGridSize, 85);
   EXPECT_EQ(d->fCompEnergyGrid, nullptr);
-  EXPECT_EQ(d->fConvCompMacXsecData, nullptr);
+
+  // Energy grid has a fixed size, but dynamic allocation
+  EXPECT_EQ(d->fGNucEnergyGridSize, 147);
+  EXPECT_EQ(d->fGNucEnergyGrid, nullptr);
+
+  EXPECT_EQ(d->fConvCompGNucMacXsecData, nullptr);
 
   EXPECT_EQ(d->fElemSelectorConvEgridSize, 0);
   EXPECT_EQ(d->fElemSelectorConvNumData, 0);

--- a/testing/GammaXSections/include/Declaration.hh
+++ b/testing/GammaXSections/include/Declaration.hh
@@ -12,12 +12,14 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData );
 #ifdef G4HepEm_CUDA_BUILD
 
   // Evaluates all test cases on the device for computing the macroscopic
-  // cross section values for conversion and Compton on the device for all test cases.
+  // cross section values for conversion, Compton and gamma-nuclear on the
+  // device for all test cases.
   void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImat_h,
                                  double* tsInEkinConv_h, double* tsInLogEkinConv_h,
                                  double* tsInEkinComp_h, double* tsInLogEkinComp_h,
+                                 double* tsInEkinGNuc_h, double* tsInLogEkinGNuc_h,
                                  double* tsOutMXConv_h,  double* tsOutMXComp_h,
-                                 int numTestCases );
+                                 double* tsOutMXGNuc_h, int numTestCases );
 
 #endif // G4HepEm_CUDA_BUILD
 

--- a/testing/GammaXSections/src/GammaMacXSecs.cu
+++ b/testing/GammaXSections/src/GammaMacXSecs.cu
@@ -24,7 +24,8 @@
 
 void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImat_h,
      double* tsInEkinConv_h, double* tsInLogEkinConv_h, double* tsInEkinComp_h, double* tsInLogEkinComp_h,
-     double* tsOutMXConv_h, double* tsOutMXComp_h, int numTestCases ) {
+     double* tsInEkinGNuc_h, double* tsInLogEkinGNuc_h, double* tsOutMXConv_h, double* tsOutMXComp_h,
+     double* tsOutMXGNuc_h, int numTestCases ) {
   //
   // --- Allocate device side memory for the input/output data and copy all input
   //     data from host to device
@@ -33,16 +34,23 @@ void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInIma
   double*  tsInLogEkinConv_d = nullptr;
   double*     tsInEkinComp_d = nullptr;
   double*  tsInLogEkinComp_d = nullptr;
+  double*     tsInEkinGNuc_d = nullptr;
+  double*  tsInLogEkinGNuc_d = nullptr;
   double*      tsOutMXConv_d = nullptr;
   double*      tsOutMXComp_d = nullptr;
+  double*      tsOutMXGNuc_d = nullptr;
+
   //
   gpuErrchk ( cudaMalloc ( &tsInImat_d,        sizeof( int )    * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInEkinConv_d,    sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInLogEkinConv_d, sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInEkinComp_d,    sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInLogEkinComp_d, sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInEkinGNuc_d,    sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInLogEkinGNuc_d, sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsOutMXConv_d,     sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsOutMXComp_d,     sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsOutMXGNuc_d,     sizeof( double ) * numTestCases ) );
   //
   // --- Copy the input data from host to device (test material index, ekin and log-ekin arrays)
   gpuErrchk ( cudaMemcpy ( tsInImat_d,        tsInImat_h,        sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
@@ -50,6 +58,9 @@ void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInIma
   gpuErrchk ( cudaMemcpy ( tsInLogEkinConv_d, tsInLogEkinConv_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInEkinComp_d,    tsInEkinComp_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInLogEkinComp_d, tsInLogEkinComp_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInEkinGNuc_d,    tsInEkinGNuc_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInLogEkinGNuc_d, tsInLogEkinGNuc_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+
   //
   // --- Launch the kernels
   int numThreads = 512;
@@ -60,6 +71,8 @@ void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInIma
   TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, tsInImat_d, tsInEkinConv_d, tsInLogEkinConv_d, tsOutMXConv_d, 0,  numTestCases );
   // Compton scatteirng
   TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, tsInImat_d, tsInEkinComp_d, tsInLogEkinComp_d, tsOutMXComp_d, 1, numTestCases );
+  // Gamma-nuclear
+  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, tsInImat_d, tsInEkinGNuc_d, tsInLogEkinGNuc_d, tsOutMXGNuc_d, 2, numTestCases );
   //
   // --- Synchronize to make sure that completed on the device
   cudaDeviceSynchronize();
@@ -67,6 +80,8 @@ void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInIma
   // --- Copy the results from the device to the host
   gpuErrchk ( cudaMemcpy ( tsOutMXConv_h,     tsOutMXConv_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
   gpuErrchk ( cudaMemcpy ( tsOutMXComp_h,     tsOutMXComp_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
+  gpuErrchk ( cudaMemcpy ( tsOutMXGNuc_h,     tsOutMXGNuc_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
+
   //
   // --- Free all dynamically allocated (device side) memory
   cudaFree ( tsInImat_d        );
@@ -74,6 +89,9 @@ void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInIma
   cudaFree ( tsInLogEkinConv_d );
   cudaFree ( tsInEkinComp_d    );
   cudaFree ( tsInLogEkinComp_d );
+  cudaFree ( tsInEkinGNuc_d    );
+  cudaFree ( tsInLogEkinGNuc_d );
   cudaFree ( tsOutMXConv_d    );
   cudaFree ( tsOutMXComp_d    );
+  cudaFree ( tsOutMXGNuc_d    );
 }

--- a/testing/GammaXSections/src/Implementation.cc
+++ b/testing/GammaXSections/src/Implementation.cc
@@ -78,7 +78,7 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
   for (int i=0; i<numTestCases; ++i) {
     tsOutMXConv[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinConv[i], tsInLogEkinConv[i], 0); // conversion
     tsOutMXComp[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinComp[i], tsInLogEkinComp[i], 1); // Compton
-    tsOutMXGNuc[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinComp[i], tsInLogEkinComp[i], 2); // gamma-nuclear
+    tsOutMXGNuc[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinGNuc[i], tsInLogEkinGNuc[i], 2); // gamma-nuclear
   }
 
 
@@ -87,7 +87,8 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
   // Perform the test case evaluations on the device
   double* tsOutOnDeviceMXConv = new double[numTestCases];
   double* tsOutOnDeviceMXComp = new double[numTestCases];
-  TestMacXSecDataOnDevice (hepEmData, tsInImat, tsInEkinConv, tsInLogEkinConv, tsInEkinComp, tsInLogEkinComp, tsOutOnDeviceMXConv, tsOutOnDeviceMXComp, numTestCases);
+  double* tsOutOnDeviceMXGNuc = new double[numTestCases];
+  TestMacXSecDataOnDevice (hepEmData, tsInImat, tsInEkinConv, tsInLogEkinConv, tsInEkinComp, tsInLogEkinComp, tsInEkinGNuc, tsInLogEkinGNuc, tsOutOnDeviceMXConv, tsOutOnDeviceMXComp, tsOutOnDeviceMXGNuc, numTestCases);
   for (int i=0; i<numTestCases; ++i) {
     if ( std::abs( 1.0 - tsOutMXConv[i]/tsOutOnDeviceMXConv[i] ) > 1.0E-14 ) {
       isPassed = false;
@@ -99,10 +100,16 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
       std::cerr << "\n*** ERROR:\nMacroscopic Cross Section data: G4HepEm Host vs Device (Compton) mismatch: " <<  std::setprecision(16) << tsOutMXComp[i] << " != " << tsOutOnDeviceMXComp[i] << " ( i = " << i << " imat  = " << tsInImat[i] << " ekin =  " << tsInEkinConv[i] << ") " << std::endl;
       break;
     }
+    if ( std::abs( 1.0 - tsOutMXGNuc[i]/tsOutOnDeviceMXGNuc[i] ) > 1.0E-14 ) {
+      isPassed = false;
+      std::cerr << "\n*** ERROR:\nMacroscopic Cross Section data: G4HepEm Host vs Device (Gamma-nuclear) mismatch: " <<  std::setprecision(16) << tsOutMXGNuc[i] << " != " << tsOutOnDeviceMXGNuc[i] << " ( i = " << i << " imat  = " << tsInImat[i] << " ekin =  " << tsInEkinGNuc[i] << ") " << std::endl;
+      break;
+    }
   }
   //
   delete [] tsOutOnDeviceMXConv;
   delete [] tsOutOnDeviceMXComp;
+  delete [] tsOutOnDeviceMXGNuc;
 #endif // G4HepEm_CUDA_BUILD
 
   //

--- a/testing/GammaXSections/src/Implementation.cc
+++ b/testing/GammaXSections/src/Implementation.cc
@@ -30,6 +30,7 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
 
   const int numConvData = theGammaData->fConvEnergyGridSize;
   const int numCompData = theGammaData->fCompEnergyGridSize;
+  const int numGNucData = theGammaData->fGNucEnergyGridSize;
   const int numMatData  = theMatData->fNumMaterialData;
   // allocate memory (host) to store the generated test cases:
   //  - the numTestCases, material index and kinetic energy combinations
@@ -41,13 +42,17 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
   double* tsInLogEkinConv = new double[numTestCases];
   double* tsInEkinComp    = new double[numTestCases];
   double* tsInLogEkinComp = new double[numTestCases];
+  double* tsInEkinGNuc    = new double[numTestCases];
+  double* tsInLogEkinGNuc = new double[numTestCases];
   double* tsOutMXConv     = new double[numTestCases];
   double* tsOutMXComp     = new double[numTestCases];
+  double* tsOutMXGNuc     = new double[numTestCases];
   // the maximum (+2%) primary particle kinetic energy that is covered by the
   // simulation (100 TeV by default). alos use -2% for the low energy limit.
   const double     maxLEKin = std::log(1.02*theGammaData->fConvEnergyGrid[numConvData-1]);
   const double minLEKinConv = std::log(theGammaData->fConvEnergyGrid[0]*0.98);
   const double minLEKinComp = std::log(theGammaData->fCompEnergyGrid[0]*0.98);
+  const double minLEKinGNuc = std::log(theGammaData->fGNucEnergyGrid[0]*0.98);
   for (int i=0; i<numTestCases; ++i) {
     int imat           = (int)(dis(gen)*numMatData);
     tsInImat[i]        = imat;
@@ -61,6 +66,11 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
     lEkinDelta         = maxLEKin - minLEKinComp;
     tsInLogEkinComp[i] = dis(gen)*lEkinDelta+minLEKinComp;
     tsInEkinComp[i]    = std::exp(tsInLogEkinComp[i]);
+    // -- gamma-nuclear
+    lMinEkin           = minLEKinGNuc;
+    lEkinDelta         = maxLEKin - minLEKinGNuc;
+    tsInLogEkinGNuc[i] = dis(gen)*lEkinDelta+minLEKinGNuc;
+    tsInEkinGNuc[i]    = std::exp(tsInLogEkinGNuc[i]);
   }
   //
   // Use G4HepEmGammaManager to evaluate the macroscopic cross sections
@@ -68,6 +78,7 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
   for (int i=0; i<numTestCases; ++i) {
     tsOutMXConv[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinConv[i], tsInLogEkinConv[i], 0); // conversion
     tsOutMXComp[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinComp[i], tsInLogEkinComp[i], 1); // Compton
+    tsOutMXGNuc[i] = G4HepEmGammaManager::GetMacXSec (theGammaData, tsInImat[i], tsInEkinComp[i], tsInLogEkinComp[i], 2); // gamma-nuclear
   }
 
 
@@ -101,8 +112,11 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
   delete [] tsInLogEkinConv;
   delete [] tsInEkinComp;
   delete [] tsInLogEkinComp;
+  delete [] tsInEkinGNuc;
+  delete [] tsInLogEkinGNuc;
   delete [] tsOutMXConv;
   delete [] tsOutMXComp;
+  delete [] tsOutMXGNuc;
 
   return isPassed;
 }

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -310,14 +310,30 @@ bool operator==(const G4HepEmGammaData& lhs, const G4HepEmGammaData& rhs)
     return false;
   }
 
+  // gamma-nuclear data grid
+  if(std::tie(lhs.fGNucLogMinEkin, lhs.fGNucEILDelta) !=
+     std::tie(rhs.fGNucLogMinEkin, rhs.fGNucEILDelta))
+  {
+    return false;
+  }
+
+  if(!compare_arrays(lhs.fGNucEnergyGridSize, lhs.fGNucEnergyGrid,
+                     rhs.fGNucEnergyGridSize, rhs.fGNucEnergyGrid))
+  {
+    return false;
+  }
+
+
   // the macroscopic cross sections for all materials and for
-  // [conversion,compton] at each material
+  // [conversion,compton,gamma-nuclear] at each material
   const int lhsXsecSize =
-    lhs.fNumMaterials * 2 * (lhs.fConvEnergyGridSize + lhs.fCompEnergyGridSize);
+    lhs.fNumMaterials * 2 * (lhs.fConvEnergyGridSize + lhs.fCompEnergyGridSize
+                             + lhs.fGNucEnergyGridSize);
   const int rhsXsecSize =
-    rhs.fNumMaterials * 2 * (rhs.fConvEnergyGridSize + rhs.fCompEnergyGridSize);
-  if(!compare_arrays(lhsXsecSize, lhs.fConvCompMacXsecData, rhsXsecSize,
-                     rhs.fConvCompMacXsecData))
+    rhs.fNumMaterials * 2 * (rhs.fConvEnergyGridSize + rhs.fCompEnergyGridSize
+                             + rhs.fGNucEnergyGridSize);
+  if(!compare_arrays(lhsXsecSize, lhs.fConvCompGNucMacXsecData, rhsXsecSize,
+                     rhs.fConvCompGNucMacXsecData))
   {
     return false;
   }


### PR DESCRIPTION
Gamma-nuclear **cross sections are available** now **and used in the HepEm physics during the step limit** calculations for gamma photons. **The interaction** itself **is performed using the corresponding native Geant4 `photonNuclear`, `G4HadronInelasticProcess`** in the HepEm tracking manager: the `PostStepDoIt` of this process is invoked whenever gamma-nuclear limited the step but only if the `photonNuclear` process was attached to gamma in the physics list. 

The HepEm tracking manager tries to find the `photonNuclear` process at initialisation by checking the processes attached to the gamma process manager. If it is found, the pointer to this process is stored locally in the tracking manager such that the process is available during the gamma tracking. If it is not found (i.e. no gamma-nuclear process attached to gamma), then this field stays `nullptr`. The process is obviously not invoked in this case but everything still works fine, i.e. the step might be limited by gamma-nuclear but delta interaction happens (no change, the original gamma keeps on going). The same happens when the `G4HepEmGammaManager::Perform` method is invoked for the interaction, i.e. no interaction happens when gamma-nuclear limited the step. So everything works fine even when gamma-nuclear process is not attached to the `G4Gamma` or when using HepEm also to perform the interaction: no interaction happens in this case.    

         
