### PR TITLE
Adding electron/positron-nuclear interactions to HepEm.

### DIFF
--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -94,6 +94,11 @@ private:
   // Pointers to the Gamma-nuclear process (if any)
   G4VProcess* fGNucProcess;
 
+  // Pointers to the Electron/Positron-nuclear processes (if any)
+  G4VProcess* fENucProcess;
+  G4VProcess* fPNucProcess;
+
+
   // Pointers to the fast simulation manager processes of the 3 particles if any
   // [0] e-; [1] e+; [2] gamma; nullptr: no fast sim manager process attached
   G4VProcess* fFastSimProcess[3];

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -68,6 +68,13 @@ G4HepEmTrackingManager::G4HepEmTrackingManager() {
   fElectronNoProcessVector.push_back(
       new G4HepEmNoProcess("msc", G4ProcessType::fElectromagnetic,
                            G4EmProcessSubType::fMultipleScattering));
+  fElectronNoProcessVector.push_back(
+      new G4HepEmNoProcess("electronNuclear", G4ProcessType::fHadronic,
+                           G4HadronicProcessType::fHadronInelastic));
+  fElectronNoProcessVector.push_back(
+      new G4HepEmNoProcess("positronNuclear", G4ProcessType::fHadronic,
+                           G4HadronicProcessType::fHadronInelastic));
+
   fGammaNoProcessVector.push_back(
       new G4HepEmNoProcess("conv", G4ProcessType::fElectromagnetic,
                            G4EmProcessSubType::fGammaConversion));
@@ -77,15 +84,18 @@ G4HepEmTrackingManager::G4HepEmTrackingManager() {
   fGammaNoProcessVector.push_back(
       new G4HepEmNoProcess("phot", G4ProcessType::fElectromagnetic,
                            G4EmProcessSubType::fPhotoElectricEffect));
-   fGammaNoProcessVector.push_back(
-       new G4HepEmNoProcess("photonNuclear", G4ProcessType::fHadronic,
-                            G4HadronicProcessType::fHadronInelastic));
+  fGammaNoProcessVector.push_back(
+      new G4HepEmNoProcess("photonNuclear", G4ProcessType::fHadronic,
+                           G4HadronicProcessType::fHadronInelastic));
 
   fTransportNoProcess = new G4HepEmNoProcess(
       "Transportation", G4ProcessType::fTransportation, TRANSPORTATION);
 
   // Init the gamma-nuclear process
   fGNucProcess = nullptr;
+  // Init the electron/positron-nuclear processes
+  fENucProcess = nullptr;
+  fPNucProcess = nullptr;
 
   // Init the fast sim mamanger process ptrs of the 3 particles
   fFastSimProcess[0] = nullptr;
@@ -116,6 +126,8 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
   if (&part == G4Electron::Definition()) {
     int particleID = 0;
     fRunManager->Initialize(fRandomEngine, particleID);
+    // Find the electron-nuclear process if has been attached
+    InitNuclearProcesses(particleID);
     // Find the fast simulation manager process for e- (if has been attached)
     InitFastSimRelated(particleID);
     // Find the ATLAS specific trans. rad. (XTR) process (if has been attached)
@@ -123,6 +135,8 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
   } else if (&part == G4Positron::Definition()) {
     int particleID = 1;
     fRunManager->Initialize(fRandomEngine, particleID);
+    // Find the positron-nuclear process if has been attached
+    InitNuclearProcesses(particleID);
     // Find the fast simulation manager process for e+ (if has been attached)
     InitFastSimRelated(particleID);
   } else if (&part == G4Gamma::Definition()) {
@@ -260,6 +274,13 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
   if (fFastSimProc != nullptr) {
     fFastSimProc->StartTracking(aTrack);
   }
+
+  // Invoke the electron/positron-nuclear process start tracking interace (if any)
+  G4VProcess* theNucProcess = isElectron ? fENucProcess : fPNucProcess;
+  if (theNucProcess != nullptr) {
+    theNucProcess->StartTracking(aTrack);
+  }
+
   // === StartTracking ===
 
   while(aTrack->GetTrackStatus() == fAlive)
@@ -532,22 +553,49 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
       }
     } else if (aTrack->GetTrackStatus() != fStopAndKill) {
       // === 4. Discrete part of the interaction (if any)
-      G4HepEmElectronManager::PerformDiscrete(theHepEmData, theHepEmPars, theTLData);
-      const double *pdir = thePrimaryTrack->GetDirection();
-      postStepPoint.SetMomentumDirection(
-          G4ThreeVector(pdir[0], pdir[1], pdir[2]));
-
-      // Get the final process defining the step - might still be MSC!
       const int iDProc = thePrimaryTrack->GetWinnerProcessIndex();
-      if (thePrimaryTrack->GetOnBoundary()) {
-        proc = fTransportNoProcess;
-      } else if (iDProc == -1) {
-        // ionization
-        proc = fElectronNoProcessVector[0];
-      } else if (iDProc == -2) {
-        proc = fElectronNoProcessVector[3];
+      if (iDProc != 3) {
+        // interactions handled by the HepEm physics: ioni, brem or annihilation (for e+)
+        G4HepEmElectronManager::PerformDiscrete(theHepEmData, theHepEmPars, theTLData);
+        const double *pdir = thePrimaryTrack->GetDirection();
+        postStepPoint.SetMomentumDirection( G4ThreeVector(pdir[0], pdir[1], pdir[2]) );
+        // Get the final process defining the step - might still be MSC!
+        if (thePrimaryTrack->GetOnBoundary()) {
+          proc = fTransportNoProcess;
+        } else if (iDProc == -1) {
+          // ionization
+          proc = fElectronNoProcessVector[0];
+        } else if (iDProc == -2) {
+          proc = fElectronNoProcessVector[3];
+        } else {
+          proc = fElectronNoProcessVector[iDProc];
+        }
       } else {
-        proc = fElectronNoProcessVector[iDProc];
+        // Electron/positron-nuclear: --> use Geant4 for the interaction:
+        proc = isElectron ? fElectronNoProcessVector[4] : fElectronNoProcessVector[5];
+        thePrimaryTrack->SetNumIALeft(-1.0, iDProc);
+        // check if delta interaction happens
+        // Invoke the electron/positron-nuclear interaction using the Geant4 process
+        G4VParticleChange* particleChangeNuc = nullptr;
+        if (theNucProcess != nullptr && !G4HepEmElectronManager::CheckDelta(theHepEmData, thePrimaryTrack, theTLData->GetRNGEngine()->flat())) {
+          // call to set some fields of the process like material, energy etc.. used in its DoIt
+          G4ForceCondition forceCondition;
+          theNucProcess->PostStepGetPhysicalInteractionLength(*aTrack, 0.0, &forceCondition);
+          //
+          postStepPoint.SetStepStatus(fPostStepDoItProc);
+          particleChangeNuc = theNucProcess->PostStepDoIt(*aTrack, step);
+          // update the track and stack according to the result of the interaction
+          particleChangeNuc->UpdateStepForPostStep(&step);
+          step.UpdateTrack();
+          aTrack->SetTrackStatus(particleChangeNuc->GetTrackStatus());
+          // need to add secondaries to the secondary vector of the current track
+          // NOTE: as we use Geant4, we should care only those changes that are
+          //   not included in the above update step and track, i.e. the energy
+          //   deposited due to applying the cut when stacking the secondaries
+          thePrimaryTrack->AddEnergyDeposit( StackG4Secondaries(particleChangeNuc, aTrack, proc, g4IMC) );
+          // done: clear the particle change
+          particleChangeNuc->Clear();
+        }
       }
 
       // ATLAS XTR RELATED:
@@ -567,6 +615,7 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
           thePrimaryTrack->SetEKin(static_cast<G4ParticleChange*>(particleChangeXTR)->GetEnergy());
         }
       }
+      // === End discrete part of the interaction (if any)
 
     } else {
       // Else the particle left the world.
@@ -1125,17 +1174,38 @@ double G4HepEmTrackingManager::StackG4Secondaries(G4VParticleChange* particleCha
 
 // Try to get the nuclear process pointer from the process manager of the particle
 void G4HepEmTrackingManager::InitNuclearProcesses(int particleID) {
-  if (particleID == 2) {
-    G4ParticleDefinition* partDef = G4Gamma::Definition();
-    const G4ProcessVector* processVector = partDef->GetProcessManager()->GetProcessList();
-    for (std::size_t ip=0; ip<processVector->entries(); ip++) {
-      if( (*processVector)[ip]->GetProcessName()=="photonNuclear") {
-        fGNucProcess = (*processVector)[ip];
-        // make sure the process is initialised (element selectors needs to be built)
-        fGNucProcess->PreparePhysicsTable(*partDef);
-        fGNucProcess->BuildPhysicsTable(*partDef);
-        break;
-      }
+  G4ParticleDefinition* particleDef = nullptr;
+  std::string nameNuclearProcess = "";
+  G4VProcess** proc = nullptr;
+  switch(particleID) {
+    case 0: particleDef = G4Electron::Definition();
+            nameNuclearProcess = "electronNuclear";
+            proc = &fENucProcess;
+            break;
+    case 1: particleDef = G4Positron::Definition();
+            nameNuclearProcess = "positronNuclear";
+            proc = &fPNucProcess;
+            break;
+    case 2: particleDef = G4Gamma::Definition();
+            nameNuclearProcess = "photonNuclear";
+            proc = &fGNucProcess;
+            break;
+  }
+  if (particleDef == nullptr) {
+    std::cerr << " *** Unknown particle in G4HepEmTrackingManager::InitNuclearProcesses with ID = "
+              << particleID
+              << std::endl;
+    exit(-1);
+  }
+  //
+  const G4ProcessVector* processVector = particleDef->GetProcessManager()->GetProcessList();
+  for (std::size_t ip=0; ip<processVector->entries(); ip++) {
+    if( (*processVector)[ip]->GetProcessName()==nameNuclearProcess) {
+      *proc = (*processVector)[ip];
+      // make sure the process is initialised (element selectors needs to be built)
+      (*proc)->PreparePhysicsTable(*particleDef);
+      (*proc)->BuildPhysicsTable(*particleDef);
+      break;
     }
   }
 }

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -554,15 +554,16 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     } else if (aTrack->GetTrackStatus() != fStopAndKill) {
       // === 4. Discrete part of the interaction (if any)
       const int iDProc = thePrimaryTrack->GetWinnerProcessIndex();
-      if (iDProc != 3) {
+      if (thePrimaryTrack->GetOnBoundary()) {
+        // no disrete interaction in this case
+        proc = fTransportNoProcess;
+      } else if (iDProc != 3) {
         // interactions handled by the HepEm physics: ioni, brem or annihilation (for e+)
         G4HepEmElectronManager::PerformDiscrete(theHepEmData, theHepEmPars, theTLData);
         const double *pdir = thePrimaryTrack->GetDirection();
         postStepPoint.SetMomentumDirection( G4ThreeVector(pdir[0], pdir[1], pdir[2]) );
         // Get the final process defining the step - might still be MSC!
-        if (thePrimaryTrack->GetOnBoundary()) {
-          proc = fTransportNoProcess;
-        } else if (iDProc == -1) {
+        if (iDProc == -1) {
           // ionization
           proc = fElectronNoProcessVector[0];
         } else if (iDProc == -2) {

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -335,7 +335,7 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     thePrimaryTrack->SetSafety(preSafety);
 
     // Sample the `number-of-interaction-left`
-    for (int ip=0; ip<3; ++ip) {
+    for (int ip=0; ip<4; ++ip) {
       if (thePrimaryTrack->GetNumIALeft(ip)<=0.) {
         thePrimaryTrack->SetNumIALeft(-G4HepEmLog(rnge->flat()), ip);
       }

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -596,6 +596,10 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
           thePrimaryTrack->AddEnergyDeposit( StackG4Secondaries(particleChangeNuc, aTrack, proc, g4IMC) );
           // done: clear the particle change
           particleChangeNuc->Clear();
+          // update the primary track kinetic energy and direction
+          thePrimaryTrack->SetEKin(aTrack->GetKineticEnergy());
+          const G4ThreeVector& dir = aTrack->GetMomentumDirection();
+          thePrimaryTrack->SetDirection(dir.x(), dir.y(), dir.z());
         }
       }
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
@@ -242,7 +242,7 @@ struct G4HepEmElectronData {
   double        fENucEILDelta = 0.0;      // = 9.192566533618830;  // 1./[log(emax/emin)/127]
   double*       fENucEnergyGrid = nullptr;    // [fENucEnergyGrid]
 
-  double*       fENucMacXsecData = nullptr;   // [#materials*2*fGNucEnergyGridSize]
+  double*       fENucMacXsecData = nullptr;   // [#materials*2*fENucEnergyGridSize]
 
 
   /**

--- a/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
@@ -234,6 +234,17 @@ struct G4HepEmElectronData {
   double*    fResMacXSecData = nullptr; // [fResMacXSecNumData]
 /// @} */ // end: restricted macroscopic cross section
 
+  //
+  // Electron - and positron - nuclear cross sections per material:
+  // --- Grid: 63 bins form 100 MeV - 100 TeV
+  const int     fENucEnergyGridSize = 64;
+  double        fENucLogMinEkin = 0.0;    // = 4.605170185988092;  // log(100.0)
+  double        fENucEILDelta = 0.0;      // = 4.560092059984145;  // 1./[log(emax/emin)/63]
+  double*       fENucEnergyGrid = nullptr;    // [fENucEnergyGrid]
+
+  double*       fENucMacXsecData = nullptr;   // [#materials*2*fGNucEnergyGridSize]
+
+
   /**
    * @name Macroscopic first transport corss section related data members:
    * These members are used to store all macroscopic first transport cross section related data

--- a/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmElectronData.hh
@@ -236,10 +236,10 @@ struct G4HepEmElectronData {
 
   //
   // Electron - and positron - nuclear cross sections per material:
-  // --- Grid: 63 bins form 100 MeV - 100 TeV
-  const int     fENucEnergyGridSize = 64;
+  // --- Grid: 127 bins form 100 MeV - 100 TeV
+  const int     fENucEnergyGridSize = 128;
   double        fENucLogMinEkin = 0.0;    // = 4.605170185988092;  // log(100.0)
-  double        fENucEILDelta = 0.0;      // = 4.560092059984145;  // 1./[log(emax/emin)/63]
+  double        fENucEILDelta = 0.0;      // = 9.192566533618830;  // 1./[log(emax/emin)/127]
   double*       fENucEnergyGrid = nullptr;    // [fENucEnergyGrid]
 
   double*       fENucMacXsecData = nullptr;   // [#materials*2*fGNucEnergyGridSize]

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -28,10 +28,10 @@ struct G4HepEmGammaData {
   double        fCompEILDelta = 0.0;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
   double*       fCompEnergyGrid = nullptr;     // [fCompEnergyGridSize]
 
-//// === gamma nuclear related data. 146 bins form  2mc^2 - 100 TeV
-  const int     fGNucEnergyGridSize = 147;
+//// === gamma nuclear related data. 255 bins form  2mc^2 - 100 TeV
+  const int     fGNucEnergyGridSize = 256;
   double        fGNucLogMinEkin = 0.0;     // =  0.021759358706830;  // log(2mc^2)
-  double        fGNucEILDelta = 0.0;       // =  7.935247775833226;  // 1./[log(emax/emin)/146]
+  double        fGNucEILDelta = 0.0;       // =  13.85950970842557;  // 1./[log(emax/emin)/255]
   double*       fGNucEnergyGrid = nullptr;     // [fGNucEnergyGridSize]
 
 

--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
@@ -21,6 +21,8 @@ void FreeElectronData (struct G4HepEmElectronData** theElectronData)  {
     delete[] (*theElectronData)->fELossEnergyGrid;
     delete[] (*theElectronData)->fELossData;
     delete[] (*theElectronData)->fResMacXSecData;
+    delete[] (*theElectronData)->fENucEnergyGrid;
+    delete[] (*theElectronData)->fENucMacXsecData;
     delete[] (*theElectronData)->fTr1MacXSecData;
     delete[] (*theElectronData)->fResMacXSecStartIndexPerMatCut;
     delete[] (*theElectronData)->fElemSelectorIoniStartIndexPerMatCut;
@@ -80,7 +82,7 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
   // allocate memory for all the tr1-mxsec data on _d and compy from _h
   const int numTr1MacXSecs = 2 * numELossGridData * numHepEmMats;
   gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fTr1MacXSecData), sizeof( double ) * numTr1MacXSecs ) );
-  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fTr1MacXSecData,  onHOST->fTr1MacXSecData, sizeof( double ) * numTr1MacXSecs,  cudaMemcpyHostToDevice ) ); 
+  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fTr1MacXSecData,  onHOST->fTr1MacXSecData, sizeof( double ) * numTr1MacXSecs,  cudaMemcpyHostToDevice ) );
   //
   //  === Target element selector data (for ioni and brem EM models)
   //

--- a/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmElectronData.cc
@@ -77,6 +77,16 @@ void CopyElectronDataToDevice(struct G4HepEmElectronData* onHOST, struct G4HepEm
   gpuErrchk ( cudaMemcpy (   elDataHTo_d->fResMacXSecStartIndexPerMatCut,  onHOST->fResMacXSecStartIndexPerMatCut, sizeof( int )    * numHepEmMatCuts, cudaMemcpyHostToDevice ) );
   gpuErrchk ( cudaMemcpy (   elDataHTo_d->fResMacXSecData,                 onHOST->fResMacXSecData,                sizeof( double ) * numResMacXSecs,  cudaMemcpyHostToDevice ) );
   //
+  // === Electron/postron nuclear macroscopic scross section data:
+  //
+  // allocate memory for all the electron/positron nuclear macroscopic cross section data on _d and compy from _h
+  const int numENucGridData = onHOST->fENucEnergyGridSize;
+  const int numENucData     = 2*numENucGridData*numHepEmMats;
+  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fENucEnergyGrid),  sizeof( double ) * numENucGridData ) );
+  gpuErrchk ( cudaMalloc ( &(elDataHTo_d->fENucMacXsecData), sizeof( double ) * numENucData     ) );
+  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fENucEnergyGrid,   onHOST->fENucEnergyGrid,  sizeof( double ) * numENucGridData, cudaMemcpyHostToDevice ) );
+  gpuErrchk ( cudaMemcpy (   elDataHTo_d->fENucMacXsecData,  onHOST->fENucMacXsecData, sizeof( double ) * numENucData,     cudaMemcpyHostToDevice ) );
+  //
   // === First macroscopic transport scross section data:
   //
   // allocate memory for all the tr1-mxsec data on _d and compy from _h
@@ -141,6 +151,9 @@ void FreeElectronDataOnDevice(struct G4HepEmElectronData** onDEVICE) {
     // Macr. cross sections for ioni/brem
     cudaFree( onHostTo_d->fResMacXSecStartIndexPerMatCut );
     cudaFree( onHostTo_d->fResMacXSecData                );
+    // Macr. scross sections for eletron/positron nuclear and the energy grid
+    cudaFree( onHostTo_d->fENucEnergyGrid  );
+    cudaFree( onHostTo_d->fENucMacXsecData );
     // Tr1-mxsec data
     cudaFree( onHostTo_d->fTr1MacXSecData                );
     // Target element selectors for ioni and brem models

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -526,6 +526,15 @@ namespace nlohmann
         j["fResMacXSecData"] =
           make_span(d->fResMacXSecNumData, d->fResMacXSecData);
 
+        j["fENucLogMinEkin"] = d->fENucLogMinEkin;
+        j["fENucEILDelta"]   = d->fENucEILDelta;
+
+        j["fENucEnergyGrid"] =
+          make_span(d->fENucEnergyGridSize, d->fENucEnergyGrid);
+
+        const int nENuc = 2 * (d->fENucEnergyGridSize) * (d->fNumMaterials);
+        j["fENucMacXsecData"]  = make_span(nENuc, d->fENucMacXsecData);
+
         const int nTr1MacXsec = 2 * (d->fELossEnergyGridSize) * (d->fNumMaterials);
         j["fTr1MacXSecData"] =
           make_span(nTr1MacXsec, d->fTr1MacXSecData);
@@ -577,6 +586,18 @@ namespace nlohmann
             j.at("fResMacXSecStartIndexPerMatCut").get<dynamic_array<int>>();
           d->fResMacXSecStartIndexPerMatCut = tmpIndex.data;
           // To validate, tmpIndex.N == d->fNumMatCuts;
+
+          j.at("fENucLogMinEkin").get_to(d->fENucLogMinEkin);
+          j.at("fENucEILDelta").get_to(d->fENucEILDelta);
+
+          // Get the array but ignore the size (fENucEnergyGridSize) as this is a
+          // const (at time of writing)
+          auto tmpENucGrid =
+            j.at("fENucEnergyGrid").get<dynamic_array<double>>();
+          d->fENucEnergyGrid     = tmpENucGrid.data;
+
+          auto tmpENucData = j.at("fENucMacXsecData").get<dynamic_array<double>>();
+          d->fENucMacXsecData    = tmpENucData.data;
 
           auto tmpData = j.at("fResMacXSecData").get<dynamic_array<double>>();
           d->fResMacXSecNumData = tmpData.N;

--- a/G4HepEm/G4HepEmInit/include/G4HepEmElectronTableBuilder.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmElectronTableBuilder.hh
@@ -10,6 +10,7 @@ class G4MollerBhabhaModel;
 class G4SeltzerBergerModel;
 class G4eBremsstrahlungRelModel;
 class G4ParticleDefinition;
+class G4CrossSectionDataStore;
 
 
 struct G4HepEmData;
@@ -26,6 +27,10 @@ void BuildELossTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMode
 void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbModel,
                       G4eBremsstrahlungRelModel* rbModel, struct G4HepEmData* hepEmData,
                       struct G4HepEmParameters* hepEmParams, bool iselectron);
+
+void BuildNuclearLambdaTables(G4CrossSectionDataStore* hadENucXSDataStore,
+                      struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmParams,
+                      bool iselectron);
 
 void BuildTransportXSectionTables(G4VEmModel* mscModel, struct G4HepEmData* hepEmData,
                       struct G4HepEmParameters* hepEmParams, bool iselectron);

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -408,7 +408,7 @@ void BuildNuclearLambdaTables(G4CrossSectionDataStore* hadENucXSDataStore, struc
     // std::cout << " ===== Material = " << g4Mat->GetName() << std::endl;
     // loop over the kinetic energies and comput the electron-nuclear mxsec
     for (int ie=0; ie<numENucEkin; ++ie) {
-      const double ekin = elData->fENucEnergyGrid[ie];
+      const double ekin = ie==0 ? elData->fENucEnergyGrid[ie]+0.000001 : elData->fENucEnergyGrid[ie];
       dyPart->SetKineticEnergy(ekin);
       double mxsec = std::max(0.0, hadENucXSDataStore->ComputeCrossSection(dyPart, g4Mat));
       theENucMXsec[ie]   = mxsec;

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -21,6 +21,8 @@
 #include "G4SeltzerBergerModel.hh"
 #include "G4eBremsstrahlungRelModel.hh"
 
+#include "G4CrossSectionDataStore.hh"
+
 #include "G4ParticleDefinition.hh"
 #include "G4Electron.hh"
 #include "G4Positron.hh"
@@ -358,6 +360,77 @@ void BuildLambdaTables(G4MollerBhabhaModel* mbModel, G4SeltzerBergerModel* sbMod
   delete[] secDerivs;
   delete[] xsecData;
 }
+
+
+void BuildNuclearLambdaTables(G4CrossSectionDataStore* hadENucXSDataStore, struct G4HepEmData* hepEmData,
+                              struct G4HepEmParameters* hepEmParams, bool iselectron) {
+  // get the pointer to the already allocated G4HepEmElectronData from the HepEmData
+  struct G4HepEmElectronData* elData = iselectron
+                                       ? hepEmData->fTheElectronData
+                                       : hepEmData->fThePositronData;
+  //
+  // get the g4 particle-definition
+  G4ParticleDefinition* g4PartDef = G4Positron::Positron();
+  if  (iselectron) {
+    g4PartDef = G4Electron::Electron();
+  }
+  //
+  // generate the energy grid (common for all materials)
+  const double emin = 100.0*CLHEP::MeV;
+  const double emax = 100.0*CLHEP::TeV;
+  int numENucEkin = elData->fENucEnergyGridSize;
+  delete [] elData->fENucEnergyGrid;
+  elData->fENucEnergyGrid = new double[numENucEkin]{};
+  G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numENucEkin, elData->fENucLogMinEkin, elData->fENucEILDelta, elData->fENucEnergyGrid);
+  //
+  // allocate some array for intermediate storage of the nuclear MXsec and its second
+  // derivatives for a given material
+  double* theENucMXsec     = new double[numENucEkin]{};
+  double* theENucMXsecSD   = new double[numENucEkin]{};
+  // allocate the array to store (continuously) all macroscopic xsec
+  const int numMaterials   = elData->fNumMaterials;
+  elData->fENucMacXsecData = new double[2*numENucEkin*numMaterials]{};
+  //
+  // loop over the HepEm materials and for each:
+  // - get the corresponding G4Material
+  // - compute the macroscopic electron-nuclear cross section at each of the
+  //   discrte kinetic energies
+  //
+  // get the HepEm material data
+  const struct G4HepEmMaterialData*  hepEmMatData = hepEmData->fTheMaterialData;
+  // get the correspondibg G4Material table (i.e. global vector of G4Material*)
+  const G4MaterialTable* theG4MaterialTable = G4Material::GetMaterialTable();
+  // a g4 dynamic particle will be needed
+  G4DynamicParticle* dyPart = new G4DynamicParticle(g4PartDef, G4ThreeVector(0,0,1), 0);
+  for (int im=0; im<numMaterials; ++im) {
+    const struct G4HepEmMatData& matData = hepEmMatData->fMaterialData[im];
+    const G4Material* g4Mat = (*theG4MaterialTable)[matData.fG4MatIndex];
+    std::cout << " ===== Material = " << g4Mat->GetName() << std::endl;
+    // loop over the kinetic energies and comput the electron-nuclear mxsec
+    for (int ie=0; ie<numENucEkin; ++ie) {
+      const double ekin = elData->fENucEnergyGrid[ie];
+      dyPart->SetKineticEnergy(ekin);
+      double mxsec = std::max(0.0, hadENucXSDataStore->ComputeCrossSection(dyPart, g4Mat));
+      theENucMXsec[ie]   = mxsec;
+      theENucMXsecSD[ie] = 0.0;
+      // std::cout << " E = " << ekin << " [MeV] Sigam-ENuc(E) = " << mxsec << std::endl;
+       std::cout <<  ekin <<" " << mxsec << std::endl;
+    }
+    // set up a spline on the electron-nuclear MXsec array for interpolation
+    G4HepEmInitUtils::PrepareSpline(numENucEkin, elData->fENucEnergyGrid, theENucMXsec, theENucMXsecSD);
+    // write the data into its final location
+    int iStart = 2*numENucEkin*im;
+    for (int ie=0; ie<numENucEkin; ++ie) {
+      elData->fENucMacXsecData[iStart++] = theENucMXsec[ie];
+      elData->fENucMacXsecData[iStart++] = theENucMXsecSD[ie];
+    }
+  }
+  // free auxilary arrays
+  delete[] theENucMXsec;
+  delete[] theENucMXsecSD;
+  delete dyPart;
+}
+
 
 void BuildTransportXSectionTables(G4VEmModel* mscModel, struct G4HepEmData* hepEmData,
                                   struct G4HepEmParameters* /*hepEmParams*/, bool iselectron) {

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronTableBuilder.cc
@@ -405,7 +405,7 @@ void BuildNuclearLambdaTables(G4CrossSectionDataStore* hadENucXSDataStore, struc
   for (int im=0; im<numMaterials; ++im) {
     const struct G4HepEmMatData& matData = hepEmMatData->fMaterialData[im];
     const G4Material* g4Mat = (*theG4MaterialTable)[matData.fG4MatIndex];
-    std::cout << " ===== Material = " << g4Mat->GetName() << std::endl;
+    // std::cout << " ===== Material = " << g4Mat->GetName() << std::endl;
     // loop over the kinetic energies and comput the electron-nuclear mxsec
     for (int ie=0; ie<numENucEkin; ++ie) {
       const double ekin = elData->fENucEnergyGrid[ie];
@@ -414,7 +414,6 @@ void BuildNuclearLambdaTables(G4CrossSectionDataStore* hadENucXSDataStore, struc
       theENucMXsec[ie]   = mxsec;
       theENucMXsecSD[ie] = 0.0;
       // std::cout << " E = " << ekin << " [MeV] Sigam-ENuc(E) = " << mxsec << std::endl;
-       std::cout <<  ekin <<" " << mxsec << std::endl;
     }
     // set up a spline on the electron-nuclear MXsec array for interpolation
     G4HepEmInitUtils::PrepareSpline(numENucEkin, elData->fENucEnergyGrid, theENucMXsec, theENucMXsecSD);

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaTableBuilder.cc
@@ -49,7 +49,7 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
   G4HepEmInitUtils::FillLogarithmicGrid(emin, emax, numCompEkin, gmData->fCompLogMinEkin, gmData->fCompEILDelta, gmData->fCompEnergyGrid);
 
   // == Generate the enegry grid for Gamma-nuclear
-  emin = 2.0*CLHEP::electron_mass_c2;
+  emin =   0.5*CLHEP::MeV;
   emax = 100.0*CLHEP::TeV;
   int numGNucEkin = gmData->fGNucEnergyGridSize;
   delete [] gmData->fGNucEnergyGrid;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.hh
@@ -159,7 +159,7 @@ public:
   static void SampleMSC(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack, G4HepEmRandomEngine* rnge);
 
   /** Sample loss fluctuations for the mean energy loss.
-    * 
+    *
     * @param hepEmData pointer to the top level, global, G4HepEmData structure.
     * @param hepEmPars pointer to the global, G4HepEmParameters structure.
     * @param theElTrack pointer to the input and output information of the track.
@@ -247,10 +247,16 @@ public:
   G4HepEmHostDevice
   static double GetRestMacXSec(const struct G4HepEmElectronData* elData, const int imc, const double ekin,
                                const double lekin, bool isioni);
+  G4HepEmHostDevice
+  static double GetMacXSecNuclear(const struct G4HepEmElectronData* elData, const int imat, const double ekin,
+                                  const double lekin);
 
   G4HepEmHostDevice
   static double GetRestMacXSecForStepping(const struct G4HepEmElectronData* elData, const int imc, double ekin,
                                           double lekin, bool isioni);
+  G4HepEmHostDevice
+  static double GetMacXSecNuclearForStepping(const struct G4HepEmElectronData* elData, const int imat, const double ekin,
+                                             const double lekin);
 
   G4HepEmHostDevice
   static double GetTransportMFP(const struct G4HepEmElectronData* elData, const int im, const double ekin, const double lekin);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -36,7 +36,7 @@ void G4HepEmElectronManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepE
   G4HepEmElectronTrack* theElTrack = tlData->GetPrimaryElectronTrack();
   G4HepEmTrack* theTrack = theElTrack->GetTrack();
   // Sample the `number-of-interaction-left`
-  for (int ip=0; ip<3; ++ip) {
+  for (int ip=0; ip<4; ++ip) {
     if (theTrack->GetNumIALeft(ip)<=0.) {
       theTrack->SetNumIALeft(-G4HepEmLog(tlData->GetRNGEngine()->flat()), ip);
     }
@@ -69,16 +69,17 @@ void G4HepEmElectronManager::HowFarToDiscreteInteraction(struct G4HepEmData* hep
 //  std::cout << " pStepLength = " << pStepLength << " range = " << range << " frange = " << frange << std::endl;
   // === 2. Discrete limits due to eestricted Ioni and Brem (accounting e-loss)
   const int theImat = (hepEmData->fTheMatCutData->fMatCutData[theIMC]).fHepEmMatIndex;
-  double mxSecs[3];
-  // ioni, brem and annihilation to 2 gammas (only for e+)
+  double mxSecs[4];
+  // ioni, brem and annihilation to 2 gammas (only for e+), electron/positron nuclear
   mxSecs[0] = GetRestMacXSecForStepping(theElectronData, theIMC, theEkin, theLEkin, true);
   mxSecs[1] = GetRestMacXSecForStepping(theElectronData, theIMC, theEkin, theLEkin, false);
   mxSecs[2] = (isElectron)
               ? 0.0
               : ComputeMacXsecAnnihilationForStepping(theEkin, hepEmData->fTheMaterialData->fMaterialData[theImat].fElectronDensity);
+  mxSecs[3] = GetMacXSecNuclearForStepping(theElectronData, theImat, theEkin, theLEkin);
   // compute mfp and see if we need to sample the `number-of-interaction-left`
   // before we use it to get the current discrete proposed step length
-  for (int ip=0; ip<3; ++ip) {
+  for (int ip=0; ip<4; ++ip) {
     const double mxsec = mxSecs[ip];
     const double   mfp = (mxsec>0.) ? 1./mxsec : kALargeValue;
     // save the mac-xsec for the update of the `number-of-interaction-left`:
@@ -207,6 +208,7 @@ void G4HepEmElectronManager::UpdateNumIALeft(G4HepEmElectronTrack* theElTrack) {
   numInterALeft[0] -= pStepLength/preStepMFP[0];
   numInterALeft[1] -= pStepLength/preStepMFP[1];
   numInterALeft[2] -= pStepLength/preStepMFP[2];
+  numInterALeft[3] -= pStepLength/preStepMFP[3];
 }
 
 bool G4HepEmElectronManager::ApplyMeanEnergyLoss(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, G4HepEmElectronTrack* theElTrack) {
@@ -405,9 +407,10 @@ bool G4HepEmElectronManager::CheckDelta(struct G4HepEmData* hepEmData, G4HepEmTr
   const int theMatIndex = hepEmData->fTheMatCutData->fMatCutData[theIMC].fHepEmMatIndex;
   const double theEkin  = theTrack->GetEKin();
   const double theLEkin = theTrack->GetLogEKin();
-  const double mxsec = (iDProc<2)
-                      ? GetRestMacXSec(elData, theIMC, theEkin, theLEkin, iDProc==0)
-                      : ComputeMacXsecAnnihilation(theEkin, hepEmData->fTheMaterialData->fMaterialData[theMatIndex].fElectronDensity);
+  const double mxsec = (iDProc<2 ? GetRestMacXSec(elData, theIMC, theEkin, theLEkin, iDProc==0) :
+                       (iDProc<3 ? ComputeMacXsecAnnihilation(theEkin, hepEmData->fTheMaterialData->fMaterialData[theMatIndex].fElectronDensity)
+                                 : GetMacXSecNuclear(elData, theMatIndex, theEkin, theLEkin))
+                       );
   return mxsec <= 0.0 || rand > mxsec*theTrack->GetMFP(iDProc);
 }
 
@@ -441,6 +444,8 @@ void G4HepEmElectronManager::PerformDiscrete(struct G4HepEmData* hepEmData, stru
             break;
     case 2: // invoke annihilation (in-flight) for e+
             G4HepEmPositronInteractionAnnihilation::Perform(tlData, false);
+            break;
+    case 3: // electron/positorn - nuclear interaction is not handled by HepEm: do nothing
             break;
   }
 }
@@ -518,6 +523,15 @@ double  G4HepEmElectronManager::GetRestMacXSec(const struct G4HepEmElectronData*
   return G4HepEmMax(0.0, mxsec);
 }
 
+double  G4HepEmElectronManager::GetMacXSecNuclear(const struct G4HepEmElectronData* elData, const int imat, const double ekin, const double lekin) {
+  if (ekin < elData->fENucEnergyGrid[0]) { return 0.0; }
+  const int numEKin   = elData->fENucEnergyGridSize; // #energy point per material
+  const int iStartMat = imat*2*numEKin; // value and second derivative at each energy point
+  // use the G4HepEmRunUtils function for interpolation
+  const double mxsec = GetSplineLog(numEKin, elData->fENucEnergyGrid, &(elData->fENucMacXsecData[iStartMat]), ekin, lekin, elData->fENucLogMinEkin, elData->fENucEILDelta);
+  return G4HepEmMax(0.0, mxsec);
+}
+
 
 double  G4HepEmElectronManager::GetRestMacXSecForStepping(const struct G4HepEmElectronData* elData, const int imc, double ekin, double lekin, bool isioni) {
   constexpr double log08 = -0.22314355131420971;
@@ -543,6 +557,11 @@ double  G4HepEmElectronManager::GetRestMacXSecForStepping(const struct G4HepEmEl
   // use the G4HepEmRunUtils function for interpolation
   const double mxsec = GetSplineLog(numData, &(elData->fResMacXSecData[iStart+5]), ekin, lekin, elData->fResMacXSecData[iStart+3], elData->fResMacXSecData[iStart+4]);
   return G4HepEmMax(0.0, mxsec);
+}
+
+double  G4HepEmElectronManager::GetMacXSecNuclearForStepping(const struct G4HepEmElectronData* elData, const int imat, const double ekin, const double lekin) {
+  // assuming increasing macroscopic cross section with increasing energy
+  return GetMacXSecNuclear(elData, imat, ekin, lekin);
 }
 
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -137,16 +137,17 @@ double  G4HepEmGammaManager::GetMacXSec(const struct G4HepEmGammaData* gmData, c
   // use the G4HepEmRunUtils GetSplineLog function for interpolation
   switch (iprocess) {
     case 0: { // Conversion
-              const double  mxsec = GetSplineLog(numConvData, gmData->fConvEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart]) , ekin, lekin, gmData->fConvLogMinEkin, gmData->fConvEILDelta);
-              return G4HepEmMax(0.0, mxsec);
+              return ekin > gmData->fConvEnergyGrid[0]
+                     ? G4HepEmMax(0.0, GetSplineLog(numConvData, gmData->fConvEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart]) , ekin, lekin, gmData->fConvLogMinEkin, gmData->fConvEILDelta))
+                     : 0.0;
             }
     case 1: { // Compton
-              const double  mxsec = GetSplineLog(numCompData, gmData->fCompEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*numConvData]) , ekin, lekin, gmData->fCompLogMinEkin, gmData->fCompEILDelta);
-              return G4HepEmMax(0.0, mxsec);
+              return G4HepEmMax(0.0, GetSplineLog(numCompData, gmData->fCompEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*numConvData]) , ekin, lekin, gmData->fCompLogMinEkin, gmData->fCompEILDelta));
             }
     case 2: { // Gamma-nuclear
-              const double  mxsec = GetSplineLog(numGNucData, gmData->fGNucEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*(numConvData+numCompData)]) , ekin, lekin, gmData->fGNucLogMinEkin, gmData->fGNucEILDelta);
-              return G4HepEmMax(0.0, mxsec);
+              return ekin > gmData->fGNucEnergyGrid[0]
+                    ? G4HepEmMax(0.0, GetSplineLog(numGNucData, gmData->fGNucEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*(numConvData+numCompData)]) , ekin, lekin, gmData->fGNucLogMinEkin, gmData->fGNucEILDelta))
+                    : 0.0;
             }
 
     default:

--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -87,7 +87,7 @@ PhysicsList::PhysicsList() : G4VModularPhysicsList(),
   // Create the G4EmExtraPhysics to add gamma and lepton nuclear interactions
   G4EmExtraPhysics* emExtra = new G4EmExtraPhysics();
   // During the development: deactiavte electron nuclear till we don't have in HepEm
-  emExtra->ElectroNuclear(false);
+  // emExtra->ElectroNuclear(false);
   // Turn off muon nuclear as well (not improtant as no muon production but
   // remove it as we don't have in HepEm)
   emExtra->MuonNuclear(false);

--- a/testing/ElectronXSections/include/Declaration.hh
+++ b/testing/ElectronXSections/include/Declaration.hh
@@ -12,12 +12,15 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron=tru
 #ifdef G4HepEm_CUDA_BUILD
 
   // Evaluates all test cases on the device for computing the restricted macroscopic
-  // cross section values for ionisation and bremsstrahlung on the device for all test cases.
+  // cross section values for ionisation, bremsstrahlung and electron/positron -
+  // nuclear interactions on the device for all test cases.
   void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
                                     double* tsInEkinIoni_h, double* tsInLogEkinIoni_h,
                                     double* tsInEkinBrem_h, double* tsInLogEkinBrem_h,
+                                    double* tsInEkinENuc_h, double* tsInLogEkinENuc_h,
                                     double* tsOutResMXIoni_h, double* tsOutResMXBrem_h,
-                                    int numTestCases, bool iselectron );
+                                    double* tsOutResMXENuc_h, int numTestCases, 
+                                    bool iselectron );
 
 #endif // G4HepEm_CUDA_BUILD
 

--- a/testing/ElectronXSections/src/Implementation.cc
+++ b/testing/ElectronXSections/src/Implementation.cc
@@ -80,7 +80,7 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
     tsOutResMXIoni[i] = G4HepEmElectronManager::GetRestMacXSec (theElectronData, tsInImc[i], tsInEkinIoni[i], tsInLogEkinIoni[i], true);
     tsOutResMXBrem[i] = G4HepEmElectronManager::GetRestMacXSec (theElectronData, tsInImc[i], tsInEkinBrem[i], tsInLogEkinBrem[i], false);
     const int imat = theMatCutData->fMatCutData[tsInImc[i]].fHepEmMatIndex;
-    tsOutResMXBrem[i] = G4HepEmElectronManager::GetMacXSecNuclear (theElectronData, imat, tsInEkinENuc[i], tsInLogEkinENuc[i]);
+    tsOutResMXENuc[i] = G4HepEmElectronManager::GetMacXSecNuclear (theElectronData, imat, tsInEkinENuc[i], tsInLogEkinENuc[i]);
   }
 
 
@@ -105,7 +105,7 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
     }
     if ( std::abs( 1.0 - tsOutResMXENuc[i]/tsOutResOnDeviceMXENuc[i] ) > 1.0E-14 ) {
       isPassed = false;
-      std::cerr << "\n*** ERROR:\nMacroscopic Cross Section data: G4HepEm Host vs Device (Electron-nuclear) mismatch: " <<  std::setprecision(16) << tsOutResMXBrem[i] << " != " << tsOutResOnDeviceMXBrem[i] << " ( i = " << i << " imc  = " << tsInImc[i] << " ekin =  " << tsInEkinBrem[i] << ") " << std::endl;
+      std::cerr << "\n*** ERROR:\nMacroscopic Cross Section data: G4HepEm Host vs Device (Electron-nuclear) mismatch: " <<  std::setprecision(16) << tsOutResMXENuc[i] << " != " << tsOutResOnDeviceMXENuc[i] << " ( i = " << i << " imc  = " << tsInImc[i] << " ekin =  " << tsInEkinENuc[i] << ") " << std::endl;
       break;
     }
   }

--- a/testing/ElectronXSections/src/Implementation.cc
+++ b/testing/ElectronXSections/src/Implementation.cc
@@ -39,8 +39,11 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
   double* tsInLogEkinIoni = new double[numTestCases];
   double* tsInEkinBrem    = new double[numTestCases];
   double* tsInLogEkinBrem = new double[numTestCases];
+  double* tsInEkinENuc    = new double[numTestCases];
+  double* tsInLogEkinENuc = new double[numTestCases];
   double* tsOutResMXIoni  = new double[numTestCases];
   double* tsOutResMXBrem  = new double[numTestCases];
+  double* tsOutResMXENuc  = new double[numTestCases];
   // the maximum (+2%) primary particle kinetic energy that is covered by the simulation (100 TeV by default)
   const double    maxEKin = 1.02*theElectronData->fELossEnergyGrid[numELossData-1];
   for (int i=0; i<numTestCases; ++i) {
@@ -63,6 +66,12 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
     lEkinDelta         = std::log(maxEKin/minEKin);
     tsInLogEkinBrem[i] = dis(gen)*lEkinDelta+lMinEkin;
     tsInEkinBrem[i]    = std::exp(tsInLogEkinBrem[i]);
+    // == Electron-nuclear:
+    minEKin            = 0.98*theElectronData->fENucEnergyGrid[0];
+    lMinEkin           = std::log(minEKin);
+    lEkinDelta         = std::log(maxEKin/minEKin);
+    tsInLogEkinENuc[i] = dis(gen)*lEkinDelta+lMinEkin;
+    tsInEkinENuc[i]    = std::exp(tsInLogEkinENuc[i]);
   }
   //
   // Use G4HepEmElectronManager to evaluate the restricted macroscopic
@@ -70,6 +79,8 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
   for (int i=0; i<numTestCases; ++i) {
     tsOutResMXIoni[i] = G4HepEmElectronManager::GetRestMacXSec (theElectronData, tsInImc[i], tsInEkinIoni[i], tsInLogEkinIoni[i], true);
     tsOutResMXBrem[i] = G4HepEmElectronManager::GetRestMacXSec (theElectronData, tsInImc[i], tsInEkinBrem[i], tsInLogEkinBrem[i], false);
+    const int imat = theMatCutData->fMatCutData[tsInImc[i]].fHepEmMatIndex;
+    tsOutResMXBrem[i] = G4HepEmElectronManager::GetMacXSecNuclear (theElectronData, imat, tsInEkinENuc[i], tsInLogEkinENuc[i]);
   }
 
 
@@ -78,7 +89,8 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
   // Perform the test case evaluations on the device
   double* tsOutResOnDeviceMXIoni = new double[numTestCases];
   double* tsOutResOnDeviceMXBrem = new double[numTestCases];
-  TestResMacXSecDataOnDevice (hepEmData, tsInImc, tsInEkinIoni, tsInLogEkinIoni, tsInEkinBrem, tsInLogEkinBrem, tsOutResOnDeviceMXIoni, tsOutResOnDeviceMXBrem, numTestCases, iselectron);
+  double* tsOutResOnDeviceMXENuc = new double[numTestCases];
+  TestResMacXSecDataOnDevice (hepEmData, tsInImc, tsInEkinIoni, tsInLogEkinIoni, tsInEkinBrem, tsInLogEkinBrem, tsInEkinENuc, tsInLogEkinENuc, tsOutResOnDeviceMXIoni, tsOutResOnDeviceMXBrem, tsOutResOnDeviceMXENuc, numTestCases, iselectron);
   for (int i=0; i<numTestCases; ++i) {
 //    std::cout << tsInEkinIoni[i] << " "<<tsOutResMXIoni[i] << " " << tsOutResOnDeviceMXIoni[i] << " " <<tsInEkinBrem[i] << " " << tsOutResMXBrem[i] << " " << tsOutResOnDeviceMXBrem[i] << std::endl;
     if ( std::abs( 1.0 - tsOutResMXIoni[i]/tsOutResOnDeviceMXIoni[i] ) > 1.0E-14 ) {
@@ -91,10 +103,16 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
       std::cerr << "\n*** ERROR:\nRestricted Macroscopic Cross Section data: G4HepEm Host vs Device (Brem) mismatch: " <<  std::setprecision(16) << tsOutResMXBrem[i] << " != " << tsOutResOnDeviceMXBrem[i] << " ( i = " << i << " imc  = " << tsInImc[i] << " ekin =  " << tsInEkinBrem[i] << ") " << std::endl;
       break;
     }
+    if ( std::abs( 1.0 - tsOutResMXENuc[i]/tsOutResOnDeviceMXENuc[i] ) > 1.0E-14 ) {
+      isPassed = false;
+      std::cerr << "\n*** ERROR:\nMacroscopic Cross Section data: G4HepEm Host vs Device (Electron-nuclear) mismatch: " <<  std::setprecision(16) << tsOutResMXBrem[i] << " != " << tsOutResOnDeviceMXBrem[i] << " ( i = " << i << " imc  = " << tsInImc[i] << " ekin =  " << tsInEkinBrem[i] << ") " << std::endl;
+      break;
+    }
   }
   //
   delete [] tsOutResOnDeviceMXIoni;
   delete [] tsOutResOnDeviceMXBrem;
+  delete [] tsOutResOnDeviceMXENuc;
 #endif // G4HepEm_CUDA_BUILD
 
   //
@@ -104,8 +122,11 @@ bool TestXSectionData ( const struct G4HepEmData* hepEmData, bool iselectron ) {
   delete [] tsInLogEkinIoni;
   delete [] tsInEkinBrem;
   delete [] tsInLogEkinBrem;
+  delete [] tsInEkinENuc;
+  delete [] tsInLogEkinENuc;
   delete [] tsOutResMXIoni;
   delete [] tsOutResMXBrem;
+  delete [] tsOutResMXENuc;
 
   return isPassed;
 }

--- a/testing/ElectronXSections/src/ResMacXSecs.cu
+++ b/testing/ElectronXSections/src/ResMacXSecs.cu
@@ -52,19 +52,22 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   double*   tsOutResMXENuc_d = nullptr;
 
   int* tsInImat_h = new int[numTestCases];
-  for (int i=0; i<numTestCases: ++i) {
+  for (int i=0; i<numTestCases; ++i) {
     tsInImat_h[i] = hepEmData->fTheMatCutData->fMatCutData[tsInImc_h[i]].fHepEmMatIndex;
   }
   int* tsInImat_d = nullptr;
   //
   gpuErrchk ( cudaMalloc ( &tsInImc_d,         sizeof( int )    * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInIamt_d,        sizeof( int )    * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInImat_d,        sizeof( int )    * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInEkinIoni_d,    sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInLogEkinIoni_d, sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInEkinBrem_d,    sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInLogEkinBrem_d, sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInEkinENuc_d,    sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInLogEkinENuc_d, sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsOutResMXIoni_d,  sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsOutResMXBrem_d,  sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsOutResMXENuc_d,  sizeof( double ) * numTestCases ) );
   //
   // --- Copy the input data from host to device (test material-cut index, ekin and log-ekin arrays)
   gpuErrchk ( cudaMemcpy ( tsInImc_d,         tsInImc_h,         sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
@@ -73,6 +76,8 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   gpuErrchk ( cudaMemcpy ( tsInLogEkinIoni_d, tsInLogEkinIoni_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInEkinBrem_d,    tsInEkinBrem_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInLogEkinBrem_d, tsInLogEkinBrem_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInEkinENuc_d,    tsInEkinENuc_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInLogEkinENuc_d, tsInLogEkinENuc_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   //
   // --- Launch the kernels
   int numThreads = 512;

--- a/testing/ElectronXSections/src/ResMacXSecs.cu
+++ b/testing/ElectronXSections/src/ResMacXSecs.cu
@@ -22,9 +22,21 @@
    }
  }
 
+
+ __global__
+ void TestMacXSecNuclearKernel ( const struct G4HepEmElectronData* theElectronData_d,
+                                 int* tsInImat_d, double* tsInEkin_d, double* tsInLogEkin_d,
+                                 double* tsOutRes_d, int numTestCases) {
+   for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
+     tsOutRes_d[i] = G4HepEmElectronManager::GetMacXSecNuclear (theElectronData_d, tsInImat_d[i], tsInEkin_d[i], tsInLogEkin_d[i]);
+   }
+ }
+
+
 void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImc_h,
      double* tsInEkinIoni_h, double* tsInLogEkinIoni_h, double* tsInEkinBrem_h, double* tsInLogEkinBrem_h,
-     double* tsOutResMXIoni_h, double* tsOutResMXBrem_h, int numTestCases, bool iselectron ) {
+     double* tsInEkinENuc_h, double* tsInLogEkinENuc_h, double* tsOutResMXIoni_h, double* tsOutResMXBrem_h,
+     double* tsOutResMXENuc_h, int numTestCases, bool iselectron ) {
   //
   // --- Allocate device side memory for the input/output data and copy all input
   //     data from host to device
@@ -33,10 +45,20 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   double*  tsInLogEkinIoni_d = nullptr;
   double*     tsInEkinBrem_d = nullptr;
   double*  tsInLogEkinBrem_d = nullptr;
+  double*     tsInEkinENuc_d = nullptr;
+  double*  tsInLogEkinENuc_d = nullptr;
   double*   tsOutResMXIoni_d = nullptr;
   double*   tsOutResMXBrem_d = nullptr;
+  double*   tsOutResMXENuc_d = nullptr;
+
+  int* tsInImat_h = new int[numTestCases];
+  for (int i=0; i<numTestCases: ++i) {
+    tsInImat_h[i] = hepEmData->fTheMatCutData->fMatCutData[tsInImc_h[i]].fHepEmMatIndex;
+  }
+  int* tsInImat_d = nullptr;
   //
   gpuErrchk ( cudaMalloc ( &tsInImc_d,         sizeof( int )    * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInIamt_d,        sizeof( int )    * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInEkinIoni_d,    sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInLogEkinIoni_d, sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInEkinBrem_d,    sizeof( double ) * numTestCases ) );
@@ -46,6 +68,7 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   //
   // --- Copy the input data from host to device (test material-cut index, ekin and log-ekin arrays)
   gpuErrchk ( cudaMemcpy ( tsInImc_d,         tsInImc_h,         sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInImat_d,        tsInImat_h,        sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInEkinIoni_d,    tsInEkinIoni_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInLogEkinIoni_d, tsInLogEkinIoni_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
   gpuErrchk ( cudaMemcpy ( tsInEkinBrem_d,    tsInEkinBrem_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
@@ -60,6 +83,8 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   TestResMacXSecDataKernel <<< numBlocks, numThreads >>> (theElectronData_d, tsInImc_d, tsInEkinIoni_d, tsInLogEkinIoni_d, tsOutResMXIoni_d, true,  numTestCases );
   // brem
   TestResMacXSecDataKernel <<< numBlocks, numThreads >>> (theElectronData_d, tsInImc_d, tsInEkinBrem_d, tsInLogEkinBrem_d, tsOutResMXBrem_d, false, numTestCases );
+  // electron/positron - nuclear
+  TestMacXSecNuclearKernel <<< numBlocks, numThreads >>> (theElectronData_d, tsInImat_d, tsInEkinENuc_d, tsInLogEkinENuc_d, tsOutResMXENuc_d, numTestCases );
   //
   // --- Synchronize to make sure that completed on the device
   cudaDeviceSynchronize();
@@ -67,9 +92,14 @@ void TestResMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsIn
   // --- Copy the results from the device to the host
   gpuErrchk ( cudaMemcpy ( tsOutResMXIoni_h,     tsOutResMXIoni_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
   gpuErrchk ( cudaMemcpy ( tsOutResMXBrem_h,     tsOutResMXBrem_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
+  gpuErrchk ( cudaMemcpy ( tsOutResMXENuc_h,     tsOutResMXENuc_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
+
+  // Free the dynamically allocated (host side) memory
+  delete tsInImat_h;
   //
   // --- Free all dynamically allocated (device side) memory
   cudaFree ( tsInImc_d          );
+  cudaFree ( tsInImat_d         );
   cudaFree ( tsInEkinIoni_d    );
   cudaFree ( tsInLogEkinIoni_d );
   cudaFree ( tsInEkinBrem_d    );

--- a/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
+++ b/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
@@ -35,6 +35,11 @@ void G4HepEmElectronDataTester(G4HepEmElectronData* d) {
   EXPECT_EQ(d->fResMacXSecStartIndexPerMatCut, nullptr);
   EXPECT_EQ(d->fResMacXSecData, nullptr);
 
+  // Energy grid has a fixed size, but dynamic allocation
+  EXPECT_EQ(d->fENucEnergyGridSize, 128);
+  EXPECT_EQ(d->fENucEnergyGrid, nullptr);
+  EXPECT_EQ(d->fENucMacXsecData, nullptr);
+
   EXPECT_EQ(d->fElemSelectorIoniNumData, 0);
   EXPECT_EQ(d->fElemSelectorIoniStartIndexPerMatCut, nullptr);
   EXPECT_EQ(d->fElemSelectorIoniData, nullptr);

--- a/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
+++ b/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
@@ -124,7 +124,7 @@ void G4HepEmGammaDataTester(G4HepEmGammaData* d) {
   EXPECT_EQ(d->fCompEnergyGrid, nullptr);
 
   // Energy grid has a fixed size, but dynamic allocation
-  EXPECT_EQ(d->fGNucEnergyGridSize, 147);
+  EXPECT_EQ(d->fGNucEnergyGridSize, 256);
   EXPECT_EQ(d->fGNucEnergyGrid, nullptr);
 
   EXPECT_EQ(d->fConvCompGNucMacXsecData, nullptr);

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -411,6 +411,22 @@ bool operator==(const G4HepEmElectronData& lhs, const G4HepEmElectronData& rhs)
     return false;
   }
 
+  if(std::tie(lhs.fENucLogMinEkin, lhs.fENucEILDelta) !=
+     std::tie(lhs.fENucLogMinEkin, lhs.fENucEILDelta))
+  {
+    return false;
+  }
+  if(!compare_arrays(lhs.fENucEnergyGridSize, lhs.fENucEnergyGrid,
+                     rhs.fENucEnergyGridSize, rhs.fENucEnergyGrid))
+  {
+    return false;
+  }
+  if(!compare_arrays(lhs.fENucEnergyGridSize, lhs.fENucMacXsecData,
+                     rhs.fENucEnergyGridSize, rhs.fENucMacXsecData))
+  {
+    return false;
+  }
+
   if(!compare_arrays(lhs.fNumMatCuts, lhs.fElemSelectorIoniStartIndexPerMatCut,
                      rhs.fNumMatCuts, rhs.fElemSelectorIoniStartIndexPerMatCut))
   {


### PR DESCRIPTION
Electron/positron-nuclear interactions are included now in HepEm. Similarly to gamma-nuclear:
- the cross sections are available in HepEm (both on host and device)
- the cross sections are used during the step limit phase in the HepEm physics 
- but the interactions are not performed inside the HepEm physics: they are done in the HepEmTrackingManager using the native electron/positron-nuclear Geant4 processes (if the user attached to e-/e+ in their physics list)
- everything works fine even if there are no such Geant4 processes attached to the e-/e+  (the particle will stop but keep on moving without any changes).       