### PR TITLE
Change the gamma cross section representation.

### DIFF
--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -921,6 +921,9 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
       } else {
         double edep = 0.0;
         // NOTE: gamma-nuclear interaction needs to be done here while others in HepEm
+        //       so we need to select first the interaction then see if we call HepEm
+        //       or Geant4 physics to perform the selected interaction.
+        G4HepEmGammaManager::SelectInteraction(theHepEmData, theTLData);
         const int iDProc = thePrimaryTrack->GetWinnerProcessIndex();
         if (iDProc != 3) {
           // Conversion, Compton or photoelectric --> use HepEm for the interaction

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -16,29 +16,6 @@ struct G4HepEmGammaData {
   /** Number of G4HepEm materials: number of G4HepEmMatData structures stored in the G4HepEmMaterialData::fMaterialData array. */
   int           fNumMaterials = 0;
 
-//// === conversion related data. Grid: 146 bins form 2mc^2 - 100 TeV
-  const int     fConvEnergyGridSize = 147;
-  double        fConvLogMinEkin = 0.0;    // = 0.021759358706830;  // log(2mc^2)
-  double        fConvEILDelta = 0.0;      // = 7.935247775833226;  // 1./[log(emax/emin)/146]
-  double*       fConvEnergyGrid = nullptr;    // [fConvEnergyGrid]
-
-//// === compton related data. 84 bins (7 per decades) from 100 eV - 100 TeV
-  const int     fCompEnergyGridSize = 85;
-  double        fCompLogMinEkin = 0.0;     // = -9.210340371976182; // log(0.0001) i.e. log(100 eV)
-  double        fCompEILDelta = 0.0;       // =  3.040061373322763; // 1./[log(emax/emin)/84]
-  double*       fCompEnergyGrid = nullptr;     // [fCompEnergyGridSize]
-
-//// === gamma nuclear related data. 255 bins form  2mc^2 - 100 TeV
-  const int     fGNucEnergyGridSize = 256;
-  double        fGNucLogMinEkin = 0.0;     // =  0.021759358706830;  // log(2mc^2)
-  double        fGNucEILDelta = 0.0;       // =  13.85950970842557;  // 1./[log(emax/emin)/255]
-  double*       fGNucEnergyGrid = nullptr;     // [fGNucEnergyGridSize]
-
-
-  // the macroscopic cross sections for all materials and for [conversion,compton,gamma-nuclear]
-  // at each material
-  double*       fConvCompGNucMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize+fGNucEnergyGridSize)]
-
 //// === Macroscopic cross section related data:
   // The 100 eV 100 TeV kinetic energy range is divided up to 3 kinetic energy window. At a discrete kinetic
   // energy point, the following macroscopic cross section data are stored:
@@ -85,7 +62,7 @@ struct G4HepEmGammaData {
   double        fLogEMin2   = 0.0;
   double        fEILDelta2  = 0.0;
 
-  double*       fMacXsecData; // [#materials x fDataPerMat]
+  double*       fMacXsecData = nullptr; // [#materials x fDataPerMat]
 
 
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmGammaData.hh
@@ -39,6 +39,55 @@ struct G4HepEmGammaData {
   // at each material
   double*       fConvCompGNucMacXsecData = nullptr;   // [#materials*2*(fConvEnergyGridSize+fCompEnergyGridSize+fGNucEnergyGridSize)]
 
+//// === Macroscopic cross section related data:
+  // The 100 eV 100 TeV kinetic energy range is divided up to 3 kinetic energy window. At a discrete kinetic
+  // energy point, the following macroscopic cross section data are stored:
+  // - window 0: 100 eV - 150 keV; only 1 data stored at each E_i
+  //   1. the Compton scattering mac. xsec. (as PE is not smooth in this region)
+  //   note: the total mac. xsec. is the sum of 1. above plus the PE mac. xsec. as Conversion and Gamma-Nuclear
+  //         are zero in this energy window
+  // - window 1: 150 keV - 2mc^2; 2 data are stored at at each E_i
+  //    1. the sum of the Compton and PE mac. xsec
+  //    2. and the PE mac. xsec alone
+  //    note: conversion is still zero in this energy window and gamma-nuclear is assumed to be zero (very small)
+  //          so 1. above is the total mac. xsec.
+  // - window 2: 2mc^2 - 100 TeV; 4 data are stored at each E_i
+  //    1. the sum of Conversion, Compton, PE, Gamma-Nuclear (GN) mac. xsec.
+  //    2. the Conversion mac. xsec.
+  //    3. the Compton mac. xsec.
+  //    4. the PE mac. xsec.
+  //    note: 1. above is the total mac. xsec.
+  // NOTE: the total mac. xsec. can be used to determine how far the gamma goes till the next interaction while
+  //       the additional mac. xsec. data are sufficient (togeter with the total) to determine the interaction
+  //       at that point (if any)
+  //
+  // these grid densities provide a relativ error less than 0.5 %
+  const int     fEGridSize0 =   32;
+  const int     fEGridSize1 =   32;
+  const int     fEGridSize2 =  256;
+
+  int           fDataPerMat =   0;    // #data for one material in the fMacXsecData array
+  int           fNumData0   =   0;    // #data for one material related to the first  (0th) ekin window
+  int           fNumData1   =   0;    // #data for one material related to the second (1th) ekinwindow
+
+  double        fEMin0      = 0.0;     // minimum kinetic energy of the first window (100.0*CLHEP::eV)
+  double        fEMax0      = 0.0;     // minimum kinetic energy of the second window (150.0*CLHEP::eV)
+  double        fLogEMin0   = 0.0;     // =  0.021759358706830;  // log(fEMin0)
+  double        fEILDelta0  = 0.0;     // =  13.85950970842557;  // 1./[log(fEMax0/fEMin0)/(fEGridSize0-1)]
+
+  // double        fEMin1  --> fEMax0
+  double        fEMax1      = 0.0;
+  double        fLogEMin1   = 0.0;
+  double        fEILDelta1  = 0.0;
+
+  // double        fEMin2  --> fEMax1
+  double        fEMax2      = 0.0;
+  double        fLogEMin2   = 0.0;
+  double        fEILDelta2  = 0.0;
+
+  double*       fMacXsecData; // [#materials x fDataPerMat]
+
+
 
 //// === element selector for conversion (note: KN compton interaction do not know anything about Z)
   int           fElemSelectorConvEgridSize = 0;

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -15,10 +15,6 @@ G4HepEmGammaData* MakeGammaData() {
 
 void FreeGammaData (struct G4HepEmGammaData** theGammaData)  {
   if (*theGammaData != nullptr) {
-    delete[] (*theGammaData)->fConvEnergyGrid ;
-    delete[] (*theGammaData)->fCompEnergyGrid;
-    delete[] (*theGammaData)->fGNucEnergyGrid;
-    delete[] (*theGammaData)->fConvCompGNucMacXsecData;
     delete[] (*theGammaData)->fMacXsecData;
     delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
     delete[] (*theGammaData)->fElemSelectorConvEgrid;

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -42,28 +42,12 @@ void CopyGammaDataToDevice(struct G4HepEmGammaData* onHOST, struct G4HepEmGammaD
   struct G4HepEmGammaData* gmDataHTo_d = new G4HepEmGammaData;
   // Set non-pointer members via a memcpy of the entire structure.
   memcpy(gmDataHTo_d, onHOST, sizeof(G4HepEmGammaData));
-  // get and set number of materials
+  // get and set number of macroscopic cross section data
   int numHepEmMat = onHOST->fNumMaterials;
-  // -- go for the conversion related data
-  int numConvData = onHOST->fConvEnergyGridSize;
-  // allocate memory on _d for the conversion energy grid and copy them form _h
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fConvEnergyGrid), sizeof( double ) * numConvData ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fConvEnergyGrid,  onHOST->fConvEnergyGrid, sizeof( double ) * numConvData, cudaMemcpyHostToDevice ) );
-  // -- go for the Compton related data
-  int numCompData = onHOST->fCompEnergyGridSize;
-  // allocate memory on _d for the Compton energy grid and copy them form _h
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fCompEnergyGrid), sizeof( double ) * numCompData ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fCompEnergyGrid,  onHOST->fCompEnergyGrid, sizeof( double ) * numCompData, cudaMemcpyHostToDevice ) );
-  // -- go for the gamma-nuclear related data
-  int numGNucData = onHOST->fGNucEnergyGridSize;
-  // allocate memory on _d for the gamma-nuclear energy grid and copy them form _h
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fGNucEnergyGrid), sizeof( double ) * numGNucData ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fGNucEnergyGrid,  onHOST->fGNucEnergyGrid, sizeof( double ) * numGNucData, cudaMemcpyHostToDevice ) );
-  // allocate memory on _d for the conversion and Compton macroscopic x-section data and copy them form _h
-  int numConvCompGNucData = numHepEmMat*2*(numConvData+numCompData+numGNucData);
-  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fConvCompGNucMacXsecData), sizeof( double ) * numConvCompGNucData ) );
-  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fConvCompGNucMacXsecData,  onHOST->fConvCompGNucMacXsecData, sizeof( double ) * numConvCompGNucData, cudaMemcpyHostToDevice ) );
-  //
+  int numMacXsecData =  numHepEmMat * onHOST->fDataPerMat;
+  // allocate memory on _d for the macroscopic cross section data and copy them form _h
+  gpuErrchk ( cudaMalloc ( &(gmDataHTo_d->fMacXsecData), sizeof( double ) * numMacXsecData ) );
+  gpuErrchk ( cudaMemcpy (   gmDataHTo_d->fMacXsecData,  onHOST->fMacXsecData, sizeof( double ) * numMacXsecData, cudaMemcpyHostToDevice ) );
   // -- go for the conversion element selector related data
   int numElSelE   = onHOST->fElemSelectorConvEgridSize;
   int numElSelDat = onHOST->fElemSelectorConvNumData;
@@ -94,11 +78,8 @@ void FreeGammaDataOnDevice(struct G4HepEmGammaData** onDEVICE) {
     // side dynamically allocated memories
     struct G4HepEmGammaData* onHostTo_d = new G4HepEmGammaData;
     gpuErrchk ( cudaMemcpy( onHostTo_d, *onDEVICE, sizeof( struct G4HepEmGammaData ), cudaMemcpyDeviceToHost ) );
-    // conversion, Compton and gamma-nuclear macroscopic x-section related data
-    cudaFree( onHostTo_d->fConvEnergyGrid );
-    cudaFree( onHostTo_d->fCompEnergyGrid );
-    cudaFree( onHostTo_d->fGNucEnergyGrid );
-    cudaFree( onHostTo_d->fConvCompGNucMacXsecData );
+    // total, conversion, Compton, PE macroscopic x-section related data
+    cudaFree( onHostTo_d->fMacXsecData );
     // conversion element selector related data
     cudaFree( onHostTo_d->fElemSelectorConvStartIndexPerMat );
     cudaFree( onHostTo_d->fElemSelectorConvEgrid );

--- a/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmGammaData.cc
@@ -19,6 +19,7 @@ void FreeGammaData (struct G4HepEmGammaData** theGammaData)  {
     delete[] (*theGammaData)->fCompEnergyGrid;
     delete[] (*theGammaData)->fGNucEnergyGrid;
     delete[] (*theGammaData)->fConvCompGNucMacXsecData;
+    delete[] (*theGammaData)->fMacXsecData;
     delete[] (*theGammaData)->fElemSelectorConvStartIndexPerMat;
     delete[] (*theGammaData)->fElemSelectorConvEgrid;
     delete[] (*theGammaData)->fElemSelectorConvData;

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -745,32 +745,27 @@ namespace nlohmann
          * stored in the G4HepEmMaterialData::fMaterialData array. */
         j["fNumMaterials"] = d->fNumMaterials;
 
-        //// === conversion related data. Grid: 146 bins form 2mc^2 - 100 TeV
-        j["fConvLogMinEkin"] = d->fConvLogMinEkin;
-        j["fConvEILDelta"]   = d->fConvEILDelta;
-        j["fConvEnergyGrid"] =
-          make_span(d->fConvEnergyGridSize, d->fConvEnergyGrid);
+        //// === Macroscopic cross section related data:
+        j["fDataPerMat"] = d->fDataPerMat;
+        j["fNumData0"] = d->fNumData0;
+        j["fNumData1"] = d->fNumData1;
 
-        //// === compton related data. 84 bins (7 per decades) from 100 eV - 100
-        /// TeV
-        j["fCompLogMinEkin"] = d->fCompLogMinEkin;
-        j["fCompEILDelta"]   = d->fCompEILDelta;
-        j["fCompEnergyGrid"] =
-          make_span(d->fCompEnergyGridSize, d->fCompEnergyGrid);
+        j["fEMin0"] = d->fEMin0;
+        j["fEMax0"] = d->fEMax0;
+        j["fLogEMin0"] = d->fLogEMin0;
+        j["fEILDelta0"] = d->fEILDelta0;
 
-        //// === compton related data. 84 bins (7 per decades) from 100 eV - 100
-        /// TeV
-        j["fGNucLogMinEkin"] = d->fGNucLogMinEkin;
-        j["fGNucEILDelta"]   = d->fGNucEILDelta;
-        j["fGNucEnergyGrid"] =
-          make_span(d->fGNucEnergyGridSize, d->fGNucEnergyGrid);
+        j["fEMax1"] = d->fEMax1;
+        j["fLogEMin1"] = d->fLogEMin1;
+        j["fEILDelta1"] = d->fEILDelta1;
 
+        j["fEMax2"] = d->fEMax2;
+        j["fLogEMin2"] = d->fLogEMin2;
+        j["fEILDelta2"] = d->fEILDelta2;
 
-        const int macXsecDataSize =
-          d->fNumMaterials * 2 *
-          (d->fConvEnergyGridSize + d->fCompEnergyGridSize + d->fGNucEnergyGridSize);
-        j["fConvCompGNucMacXsecData"] =
-          make_span(macXsecDataSize, d->fConvCompGNucMacXsecData);
+        const int macXsecDataSize = d->fNumMaterials*d->fDataPerMat;
+        j["fMacXsecData"] =make_span(macXsecDataSize, d->fMacXsecData);
+
 
         //// === element selector for conversion (note: KN compton interaction
         /// do not know anything about Z)
@@ -800,36 +795,29 @@ namespace nlohmann
 
         j.at("fNumMaterials").get_to(d->fNumMaterials);
 
-        j.at("fConvLogMinEkin").get_to(d->fConvLogMinEkin);
-        j.at("fConvEILDelta").get_to(d->fConvEILDelta);
-        // Get the array but ignore the size (fConvEnergyGridSize) as this is a
-        // const (at time of writing)
-        auto tmpConvEnergyGrid =
-          j.at("fConvEnergyGrid").get<dynamic_array<double>>();
-        d->fConvEnergyGrid = tmpConvEnergyGrid.data;
 
-        j.at("fCompLogMinEkin").get_to(d->fCompLogMinEkin);
-        j.at("fCompEILDelta").get_to(d->fCompEILDelta);
-        // Get the array but ignore the size (fCompEnergyGridSize) as this is a
-        // const (at time of writing)
-        auto tmpCompEnergyGrid =
-          j.at("fCompEnergyGrid").get<dynamic_array<double>>();
-        d->fCompEnergyGrid = tmpCompEnergyGrid.data;
+        j.at("fDataPerMat").get_to(d->fDataPerMat);
+        j.at("fNumData0").get_to(d->fNumData0);
+        j.at("fNumData1").get_to(d->fNumData1);
 
-        j.at("fGNucLogMinEkin").get_to(d->fGNucLogMinEkin);
-        j.at("fGNucEILDelta").get_to(d->fGNucEILDelta);
-        // Get the array but ignore the size (fGNucEnergyGridSize) as this is a
-        // const (at time of writing)
-        auto tmpGNucEnergyGrid =
-          j.at("fGNucEnergyGrid").get<dynamic_array<double>>();
-        d->fGNucEnergyGrid = tmpGNucEnergyGrid.data;
+        j.at("fEMin0").get_to(d->fEMin0 );
+        j.at("fEMax0").get_to(d->fEMax0);
+        j.at("fLogEMin0").get_to(d->fLogEMin0);
+        j.at("fEILDelta0").get_to(d->fEILDelta0);
+
+        j.at("fEMax1").get_to(d->fEMax1);
+        j.at("fLogEMin1").get_to(d->fLogEMin1);
+        j.at("fEILDelta1").get_to(d->fEILDelta1);
+
+        j.at("fEMax2").get_to(d->fEMax2);
+        j.at("fLogEMin2").get_to(d->fLogEMin2);
+        j.at("fEILDelta2").get_to(d->fEILDelta2);
 
         // We don't store the size of the following array, rather should
-        // validate that it is expected size: d->fNumMaterials * 2 *
-        // (d->fConvEnergyGridSize + d->fCompEnergyGridSize + d->fGNucEnergyGridSize);
-        auto tmpConvCompGNucXsecData =
-          j.at("fConvCompGNucMacXsecData").get<dynamic_array<double>>();
-        d->fConvCompGNucMacXsecData = tmpConvCompGNucXsecData.data;
+        // validate that it is expected size: d->fNumMaterials * d->fDataPerMat
+        auto tmpMacXsecData = j.at("fMacXsecData").get<dynamic_array<double>>();
+        d->fMacXsecData = tmpMacXsecData.data;
+
 
         j.at("fElemSelectorConvLogMinEkin")
           .get_to(d->fElemSelectorConvLogMinEkin);

--- a/G4HepEm/G4HepEmInit/include/G4HepEmGammaTableBuilder.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmGammaTableBuilder.hh
@@ -21,4 +21,6 @@ void BuildLambdaTables(G4PairProductionRelModel* ppModel, G4KleinNishinaCompton*
 
 void BuildElementSelectorTables(G4PairProductionRelModel* ppModel, struct G4HepEmData* hepEmData);
 
+double GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin);
+
 #endif // G4HepEmGammaTableBuilder_HH

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -43,13 +43,13 @@ public:
 
   G4HepEmHostDevice
   static double
-  GetTotalMacXSec(struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack);
+  GetTotalMacXSec(const struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack);
 
-  static void SelectInteraction(struct G4HepEmData* hepEmData, G4HepEmTLData* tlData);
+  static void SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData);
 
   G4HepEmHostDevice
   static void
-  SampleInteraction(struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd);
+  SampleInteraction(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd);
 
   G4HepEmHostDevice
   static double GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -43,16 +43,16 @@ public:
 
   G4HepEmHostDevice
   static double
-  GetTotalMacXSec(const struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack);
+  GetTotalMacXSec(const struct G4HepEmGammaData* gmData, const struct G4HepEmMaterialData* matData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack);
 
   static void SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData);
 
   G4HepEmHostDevice
   static void
-  SampleInteraction(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd);
+  SampleInteraction(const G4HepEmGammaData* gmData, G4HepEmGammaTrack* theGammaTrack, double ekin, double lekin, int imat, const double urnd);
 
   G4HepEmHostDevice
-  static double GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin);
+  static double GetMacXSecPE(const struct G4HepEmMaterialData* theMatData, const int imat, const double ekin);
 
 };
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -41,10 +41,15 @@ public:
   G4HepEmHostDevice
   static void UpdateNumIALeft(G4HepEmTrack* theTrack);
 
+  G4HepEmHostDevice
+  static double
+  GetTotalMacXSec(struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack);
+
+  static void SelectInteraction(struct G4HepEmData* hepEmData, G4HepEmTLData* tlData);
 
   G4HepEmHostDevice
-  static double GetMacXSec(const struct G4HepEmGammaData* gmData, const int imat, const double ekin,
-                           const double lekin, const int iprocess);
+  static void
+  SampleInteraction(struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd);
 
   G4HepEmHostDevice
   static double GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin);

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.hh
@@ -43,16 +43,16 @@ public:
 
   G4HepEmHostDevice
   static double
-  GetTotalMacXSec(const struct G4HepEmGammaData* gmData, const struct G4HepEmMaterialData* matData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack);
+  GetTotalMacXSec(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack);
+
+  G4HepEmHostDevice
+  static double GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin);
 
   static void SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData);
 
   G4HepEmHostDevice
   static void
-  SampleInteraction(const G4HepEmGammaData* gmData, G4HepEmGammaTrack* theGammaTrack, double ekin, double lekin, int imat, const double urnd);
-
-  G4HepEmHostDevice
-  static double GetMacXSecPE(const struct G4HepEmMaterialData* theMatData, const int imat, const double ekin);
+  SampleInteraction(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd);
 
 };
 

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -28,10 +28,8 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
   G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
   G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
   // Sample the `number-of-interaction-left`
-  for (int ip=0; ip<4; ++ip) {
-    if (theTrack->GetNumIALeft(ip)<=0.) {
-      theTrack->SetNumIALeft(-G4HepEmLog(tlData->GetRNGEngine()->flat()), ip);
-    }
+  if (theTrack->GetNumIALeft(0) <= 0.0) {
+    theTrack->SetNumIALeft(-G4HepEmLog(tlData->GetRNGEngine()->flat()), 0);
   }
   HowFar(hepEmData, hepEmPars, theGammaTrack);
 }
@@ -44,42 +42,21 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
   const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
   // get the Gamma data from the op level data structure
   const G4HepEmGammaData* theGammaData = hepEmData->fTheGammaData;
-  // === Gamma has only discrete limits due to Conversion, Compton, and the photoelectric effect.
-  double mxSecs[4];
-  // conversion, compton and photoelectric
-  mxSecs[0] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 0);
-  mxSecs[1] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 1);
-  mxSecs[2] = GetMacXSecPE(hepEmData, theMatIndx, theEkin);
-  mxSecs[3] = GetMacXSec(theGammaData, theMatIndx, theEkin, theLEkin, 2);
-  // Remember value of photoelectric effect, needed for selecting the element.
-  theGammaTrack->SetPEmxSec(mxSecs[2]);
-  // compute mfp and see if we need to sample the `number-of-interaction-left`
-  // before we use it to get the current discrete proposed step length
-  int indxWinnerProcess = -1;             // init to nothing
-  double pStepLength    = kALargeValue;   // init to a large value
-  for (int ip=0; ip<4; ++ip) {
-    const double mxsec = mxSecs[ip];
-    const double   mfp = (mxsec>0.) ? 1./mxsec : kALargeValue;
-    // save the mac-xsec for the update of the `number-of-interaction-left`:
-    // the `number-of-intercation-left` should be updated in the along-step-action
-    theTrack->SetMFP(mfp, ip);
-    // sample the proposed step length
-    const double dStepLimit = mfp*theTrack->GetNumIALeft(ip);
-    // std::cout << " ip = " << ip << " mxsec = " << mxsec << " dStepLimit = " << dStepLimit << std::endl;
-    if (dStepLimit<pStepLength) {
-      pStepLength = dStepLimit;
-      indxWinnerProcess = ip;
-    }
-  }
-//  std::cout << "indxWinnerProcess = " << indxWinnerProcess <<  " dStepLimit = " << pStepLength << std::endl;
-  //
-  // the geometrical and physical step lengths are the same for gamma
-  theTrack->SetGStepLength(pStepLength);
-  theTrack->SetWinnerProcessIndex(indxWinnerProcess);
-  //
+
+  // get the total macroscopic cross section and use this to sample the actual step length
+  // (till any of the possible discrete interactions: conversion, compton, photoelectric, gamma-nuclear)
+  const double totMXSec = GetTotalMacXSec(hepEmData, theMatIndx, theEkin, theLEkin, theGammaTrack);
+  const double totalMFP = (totMXSec>0.) ? 1./totMXSec : kALargeValue;
+  // save the mac-xsec for the update of the `number-of-interaction-left`:
+  theTrack->SetMFP(totalMFP, 0);
+  // sample the proposed step length
+  theTrack->SetGStepLength(totalMFP*theTrack->GetNumIALeft(0));
 }
 
 
+// NOTE: `SampleInteraction` needs to be invoked before that will set the winner process ID of the trimary track.
+//        This is not invoked here inside as it might be possible that gamma-nuclear happens in which case the caller
+//        needs to perfrom the interaction.
 void G4HepEmGammaManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmTLData* tlData) {
   G4HepEmTrack* theTrack = tlData->GetPrimaryGammaTrack()->GetTrack();
   // === 1. The `number-of-interaction-left` needs to be updated based on the actual
@@ -94,10 +71,10 @@ void G4HepEmGammaManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmP
   if (theTrack->GetOnBoundary()) {
     return;
   }
+
   // reset number of interaction left for the winner discrete process
   const int iDProc = theTrack->GetWinnerProcessIndex();
   theTrack->SetNumIALeft(-1.0, iDProc);
-//  std::cout<< " --- iDProc = " << iDProc << std::endl;
   //
   // perform the discrete part of the winner interaction
   switch (iDProc) {
@@ -119,41 +96,107 @@ void G4HepEmGammaManager::Perform(struct G4HepEmData* hepEmData, struct G4HepEmP
 
 void   G4HepEmGammaManager::UpdateNumIALeft(G4HepEmTrack* theTrack) {
   const double pStepLength = theTrack->GetGStepLength();
-  double*    numInterALeft = theTrack->GetNumIALeft();
+  // NOTE: only one `number of interaction length left` is used from now on
+  //       for gamma that is the total, i.e. including all possible interactions,
+  //       and the MFP[0] is the total MFP
   double*       preStepMFP = theTrack->GetMFP();
+  double*    numInterALeft = theTrack->GetNumIALeft();
   numInterALeft[0] -= pStepLength/preStepMFP[0];
-  numInterALeft[1] -= pStepLength/preStepMFP[1];
-  numInterALeft[2] -= pStepLength/preStepMFP[2];
-  numInterALeft[3] -= pStepLength/preStepMFP[3];
 }
 
 
-double  G4HepEmGammaManager::GetMacXSec(const struct G4HepEmGammaData* gmData, const int imat, const double ekin, const double lekin, const int iprocess) {
-  // get number of Conversion and Compton discrete energy grid points
-  const int numConvData = gmData->fConvEnergyGridSize;
-  const int numCompData = gmData->fCompEnergyGridSize;
-  const int numGNucData = gmData->fGNucEnergyGridSize;
-  const int      iStart = imat*2*(numConvData + numCompData + numGNucData);
-  // use the G4HepEmRunUtils GetSplineLog function for interpolation
-  switch (iprocess) {
-    case 0: { // Conversion
-              return ekin > gmData->fConvEnergyGrid[0]
-                     ? G4HepEmMax(0.0, GetSplineLog(numConvData, gmData->fConvEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart]) , ekin, lekin, gmData->fConvLogMinEkin, gmData->fConvEILDelta))
-                     : 0.0;
-            }
-    case 1: { // Compton
-              return G4HepEmMax(0.0, GetSplineLog(numCompData, gmData->fCompEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*numConvData]) , ekin, lekin, gmData->fCompLogMinEkin, gmData->fCompEILDelta));
-            }
-    case 2: { // Gamma-nuclear
-              return ekin > gmData->fGNucEnergyGrid[0]
-                    ? G4HepEmMax(0.0, GetSplineLog(numGNucData, gmData->fGNucEnergyGrid, &(gmData->fConvCompGNucMacXsecData[iStart+2*(numConvData+numCompData)]) , ekin, lekin, gmData->fGNucLogMinEkin, gmData->fGNucEILDelta))
-                    : 0.0;
-            }
+double  G4HepEmGammaManager::GetTotalMacXSec(struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack) {
+  const G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+  // find the kinetic energy window for the given `ekin` and
 
-    default:
-            return 0.0;
+  if (ekin > gmData->fEMax1) {
+    // window 2: ekin \in [2mc^2,100 TeV]; spline with 4 `y_i` values and their second derivatives at each `E_i`
+    // The total macroscopic ross section is the first `y` value so `iwhich=1`
+    const int ndata  = gmData->fEGridSize2;
+    const int istart = imat*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
+    return GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin2, gmData->fEILDelta2, 1);
   }
+
+  // NOTE: in case of window 0 and 1, the macroscopic cross section for PE is stored in the track that is used:
+  //       - to sample the interaction (Compton or PE if any) at the post step point (in `SampleInteraction` below)
+  //       - if PE interactin happens, then used to sample the target atom in the mnodel
+  //       While in case of window 2 above, the macroscopic corss section for PE is set in the track when sampling
+  //       the interaction and only if PE happens.
+  if (ekin > gmData->fEMax0) {
+    // window 1: ekin in [150 keV, 2mc^2]; linear interpolation with 2 `y_i` values at each `E_i`
+    // The total macroscopic cross sectino is the first `y` value so `iwhich=1`
+    const int ndata  = gmData->fEGridSize1;
+    const int istart = imat*gmData->fDataPerMat + gmData->fNumData0; // start of data for this material and this energy window
+    // might be better to interpolate both in this case and set the PEmxSec here
+    double mx[2]; // [total mac. xsec, PE mac. xsec]
+    GetLinearLog2(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin1, gmData->fEILDelta1, mx);
+    theGammaTrack->SetPEmxSec(mx[1]);
+    return mx[0];
+  }
+
+  // window 1: ekin in [100 eV, 150 keV]; linear interpolation with one `y_i` values at each `E_i`
+  //           which is not the total, but only the Compton scattering cross section so interpolate
+  //           that and add the PE cross section (also stores the PE cross section in the track
+  //           that can be used to select the interaction in this case)
+  const int  ndata  = gmData->fEGridSize0;
+  const int  istart = imat*gmData->fDataPerMat; // start of data for this material and this energy window
+  const double comp = GetLinearLog(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin0, gmData->fEILDelta0);
+  const double   pe = G4HepEmMax(0.0, GetMacXSecPE(hepEmData, imat, ekin));
+  theGammaTrack->SetPEmxSec(pe);
+  return comp+pe;
 }
+
+
+void G4HepEmGammaManager::SelectInteraction(struct G4HepEmData* hepEmData, G4HepEmTLData* tlData) {
+  G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
+  // selected interactin ID will be set into the track as the winner process index
+  // and number of interaction length left will be reset to -1.0
+  SampleInteraction(hepEmData, theGammaTrack, tlData->GetRNGEngine()->flat());
+}
+
+
+// Sample the discrete interaction that happens at the post setp point and sets the track filed
+// Also sets the PE macroscopic cross section in the gamma track if PE happens (garbage othewise)
+// pid = 0 --> Conversion
+// pid = 1 --> Compton scattering
+// pid = 2 --> Photoelectric effect
+// pid = 3 --> Gamma nuclear interaction
+void G4HepEmGammaManager::SampleInteraction(struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd) {
+  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
+  const double  theTMFP  = theTrack->GetMFP(0);       // only the total mean free path is stored (and that at[0])
+  const double   theEkin = theTrack->GetEKin();
+
+  // reset it as interaction will happen so we need to re-sample the number of ia left at the
+  // beginning of the next step
+  theTrack->SetNumIALeft(-1.0, 0);
+
+  G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+  if (theEkin > gmData->fEMax1) {
+    const double lekin = theTrack->GetLogEKin();
+    const int     imat = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
+    const int   ndata  = gmData->fEGridSize2;
+    const int   istart = imat*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
+
+    double mxSec = 0.0;
+    double cProb = 0.0;
+    int pid = 2; // the real pid is pid-2
+    do {
+      mxSec  = GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), theEkin, lekin, gmData->fLogEMin2, gmData->fEILDelta2, pid);
+      cProb += mxSec*theTMFP;
+      ++pid;
+    } while (pid<6 && urnd>cProb);
+    theTrack->SetWinnerProcessIndex(pid-3); // -3 because at the end ++pid
+    theGammaTrack->SetPEmxSec(mxSec);
+    return;
+  }
+
+  // Below the 2 electron mass kinetic energy limit:
+  // Only Compton or PE possible and mac. xsec. for PE is already in the track
+  const double mxPE = theGammaTrack->GetPEmxSec();
+  const int pid = (urnd > theTMFP*mxPE) ? 1:2;
+  theTrack->SetWinnerProcessIndex(pid);
+}
+
 
 double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin) {
   const G4HepEmMatData* matData = &hepEmData->fTheMaterialData->fMaterialData[imat];

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -105,7 +105,7 @@ void   G4HepEmGammaManager::UpdateNumIALeft(G4HepEmTrack* theTrack) {
 }
 
 
-double  G4HepEmGammaManager::GetTotalMacXSec(struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack) {
+double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack) {
   const G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
   // find the kinetic energy window for the given `ekin` and
 
@@ -147,7 +147,7 @@ double  G4HepEmGammaManager::GetTotalMacXSec(struct G4HepEmData* hepEmData, cons
 }
 
 
-void G4HepEmGammaManager::SelectInteraction(struct G4HepEmData* hepEmData, G4HepEmTLData* tlData) {
+void G4HepEmGammaManager::SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData) {
   G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
   // selected interactin ID will be set into the track as the winner process index
   // and number of interaction length left will be reset to -1.0
@@ -161,7 +161,7 @@ void G4HepEmGammaManager::SelectInteraction(struct G4HepEmData* hepEmData, G4Hep
 // pid = 1 --> Compton scattering
 // pid = 2 --> Photoelectric effect
 // pid = 3 --> Gamma nuclear interaction
-void G4HepEmGammaManager::SampleInteraction(struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd) {
+void G4HepEmGammaManager::SampleInteraction(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd) {
   G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
   const double  theTMFP  = theTrack->GetMFP(0);       // only the total mean free path is stored (and that at[0])
   const double   theEkin = theTrack->GetEKin();

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -40,12 +40,9 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
   const double   theEkin = theTrack->GetEKin();
   const double  theLEkin = theTrack->GetLogEKin();
   const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
-  // get the Gamma data from the op level data structure
-  const G4HepEmGammaData* theGammaData = hepEmData->fTheGammaData;
-
   // get the total macroscopic cross section and use this to sample the actual step length
   // (till any of the possible discrete interactions: conversion, compton, photoelectric, gamma-nuclear)
-  const double totMXSec = GetTotalMacXSec(hepEmData, theMatIndx, theEkin, theLEkin, theGammaTrack);
+  const double totMXSec = GetTotalMacXSec(hepEmData->fTheGammaData, hepEmData->fTheMaterialData, theMatIndx, theEkin, theLEkin, theGammaTrack);
   const double totalMFP = (totMXSec>0.) ? 1./totMXSec : kALargeValue;
   // save the mac-xsec for the update of the `number-of-interaction-left`:
   theTrack->SetMFP(totalMFP, 0);
@@ -105,10 +102,8 @@ void   G4HepEmGammaManager::UpdateNumIALeft(G4HepEmTrack* theTrack) {
 }
 
 
-double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmData* hepEmData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack) {
-  const G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmGammaData* gmData, const struct G4HepEmMaterialData* matData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack) {
   // find the kinetic energy window for the given `ekin` and
-
   if (ekin > gmData->fEMax1) {
     // window 2: ekin \in [2mc^2,100 TeV]; spline with 4 `y_i` values and their second derivatives at each `E_i`
     // The total macroscopic ross section is the first `y` value so `iwhich=1`
@@ -141,7 +136,7 @@ double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmData* hepEmData
   const int  ndata  = gmData->fEGridSize0;
   const int  istart = imat*gmData->fDataPerMat; // start of data for this material and this energy window
   const double comp = GetLinearLog(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin0, gmData->fEILDelta0);
-  const double   pe = G4HepEmMax(0.0, GetMacXSecPE(hepEmData, imat, ekin));
+  const double   pe = G4HepEmMax(0.0, GetMacXSecPE(matData, imat, ekin));
   theGammaTrack->SetPEmxSec(pe);
   return comp+pe;
 }
@@ -149,9 +144,14 @@ double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmData* hepEmData
 
 void G4HepEmGammaManager::SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData) {
   G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
+  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
+  const double   theEkin = theTrack->GetEKin();
+  const double  theLEkin = theTrack->GetLogEKin();
+  const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
+  G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
   // selected interactin ID will be set into the track as the winner process index
   // and number of interaction length left will be reset to -1.0
-  SampleInteraction(hepEmData, theGammaTrack, tlData->GetRNGEngine()->flat());
+  SampleInteraction(gmData, theGammaTrack,  theEkin, theLEkin, theMatIndx, tlData->GetRNGEngine()->flat());
 }
 
 
@@ -161,19 +161,14 @@ void G4HepEmGammaManager::SelectInteraction(const struct G4HepEmData* hepEmData,
 // pid = 1 --> Compton scattering
 // pid = 2 --> Photoelectric effect
 // pid = 3 --> Gamma nuclear interaction
-void G4HepEmGammaManager::SampleInteraction(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd) {
+void G4HepEmGammaManager::SampleInteraction(const G4HepEmGammaData* gmData, G4HepEmGammaTrack* theGammaTrack, double ekin, double lekin, int imat, const double urnd) {
   G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
   const double  theTMFP  = theTrack->GetMFP(0);       // only the total mean free path is stored (and that at[0])
-  const double   theEkin = theTrack->GetEKin();
-
   // reset it as interaction will happen so we need to re-sample the number of ia left at the
   // beginning of the next step
   theTrack->SetNumIALeft(-1.0, 0);
 
-  G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
-  if (theEkin > gmData->fEMax1) {
-    const double lekin = theTrack->GetLogEKin();
-    const int     imat = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
+  if (ekin > gmData->fEMax1) {
     const int   ndata  = gmData->fEGridSize2;
     const int   istart = imat*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
 
@@ -181,7 +176,7 @@ void G4HepEmGammaManager::SampleInteraction(const struct G4HepEmData* hepEmData,
     double cProb = 0.0;
     int pid = 2; // the real pid is pid-2
     do {
-      mxSec  = GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), theEkin, lekin, gmData->fLogEMin2, gmData->fEILDelta2, pid);
+      mxSec  = GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin2, gmData->fEILDelta2, pid);
       cProb += mxSec*theTMFP;
       ++pid;
     } while (pid<6 && urnd>cProb);
@@ -198,8 +193,8 @@ void G4HepEmGammaManager::SampleInteraction(const struct G4HepEmData* hepEmData,
 }
 
 
-double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin) {
-  const G4HepEmMatData* matData = &hepEmData->fTheMaterialData->fMaterialData[imat];
+double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmMaterialData* theMatData, const int imat, const double ekin) {
+  const G4HepEmMatData* matData = &theMatData->fMaterialData[imat];
   int interval = 0;
   if (ekin >= matData->fSandiaEnergies[0]) {
     // Optimization: linear search starting with intervals for higher energies.

--- a/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmGammaManager.icc
@@ -37,12 +37,9 @@ void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmPa
 
 void G4HepEmGammaManager::HowFar(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, G4HepEmGammaTrack* theGammaTrack) {
   G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
-  const double   theEkin = theTrack->GetEKin();
-  const double  theLEkin = theTrack->GetLogEKin();
-  const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
   // get the total macroscopic cross section and use this to sample the actual step length
   // (till any of the possible discrete interactions: conversion, compton, photoelectric, gamma-nuclear)
-  const double totMXSec = GetTotalMacXSec(hepEmData->fTheGammaData, hepEmData->fTheMaterialData, theMatIndx, theEkin, theLEkin, theGammaTrack);
+  const double totMXSec = GetTotalMacXSec(hepEmData, theGammaTrack);
   const double totalMFP = (totMXSec>0.) ? 1./totMXSec : kALargeValue;
   // save the mac-xsec for the update of the `number-of-interaction-left`:
   theTrack->SetMFP(totalMFP, 0);
@@ -102,99 +99,55 @@ void   G4HepEmGammaManager::UpdateNumIALeft(G4HepEmTrack* theTrack) {
 }
 
 
-double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmGammaData* gmData, const struct G4HepEmMaterialData* matData, const int imat, const double ekin, const double lekin, G4HepEmGammaTrack* theGammaTrack) {
-  // find the kinetic energy window for the given `ekin` and
-  if (ekin > gmData->fEMax1) {
+double  G4HepEmGammaManager::GetTotalMacXSec(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack) {
+  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
+  const double   theEkin = theTrack->GetEKin();
+  const double  theLEkin = theTrack->GetLogEKin();
+  const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
+  // get the G4HepEmGammaData
+  const G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+  // find the kinetic energy window for the given `ekin`:
+  // most common case first: ekin > 2m_ec^2
+  if (theEkin > gmData->fEMax1) {
     // window 2: ekin \in [2mc^2,100 TeV]; spline with 4 `y_i` values and their second derivatives at each `E_i`
     // The total macroscopic ross section is the first `y` value so `iwhich=1`
     const int ndata  = gmData->fEGridSize2;
-    const int istart = imat*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
-    return GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin2, gmData->fEILDelta2, 1);
+    const int istart = theMatIndx*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
+    return GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), theEkin, theLEkin, gmData->fLogEMin2, gmData->fEILDelta2, 1);
   }
 
-  // NOTE: in case of window 0 and 1, the macroscopic cross section for PE is stored in the track that is used:
+  // NOTE: in case of window 1 and 0, the macroscopic cross section for PE is stored in the track that is used:
   //       - to sample the interaction (Compton or PE if any) at the post step point (in `SampleInteraction` below)
   //       - if PE interactin happens, then used to sample the target atom in the mnodel
   //       While in case of window 2 above, the macroscopic corss section for PE is set in the track when sampling
   //       the interaction and only if PE happens.
-  if (ekin > gmData->fEMax0) {
+  if (theEkin > gmData->fEMax0) {
     // window 1: ekin in [150 keV, 2mc^2]; linear interpolation with 2 `y_i` values at each `E_i`
     // The total macroscopic cross sectino is the first `y` value so `iwhich=1`
     const int ndata  = gmData->fEGridSize1;
-    const int istart = imat*gmData->fDataPerMat + gmData->fNumData0; // start of data for this material and this energy window
+    const int istart = theMatIndx*gmData->fDataPerMat + gmData->fNumData0; // start of data for this material and this energy window
     // might be better to interpolate both in this case and set the PEmxSec here
     double mx[2]; // [total mac. xsec, PE mac. xsec]
-    GetLinearLog2(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin1, gmData->fEILDelta1, mx);
+    GetLinearLog2(ndata, &(gmData->fMacXsecData[istart]), theEkin, theLEkin, gmData->fLogEMin1, gmData->fEILDelta1, mx);
     theGammaTrack->SetPEmxSec(mx[1]);
     return mx[0];
   }
 
-  // window 1: ekin in [100 eV, 150 keV]; linear interpolation with one `y_i` values at each `E_i`
+  // window 0: ekin in [100 eV, 150 keV]; linear interpolation with one `y_i` values at each `E_i`
   //           which is not the total, but only the Compton scattering cross section so interpolate
   //           that and add the PE cross section (also stores the PE cross section in the track
   //           that can be used to select the interaction in this case)
   const int  ndata  = gmData->fEGridSize0;
-  const int  istart = imat*gmData->fDataPerMat; // start of data for this material and this energy window
-  const double comp = GetLinearLog(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin0, gmData->fEILDelta0);
-  const double   pe = G4HepEmMax(0.0, GetMacXSecPE(matData, imat, ekin));
+  const int  istart = theMatIndx*gmData->fDataPerMat; // start of data for this material and this energy window
+  const double comp = GetLinearLog(ndata, &(gmData->fMacXsecData[istart]), theEkin, theLEkin, gmData->fLogEMin0, gmData->fEILDelta0);
+  const double   pe = G4HepEmMax(0.0, GetMacXSecPE(hepEmData, theMatIndx, theEkin));
   theGammaTrack->SetPEmxSec(pe);
   return comp+pe;
 }
 
 
-void G4HepEmGammaManager::SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData) {
-  G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
-  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
-  const double   theEkin = theTrack->GetEKin();
-  const double  theLEkin = theTrack->GetLogEKin();
-  const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
-  G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
-  // selected interactin ID will be set into the track as the winner process index
-  // and number of interaction length left will be reset to -1.0
-  SampleInteraction(gmData, theGammaTrack,  theEkin, theLEkin, theMatIndx, tlData->GetRNGEngine()->flat());
-}
-
-
-// Sample the discrete interaction that happens at the post setp point and sets the track filed
-// Also sets the PE macroscopic cross section in the gamma track if PE happens (garbage othewise)
-// pid = 0 --> Conversion
-// pid = 1 --> Compton scattering
-// pid = 2 --> Photoelectric effect
-// pid = 3 --> Gamma nuclear interaction
-void G4HepEmGammaManager::SampleInteraction(const G4HepEmGammaData* gmData, G4HepEmGammaTrack* theGammaTrack, double ekin, double lekin, int imat, const double urnd) {
-  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
-  const double  theTMFP  = theTrack->GetMFP(0);       // only the total mean free path is stored (and that at[0])
-  // reset it as interaction will happen so we need to re-sample the number of ia left at the
-  // beginning of the next step
-  theTrack->SetNumIALeft(-1.0, 0);
-
-  if (ekin > gmData->fEMax1) {
-    const int   ndata  = gmData->fEGridSize2;
-    const int   istart = imat*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
-
-    double mxSec = 0.0;
-    double cProb = 0.0;
-    int pid = 2; // the real pid is pid-2
-    do {
-      mxSec  = GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), ekin, lekin, gmData->fLogEMin2, gmData->fEILDelta2, pid);
-      cProb += mxSec*theTMFP;
-      ++pid;
-    } while (pid<6 && urnd>cProb);
-    theTrack->SetWinnerProcessIndex(pid-3); // -3 because at the end ++pid
-    theGammaTrack->SetPEmxSec(mxSec);
-    return;
-  }
-
-  // Below the 2 electron mass kinetic energy limit:
-  // Only Compton or PE possible and mac. xsec. for PE is already in the track
-  const double mxPE = theGammaTrack->GetPEmxSec();
-  const int pid = (urnd > theTMFP*mxPE) ? 1:2;
-  theTrack->SetWinnerProcessIndex(pid);
-}
-
-
-double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmMaterialData* theMatData, const int imat, const double ekin) {
-  const G4HepEmMatData* matData = &theMatData->fMaterialData[imat];
+double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmData* hepEmData, const int imat, const double ekin) {
+  const G4HepEmMatData* matData = &hepEmData->fTheMaterialData->fMaterialData[imat];
   int interval = 0;
   if (ekin >= matData->fSandiaEnergies[0]) {
     // Optimization: linear search starting with intervals for higher energies.
@@ -208,4 +161,53 @@ double G4HepEmGammaManager::GetMacXSecPE(const struct G4HepEmMaterialData* theMa
   const double* sandiaCof = &matData->fSandiaCoefficients[4 * interval];
   const double inv = 1 / ekin;
   return inv * (sandiaCof[0] + inv * (sandiaCof[1] + inv * (sandiaCof[2] + inv * sandiaCof[3])));
+}
+
+
+void G4HepEmGammaManager::SelectInteraction(const struct G4HepEmData* hepEmData, G4HepEmTLData* tlData) {
+  G4HepEmGammaTrack* theGammaTrack = tlData->GetPrimaryGammaTrack();
+  // selected interactin ID will be set into the track as the winner process index
+  // and number of interaction length left will be reset to -1.0
+  SampleInteraction(hepEmData, theGammaTrack, tlData->GetRNGEngine()->flat());
+}
+
+
+// Sample the discrete interaction that happens at the post setp point and sets the track filed
+// Also sets the PE macroscopic cross section in the gamma track if PE happens (garbage othewise)
+// pid = 0 --> Conversion
+// pid = 1 --> Compton scattering
+// pid = 2 --> Photoelectric effect
+// pid = 3 --> Gamma nuclear interaction
+void G4HepEmGammaManager::SampleInteraction(const struct G4HepEmData* hepEmData, G4HepEmGammaTrack* theGammaTrack, const double urnd) {
+  G4HepEmTrack* theTrack = theGammaTrack->GetTrack();
+  const double   theEkin = theTrack->GetEKin();
+  const double  theTMFP  = theTrack->GetMFP(0); // only the total mean free path is stored (and that at[0])
+  // reset num-ia-left as interaction will happen so we need to re-sample it at the beginning of the next step
+  theTrack->SetNumIALeft(-1.0, 0);
+  // get the G4HepEmGammaData
+  const G4HepEmGammaData* gmData = hepEmData->fTheGammaData;
+  // check kinetic energy window: most common case, ekin > 2m_ec^2
+  if (theEkin > gmData->fEMax1) {
+    const double  theLEkin = theTrack->GetLogEKin();
+    const int   theMatIndx = hepEmData->fTheMatCutData->fMatCutData[theTrack->GetMCIndex()].fHepEmMatIndex;
+    const int       ndata  = gmData->fEGridSize2;
+    const int       istart = theMatIndx*gmData->fDataPerMat + gmData->fNumData0 + gmData->fNumData1; // start of data for this material and this energy window
+    double mxSec = 0.0;
+    double cProb = 0.0;
+    int pid = 2; // the real pid is pid-2
+    do {
+      mxSec  = GetSplineLog4(ndata, &(gmData->fMacXsecData[istart]), theEkin, theLEkin, gmData->fLogEMin2, gmData->fEILDelta2, pid);
+      cProb += mxSec*theTMFP;
+      ++pid;
+    } while (pid<6 && urnd>cProb);
+    theTrack->SetWinnerProcessIndex(pid-3); // -3 because at the end ++pid
+    theGammaTrack->SetPEmxSec(mxSec);
+    return;
+  }
+  // Below the 2 electron mass kinetic energy limit:
+  // Only Compton or PE possible and mac. xsec. for PE is already in the track
+  // (was set during the step limit when the total mac. xsec. was calculated)
+  const double mxPE = theGammaTrack->GetPEmxSec();
+  const int pid = (urnd > theTMFP*mxPE) ? 1:2;
+  theTrack->SetWinnerProcessIndex(pid);
 }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.hh
@@ -16,9 +16,13 @@ void RotateToReferenceFrame(double &u, double &v, double &w, const double* refDi
 G4HepEmHostDevice
 void RotateToReferenceFrame(double* dir, const double* refDir);
 
-// get spline interpolation of y(x) between (x1, x2) given y_N = y(x_N), y''N(x_N) 
+// get spline interpolation of y(x) between (x1, x2) given y_N = y(x_N), y''N(x_N)
 G4HepEmHostDevice
 double GetSpline(double x1, double x2, double y1, double y2, double secderiv1, double secderiv2, double x);
+
+// get linear interpolation of y(x) between (x1, x2) given y_1 = y(x_N)
+G4HepEmHostDevice
+double GetLinear(double x1, double x2, double y1, double y2, double x);
 
 // get spline interpolation over a log-spaced xgrid previously prepared by
 // PrepareSpline (separate storrage of ydata and second deriavtive)
@@ -56,6 +60,50 @@ double GetSpline(double* xdata, double* ydata, double x, int idx);
 // ydata and second deriavtive in data
 G4HepEmHostDevice
 double GetSpline(double* data, double x, int idx);
+
+
+// get linear interpolation over a log-spaced xgrid previously prepared by
+// PrepareSpline; compact storrage of xdata, ydata in data with a single `y`
+// at each `x` (x_i,y_i, x_i+1,y_i+1,...)
+G4HepEmHostDevice
+double GetLinearLog(int ndata, double* data, double x, double logx, double logxmin, double invLDBin);
+
+// same as above but having 2 `y` data now at each `x` (x_i,y1_i,y2_i, x_i+1,y_i+1,y2_i+1,,...)
+// `iwhich=1` interpolates `y1` while `iwhich=2` `y2`
+G4HepEmHostDevice
+double GetLinearLog2(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich);
+// same as above but interpolate sthe 2 data at once
+G4HepEmHostDevice
+void GetLinearLog2(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, double res[2]);
+
+/*
+// same as GetLinearLog2 but general for N `y` data at each `x` with `shift=N+1`
+// - the special case above with `N=2`: `shift=N+1=3` and this the same as the above
+// - the special case having `N=1`: `shift=1+1=2` and with `which=1` this the same as the above GetLinearLog
+G4HepEmHostDevice
+double GetLinearLogN(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich, int shift);
+*/
+
+// get spline interpolation over a log-spaced xgrid previously prepared by
+// PrepareSpline; compact storrage of xdata, ydata in data with 4 `y` values
+// and their second derivatives at each `x` (x_i, y1_i,y1_i'',y2_i,y2_i'',y3_i,y3_i'',y4_i,y4_i'', x_i+1...)
+// `iwhich=1` interpolates `y1`; `iwhich=2` `y2`, `iwhich=3` `y3`, `iwhich=4` `y4`
+G4HepEmHostDevice
+double GetSplineLog4(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich);
+//same as above but interpolates all the 4 data at once
+G4HepEmHostDevice
+void GetSplineLog4(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, double res[4]);
+
+/*
+// same as GetSplineLog4 but general for N `y` data and their second derivatives at each `x`
+// - the special case above with `N=4`: `shift=2xN +1=9` and this the same as the above
+// - the special case having `N=1`: `shift=2xN +1=3` and with `which=1` this the same as the above GetSplineLog with the single `double* data` array
+G4HepEmHostDevice
+double GetSplineLogN(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich, int shift);
+*/
+
+
+
 
 // finds the lower index of the x-bin in an ordered, increasing x-grid such
 // that x[i] <= x < x[i+1]

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRunUtils.icc
@@ -60,6 +60,17 @@ double GetSpline(double x1, double x2, double y1, double y2, double secderiv1, d
   return y1 + b*(y2 - y1) + (b*(b-1.0))*(c0+c1)*(dl*dl*os);
 }
 
+double GetLinear(double x1, double x2, double y1, double y2, double x) {
+  // Unchecked precondition: x1 < x < x2
+  const double dl = x2 - x1;
+  // note: all corner cases of the previous methods are covered and eventually
+  //       gives b=0/1 that results in y=y0\y_{N-1} if e<=x[0]/e>=x[N-1] or
+  //       y=y_i/y_{i+1} if e<x[i]/e>=x[i+1] due to small numerical errors
+  const double  b = G4HepEmMax(0., G4HepEmMin(1., (x - x1)/dl));
+  return y1 + b*(y2 - y1);
+}
+
+
 // use the improved, robust spline interpolation that I put in G4 10.6
 double GetSplineLog(int ndata, double* xdata, double* ydata, double* secderiv, double x, double logx, double logxmin, double invLDBin) {
   // make sure that $x \in  [x[0],x[ndata-1]]$
@@ -75,7 +86,7 @@ double GetSplineLog(int ndata, double* xdata, double* ydata, double x, double lo
   const double xv = G4HepEmMax(xdata[0], G4HepEmMin(xdata[ndata-1], x));
   // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
   const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
-  const int  idx2 = 2*idx; 
+  const int  idx2 = 2*idx;
   return GetSpline(xdata[idx], xdata[idx+1], ydata[idx2], ydata[idx2+2], ydata[idx2+1], ydata[idx2+3], xv);
 }
 
@@ -107,6 +118,108 @@ double GetSpline(double* data, double x, int idx) {
   const int  idx3 = 3*idx;
   return GetSpline(data[idx3], data[idx3+3], data[idx3+1], data[idx3+4], data[idx3+2], data[idx3+5], x);
 }
+
+
+
+
+double GetLinearLog(int ndata, double* data, double x, double logx, double logxmin, double invLDBin) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[2*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int  idx2_0 = 2*idx;
+  const int  idx2_1 = idx2_0+2;
+  return GetLinear(data[idx2_0], data[idx2_1], data[idx2_0+1], data[idx2_1+1], x);
+}
+
+// interpolates one data out of the 2 specifed by the `iwhich=1,2` parameter
+double GetLinearLog2(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[3*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int  idx3_0 = 3*idx;
+  const int  idx3_1 = idx3_0+3;
+  return GetLinear(data[idx3_0], data[idx3_1], data[idx3_0+iwhich], data[idx3_1+iwhich], x);
+}
+// interpolates all the 2 data at once
+void GetLinearLog2(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, double res[2]) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[3*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int  idx3_0 = 3*idx;
+  const int  idx3_1 = idx3_0+3;
+  //return GetLinear(data[idx3_0], data[idx3_1], data[idx3_0+iwhich], data[idx3_1+iwhich], x);
+  const double dl = data[idx3_1] - data[idx3_0];
+  const double  b = G4HepEmMax(0., G4HepEmMin(1., (x - data[idx3_0])/dl));
+  for (int i=1; i<3; ++i) {
+    const double y1 = data[idx3_0+i];
+    const double y2 = data[idx3_1+i];
+    res[i-1] = G4HepEmMax(0.0, y1 + b*(y2 - y1));
+  }
+}
+/*
+double GetLinearLogN(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich, int shift) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[shift*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int    i0 = shift*idx;
+  const int    i1 = shift*(idx+1);
+  return GetLinear(data[i0], data[i1], data[i0+iwhich], data[i1+iwhich], x);
+}
+*/
+
+
+
+
+// interpolates one out of the 4 data at once, specififed by `iwhich =1,2,3 or 4`
+double GetSplineLog4(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[9*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int  idx9_0 = 9*idx;
+  const int  idx9_1 = idx9_0 + 9;
+  iwhich = (iwhich-1)*2+1;
+  return GetSpline(data[idx9_0], data[idx9_1], data[idx9_0+iwhich], data[idx9_1+iwhich], data[idx9_0+iwhich+1], data[idx9_1+iwhich+1], x);
+}
+// interpolates all the 4 data at once
+void GetSplineLog4(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, double res[4]) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[9*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int  idx9_0 = 9*idx;
+  const int  idx9_1 = idx9_0 + 9;
+  const double   dl = data[idx9_1] - data[idx9_0];
+  const double    b = G4HepEmMax(0., G4HepEmMin(1., (x - data[idx9_0])/dl));
+  for (int i=0; i<4; i++) {
+    const double os = 0.166666666667; // 1./6.
+    const int ii = 2*i+1;
+    const double secderiv1 = data[idx9_0+ii+1];
+    const double secderiv2 = data[idx9_1+ii+1];
+    const double c0 = (2.0 - b)*secderiv1;
+    const double c1 = (1.0 + b)*secderiv2;
+    const double y1 = data[idx9_0+ii];
+    const double y2 = data[idx9_1+ii];
+    res[i] = G4HepEmMax(0.0, y1 + b*(y2 - y1) + (b*(b-1.0))*(c0+c1)*(dl*dl*os));
+  }
+}
+/*
+double GetSplineLogN(int ndata, double* data, double x, double logx, double logxmin, double invLDBin, int iwhich, int shift) {
+  // make sure that $x \in  [x[0],x[ndata-1]]$
+  const double xv = G4HepEmMax(data[0], G4HepEmMin(data[shift*(ndata-1)], x));
+  // compute the lowerindex of the x bin (idx \in [0,N-2] will be guaranted)
+  const int   idx = (int)G4HepEmMax(0., G4HepEmMin((logx-logxmin)*invLDBin, ndata-2.));
+  const int    i0 = shift*idx;
+  const int    i1 = shift*(idx+1);
+  iwhich = (iwhich-1)*2+1;
+  return GetSpline(data[i0], data[i1], data[i0+iwhich], data[i1+iwhich], data[i0+iwhich+1], data[i1+iwhich+1], x);
+}
+*/
+
 
 // this is used to get index for inverse range on host
 // NOTE: it is assumed that x[0] <= x and x < x[step*(num-1)]

--- a/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmTrack.hh
@@ -147,7 +147,7 @@ public:
   G4HepEmHostDevice
   double  GetGStepLength()    const    { return fGStepLength; }
 
-  // Macroscopic cross section
+  // Mean free paths
   G4HepEmHostDevice
   void    SetMFP(double val, int pindx) { fMFPs[pindx] = val; }
   G4HepEmHostDevice

--- a/apps/examples/TestEm3/ATLASbar.mac
+++ b/apps/examples/TestEm3/ATLASbar.mac
@@ -29,8 +29,18 @@
 ##   =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
 ##   = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
 ## -----------------------------------------------------------------------------
-/testem/phys/addPhysics   HepEm
+/testem/phys/addPhysics   HepEmTracking
 ##/testem/phys/addPhysics   G4Em
+##
+## -----------------------------------------------------------------------------
+## Use the gamma-general process in Geant4 (similarly to HepEmTracking)
+## -----------------------------------------------------------------------------
+/process/em/UseGeneralProcess true
+##
+## -----------------------------------------------------------------------------
+## Option to apply cuts also beyond ionisation and bremsstrahlung
+## -----------------------------------------------------------------------------
+##/process/em/UseGeneralProcess true
 ##
 ## -----------------------------------------------------------------------------
 ## Set secondary production threshold, init. the run and set primary properties

--- a/apps/examples/TestEm3/src/PhysListG4Em.cc
+++ b/apps/examples/TestEm3/src/PhysListG4Em.cc
@@ -34,6 +34,7 @@
 #include "G4ComptonScattering.hh"
 #include "G4GammaConversion.hh"
 #include "G4PhotoElectricEffect.hh"
+#include "G4GammaGeneralProcess.hh"
 
 #include "G4eMultipleScattering.hh"
 #include "G4eIonisation.hh"
@@ -47,6 +48,7 @@
 
 #include "G4PhysicsListHelper.hh"
 #include "G4BuilderType.hh"
+#include "G4LossTableManager.hh"
 
 
 PhysListG4Em::PhysListG4Em(const G4String& name)
@@ -82,10 +84,19 @@ void PhysListG4Em::ConstructProcess()
 
   // Add gamma EM processes
   particle = G4Gamma::Gamma();
-
-  ph->RegisterProcess(new G4PhotoElectricEffect, particle);
-  ph->RegisterProcess(new G4ComptonScattering, particle);
-  ph->RegisterProcess(new G4GammaConversion, particle);
+  if (G4EmParameters::Instance()->GeneralProcessActive()) {
+    // Gamma general or Woodcock process depending is the latter was set
+    G4GammaGeneralProcess* sp = new G4GammaGeneralProcess;
+    sp->AddEmProcess(new G4PhotoElectricEffect);
+    sp->AddEmProcess(new G4ComptonScattering);
+    sp->AddEmProcess(new G4GammaConversion);
+    G4LossTableManager::Instance()->SetGammaGeneralProcess(sp);
+    ph->RegisterProcess(sp, particle);
+  } else {
+    ph->RegisterProcess(new G4PhotoElectricEffect, particle);
+    ph->RegisterProcess(new G4ComptonScattering, particle);
+    ph->RegisterProcess(new G4GammaConversion, particle);
+  }
 
   //
   // Add e- EM processes

--- a/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
+++ b/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
@@ -116,18 +116,11 @@ void G4HepEmGammaDataTester(G4HepEmGammaData* d) {
   EXPECT_EQ(d->fNumMaterials, 0);
 
   // Energy grid has a fixed size, but dynamic allocation
-  EXPECT_EQ(d->fConvEnergyGridSize, 147);
-  EXPECT_EQ(d->fConvEnergyGrid, nullptr);
+  EXPECT_EQ(d->fEGridSize0,  32);
+  EXPECT_EQ(d->fEGridSize1,  32);
+  EXPECT_EQ(d->fEGridSize2, 256);
 
-  // Energy grid has a fixed size, but dynamic allocation
-  EXPECT_EQ(d->fCompEnergyGridSize, 85);
-  EXPECT_EQ(d->fCompEnergyGrid, nullptr);
-
-  // Energy grid has a fixed size, but dynamic allocation
-  EXPECT_EQ(d->fGNucEnergyGridSize, 256);
-  EXPECT_EQ(d->fGNucEnergyGrid, nullptr);
-
-  EXPECT_EQ(d->fConvCompGNucMacXsecData, nullptr);
+  EXPECT_EQ(d->fMacXsecData, nullptr);
 
   EXPECT_EQ(d->fElemSelectorConvEgridSize, 0);
   EXPECT_EQ(d->fElemSelectorConvNumData, 0);

--- a/testing/GammaTargetElementSelector/src/Implementation.cc
+++ b/testing/GammaTargetElementSelector/src/Implementation.cc
@@ -45,8 +45,8 @@ bool TestGammaElemSelectorData ( const struct G4HepEmData* hepEmData ) {
   for (int i=0; i<numTestCases; ++i) {
     int imat          = (int)(dis(gen)*numMatData);
     tsInImat[i]       = imat;
-    double minEKin    = theGammaData->fConvEnergyGrid[0];
-    double maxEKin    = theGammaData->fConvEnergyGrid[theGammaData->fConvEnergyGridSize-1];
+    double minEKin    = theGammaData->fEMax0;
+    double maxEKin    = theGammaData->fEMax2;
     double lMinEkin   = std::log(minEKin);
     double lEkinDelta = std::log(maxEKin/minEKin);
     tsInLogEkin[i]    = dis(gen)*lEkinDelta+lMinEkin;

--- a/testing/GammaXSections/include/Declaration.hh
+++ b/testing/GammaXSections/include/Declaration.hh
@@ -15,11 +15,9 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData );
   // cross section values for conversion, Compton and gamma-nuclear on the
   // device for all test cases.
   void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImat_h,
-                                 double* tsInEkinConv_h, double* tsInLogEkinConv_h,
-                                 double* tsInEkinComp_h, double* tsInLogEkinComp_h,
-                                 double* tsInEkinGNuc_h, double* tsInLogEkinGNuc_h,
-                                 double* tsOutMXConv_h,  double* tsOutMXComp_h,
-                                 double* tsOutMXGNuc_h, int numTestCases );
+                                 double* tsInEkin_h, double* tsInLogEkinv_h,
+                                 double* tsInURand_h, double* tsOutMXTot_h,
+                                 int* tsOutProcID_h, int numTestCases );
 
 #endif // G4HepEm_CUDA_BUILD
 

--- a/testing/GammaXSections/src/GammaMacXSecs.cu
+++ b/testing/GammaXSections/src/GammaMacXSecs.cu
@@ -14,84 +14,78 @@
 #include "G4HepEmRunUtils.icc"
 
  __global__
- void TestMacXSecDataKernel ( const struct G4HepEmGammaData* theGammaData_d,
-                              int* tsInImat_d, double* tsInEkin_d, double* tsInLogEkin_d,
-                              double* tsOutRes_d, int iprocess, int numTestCases) {
+ void TestMacXSecDataKernel ( const struct G4HepEmGammaData* gmData_d, const struct G4HepEmMaterialData* matData_d,
+                              int* tsInImat_d, double* tsInEkin_d, double* tsInLogEkin_d, double* tsInURand_d,
+                              double* tsOutMXTot_d, int* tsOutProcID_d, G4HepEmGammaTrack* gTracks_d,
+                              int numTestCases) {
    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
-     tsOutRes_d[i] = G4HepEmGammaManager::GetMacXSec (theGammaData_d, tsInImat_d[i], tsInEkin_d[i], tsInLogEkin_d[i], iprocess);
+     tsOutMXTot_d[i] = G4HepEmGammaManager::GetTotalMacXSec (gmData_d, matData_d, tsInImat_d[i], tsInEkin_d[i], tsInLogEkin_d[i], &(gTracks_d[i]));
+     double totMFP = (tsOutMXTot_d[i] > 0) ? 1.0/tsOutMXTot_d[i] : 1E+20;
+     if (tsOutMXTot_d[i]>0) { // otherwise IMFP would be such that we never call sampling
+       gTracks_d[i].GetTrack()->SetMFP(totMFP, 0);
+       G4HepEmGammaManager::SampleInteraction(gmData_d, &(gTracks_d[i]), tsInEkin_d[i], tsInLogEkin_d[i], tsInImat_d[i], tsInURand_d[i]); // sample interaction
+       tsOutProcID_d[i] = gTracks_d[i].GetTrack()->GetWinnerProcessIndex();
+     }
    }
  }
 
 void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImat_h,
-     double* tsInEkinConv_h, double* tsInLogEkinConv_h, double* tsInEkinComp_h, double* tsInLogEkinComp_h,
-     double* tsInEkinGNuc_h, double* tsInLogEkinGNuc_h, double* tsOutMXConv_h, double* tsOutMXComp_h,
-     double* tsOutMXGNuc_h, int numTestCases ) {
+                               double* tsInEkin_h, double* tsInLogEkin_h,
+                               double* tsInURand_h, double* tsOutMXTot_h,
+                               int* tsOutProcID_h, int numTestCases  ) {
   //
   // --- Allocate device side memory for the input/output data and copy all input
   //     data from host to device
-  int*            tsInImat_d = nullptr;
-  double*     tsInEkinConv_d = nullptr;
-  double*  tsInLogEkinConv_d = nullptr;
-  double*     tsInEkinComp_d = nullptr;
-  double*  tsInLogEkinComp_d = nullptr;
-  double*     tsInEkinGNuc_d = nullptr;
-  double*  tsInLogEkinGNuc_d = nullptr;
-  double*      tsOutMXConv_d = nullptr;
-  double*      tsOutMXComp_d = nullptr;
-  double*      tsOutMXGNuc_d = nullptr;
+  int*        tsInImat_d = nullptr;
+  double*     tsInEkin_d = nullptr;
+  double*  tsInLogEkin_d = nullptr;
+  double*    tsInURand_d = nullptr;
+  double*   tsOutMXTot_d = nullptr;
+  int*     tsOutProcID_d = nullptr;
 
   //
-  gpuErrchk ( cudaMalloc ( &tsInImat_d,        sizeof( int )    * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInEkinConv_d,    sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInLogEkinConv_d, sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInEkinComp_d,    sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInLogEkinComp_d, sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInEkinGNuc_d,    sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInLogEkinGNuc_d, sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsOutMXConv_d,     sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsOutMXComp_d,     sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsOutMXGNuc_d,     sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInImat_d,    sizeof( int )    * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInEkin_d,    sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInLogEkin_d, sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsInURand_d,   sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsOutMXTot_d,  sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &tsOutProcID_d, sizeof( int )    * numTestCases ) );
   //
   // --- Copy the input data from host to device (test material index, ekin and log-ekin arrays)
-  gpuErrchk ( cudaMemcpy ( tsInImat_d,        tsInImat_h,        sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInEkinConv_d,    tsInEkinConv_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInLogEkinConv_d, tsInLogEkinConv_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInEkinComp_d,    tsInEkinComp_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInLogEkinComp_d, tsInLogEkinComp_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInEkinGNuc_d,    tsInEkinGNuc_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInLogEkinGNuc_d, tsInLogEkinGNuc_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInImat_d,    tsInImat_h,    sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInEkin_d,    tsInEkin_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInLogEkin_d, tsInLogEkin_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( tsInURand_d,   tsInURand_h,   sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+
+  G4HepEmGammaTrack* gTracks_d;
+  gpuErrchk ( cudaMalloc ( &gTracks_d, sizeof( G4HepEmGammaTrack ) * numTestCases ) );
 
   //
   // --- Launch the kernels
   int numThreads = 512;
   int numBlocks  = std::ceil( float(numTestCases)/numThreads );
+
   //  std::cout << " N = " << numTestCases << " numBlocks = " << numBlocks << " numThreads = " << numThreads << " x = " << numBlocks*numThreads << std::endl;
-  const G4HepEmGammaData* theGammaData_d = hepEmData->fTheGammaData_gpu;
+  const G4HepEmGammaData* theGammaData_d  = hepEmData->fTheGammaData_gpu;
+  const G4HepEmMaterialData* theMatData_d = hepEmData->fTheMaterialData_gpu;
   // conversion
-  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, tsInImat_d, tsInEkinConv_d, tsInLogEkinConv_d, tsOutMXConv_d, 0,  numTestCases );
-  // Compton scatteirng
-  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, tsInImat_d, tsInEkinComp_d, tsInLogEkinComp_d, tsOutMXComp_d, 1, numTestCases );
-  // Gamma-nuclear
-  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, tsInImat_d, tsInEkinGNuc_d, tsInLogEkinGNuc_d, tsOutMXGNuc_d, 2, numTestCases );
+  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, theMatData_d, tsInImat_d, tsInEkin_d, tsInLogEkin_d, tsInURand_d, tsOutMXTot_d, tsOutProcID_d, gTracks_d, numTestCases );
   //
   // --- Synchronize to make sure that completed on the device
   cudaDeviceSynchronize();
   //
   // --- Copy the results from the device to the host
-  gpuErrchk ( cudaMemcpy ( tsOutMXConv_h,     tsOutMXConv_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
-  gpuErrchk ( cudaMemcpy ( tsOutMXComp_h,     tsOutMXComp_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
-  gpuErrchk ( cudaMemcpy ( tsOutMXGNuc_h,     tsOutMXGNuc_d,     sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
+  gpuErrchk ( cudaMemcpy ( tsOutMXTot_h,  tsOutMXTot_d,  sizeof( double ) * numTestCases, cudaMemcpyDeviceToHost ) );
+  gpuErrchk ( cudaMemcpy ( tsOutProcID_h, tsOutProcID_d, sizeof( int ) * numTestCases, cudaMemcpyDeviceToHost ) );
 
   //
   // --- Free all dynamically allocated (device side) memory
-  cudaFree ( tsInImat_d        );
-  cudaFree ( tsInEkinConv_d    );
-  cudaFree ( tsInLogEkinConv_d );
-  cudaFree ( tsInEkinComp_d    );
-  cudaFree ( tsInLogEkinComp_d );
-  cudaFree ( tsInEkinGNuc_d    );
-  cudaFree ( tsInLogEkinGNuc_d );
-  cudaFree ( tsOutMXConv_d    );
-  cudaFree ( tsOutMXComp_d    );
-  cudaFree ( tsOutMXGNuc_d    );
+  cudaFree ( tsInImat_d    );
+  cudaFree ( tsInEkin_d    );
+  cudaFree ( tsInLogEkin_d );
+  cudaFree ( tsInURand_d   );
+  cudaFree ( tsOutMXTot_d  );
+  cudaFree ( tsOutProcID_d );
+
+  cudaFree ( gTracks_d    );
 }

--- a/testing/GammaXSections/src/GammaMacXSecs.cu
+++ b/testing/GammaXSections/src/GammaMacXSecs.cu
@@ -13,63 +13,72 @@
 #include "G4HepEmGammaManager.icc"
 #include "G4HepEmRunUtils.icc"
 
+// a device side G4HepEm data: all its members pointing to host memory will be set to
+// overwritten by the device side pointers (i.e. their _gpu correspondance)
+__constant__ __device__ struct G4HepEmData hepEmData_d;
+
  __global__
- void TestMacXSecDataKernel ( const struct G4HepEmGammaData* gmData_d, const struct G4HepEmMaterialData* matData_d,
-                              int* tsInImat_d, double* tsInEkin_d, double* tsInLogEkin_d, double* tsInURand_d,
-                              double* tsOutMXTot_d, int* tsOutProcID_d, G4HepEmGammaTrack* gTracks_d,
-                              int numTestCases) {
+ void TestMacXSecDataKernel ( G4HepEmGammaTrack* gTracks_d, double* tsInURand_d,
+                              double* tsOutMXTot_d, int* tsOutProcID_d, int numTestCases) {
    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < numTestCases; i += blockDim.x * gridDim.x) {
-     tsOutMXTot_d[i] = G4HepEmGammaManager::GetTotalMacXSec (gmData_d, matData_d, tsInImat_d[i], tsInEkin_d[i], tsInLogEkin_d[i], &(gTracks_d[i]));
+     tsOutMXTot_d[i] = G4HepEmGammaManager::GetTotalMacXSec (&hepEmData_d, &(gTracks_d[i]));
      double totMFP = (tsOutMXTot_d[i] > 0) ? 1.0/tsOutMXTot_d[i] : 1E+20;
      if (tsOutMXTot_d[i]>0) { // otherwise IMFP would be such that we never call sampling
        gTracks_d[i].GetTrack()->SetMFP(totMFP, 0);
-       G4HepEmGammaManager::SampleInteraction(gmData_d, &(gTracks_d[i]), tsInEkin_d[i], tsInLogEkin_d[i], tsInImat_d[i], tsInURand_d[i]); // sample interaction
+       G4HepEmGammaManager::SampleInteraction(&hepEmData_d, &(gTracks_d[i]), tsInURand_d[i]); // sample interaction
        tsOutProcID_d[i] = gTracks_d[i].GetTrack()->GetWinnerProcessIndex();
      }
    }
  }
 
-void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInImat_h,
-                               double* tsInEkin_h, double* tsInLogEkin_h,
+void TestMacXSecDataOnDevice( const struct G4HepEmData* hepEmData, int* tsInImat_h,
+                               double* tsInEkin_h, double* /*tsInLogEkin_h*/,
                                double* tsInURand_h, double* tsOutMXTot_h,
                                int* tsOutProcID_h, int numTestCases  ) {
   //
   // --- Allocate device side memory for the input/output data and copy all input
-  //     data from host to device
-  int*        tsInImat_d = nullptr;
-  double*     tsInEkin_d = nullptr;
-  double*  tsInLogEkin_d = nullptr;
-  double*    tsInURand_d = nullptr;
-  double*   tsOutMXTot_d = nullptr;
-  int*     tsOutProcID_d = nullptr;
+  // data from host to device
+  double* tsInURand_d = nullptr;
+  double* tsOutMXTot_d = nullptr;
+  int*    tsOutProcID_d = nullptr;
+  G4HepEmGammaTrack* gTracks_d = nullptr;
+
+  // prepare the gamm atracks on host by setting their fields accroding to the set values
+  G4HepEmGammaTrack* gTracks_h = new G4HepEmGammaTrack[numTestCases];
+  for (int i=0; i<numTestCases; ++i) {
+    gTracks_h[i].GetTrack()->SetEKin(tsInEkin_h[i]);
+    gTracks_h[i].GetTrack()->SetMCIndex(tsInImat_h[i]); // mat index can be used now as mc index
+  }
+
+  // make the HepEmData available on device: all members have their _gpu correspondance
+  // that are already available on the device (was copied in the caller). What we do
+  // here is to overwrite the memebrs pointing to host by those pointing to the device
+  // This makes possible to use all HepEm functions without the _gpu business.
+  G4HepEmData tmpHepEmData_d;
+  tmpHepEmData_d.fTheMatCutData   = hepEmData->fTheMatCutData_gpu;
+  tmpHepEmData_d.fTheMaterialData = hepEmData->fTheMaterialData_gpu;
+  tmpHepEmData_d.fTheElementData  = hepEmData->fTheElementData_gpu;
+  tmpHepEmData_d.fTheElectronData = hepEmData->fTheElectronData_gpu;
+  tmpHepEmData_d.fThePositronData = hepEmData->fThePositronData_gpu;
+  tmpHepEmData_d.fTheSBTableData  = hepEmData->fTheSBTableData_gpu;
+  tmpHepEmData_d.fTheGammaData    = hepEmData->fTheGammaData_gpu;
+  gpuErrchk ( cudaMemcpyToSymbol(hepEmData_d, &tmpHepEmData_d, sizeof(G4HepEmData) ) );
 
   //
-  gpuErrchk ( cudaMalloc ( &tsInImat_d,    sizeof( int )    * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInEkin_d,    sizeof( double ) * numTestCases ) );
-  gpuErrchk ( cudaMalloc ( &tsInLogEkin_d, sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsInURand_d,   sizeof( double ) * numTestCases ) );
+  gpuErrchk ( cudaMalloc ( &gTracks_d,     sizeof( G4HepEmGammaTrack ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsOutMXTot_d,  sizeof( double ) * numTestCases ) );
   gpuErrchk ( cudaMalloc ( &tsOutProcID_d, sizeof( int )    * numTestCases ) );
-  //
   // --- Copy the input data from host to device (test material index, ekin and log-ekin arrays)
-  gpuErrchk ( cudaMemcpy ( tsInImat_d,    tsInImat_h,    sizeof( int )    * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInEkin_d,    tsInEkin_h,    sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInLogEkin_d, tsInLogEkin_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-  gpuErrchk ( cudaMemcpy ( tsInURand_d,   tsInURand_h,   sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
-
-  G4HepEmGammaTrack* gTracks_d;
-  gpuErrchk ( cudaMalloc ( &gTracks_d, sizeof( G4HepEmGammaTrack ) * numTestCases ) );
-
+  gpuErrchk ( cudaMemcpy ( tsInURand_d, tsInURand_h, sizeof( double ) * numTestCases, cudaMemcpyHostToDevice) );
+  gpuErrchk ( cudaMemcpy ( gTracks_d,   gTracks_h,   sizeof( G4HepEmGammaTrack ) * numTestCases, cudaMemcpyHostToDevice) );
   //
   // --- Launch the kernels
   int numThreads = 512;
   int numBlocks  = std::ceil( float(numTestCases)/numThreads );
 
-  //  std::cout << " N = " << numTestCases << " numBlocks = " << numBlocks << " numThreads = " << numThreads << " x = " << numBlocks*numThreads << std::endl;
-  const G4HepEmGammaData* theGammaData_d  = hepEmData->fTheGammaData_gpu;
-  const G4HepEmMaterialData* theMatData_d = hepEmData->fTheMaterialData_gpu;
   // conversion
-  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (theGammaData_d, theMatData_d, tsInImat_d, tsInEkin_d, tsInLogEkin_d, tsInURand_d, tsOutMXTot_d, tsOutProcID_d, gTracks_d, numTestCases );
+  TestMacXSecDataKernel <<< numBlocks, numThreads >>> (gTracks_d, tsInURand_d, tsOutMXTot_d, tsOutProcID_d, numTestCases );
   //
   // --- Synchronize to make sure that completed on the device
   cudaDeviceSynchronize();
@@ -80,12 +89,8 @@ void TestMacXSecDataOnDevice ( const struct G4HepEmData* hepEmData, int* tsInIma
 
   //
   // --- Free all dynamically allocated (device side) memory
-  cudaFree ( tsInImat_d    );
-  cudaFree ( tsInEkin_d    );
-  cudaFree ( tsInLogEkin_d );
   cudaFree ( tsInURand_d   );
+  cudaFree ( gTracks_d     );
   cudaFree ( tsOutMXTot_d  );
   cudaFree ( tsOutProcID_d );
-
-  cudaFree ( gTracks_d    );
 }

--- a/testing/GammaXSections/src/Implementation.cc
+++ b/testing/GammaXSections/src/Implementation.cc
@@ -54,19 +54,21 @@ bool TestGammaXSectionData ( const struct G4HepEmData* hepEmData ) {
     tsInEkin[i]    = std::exp(tsInLogEkin[i]);
 
     tsInURand[i] = dis(gen);
-}
+  }
   //
   // Use G4HepEmGammaManager to evaluate the macroscopic cross sections
   // for conversion inot e-e+ pairs and Compton scattering.
   G4HepEmGammaTrack aGammaTrack;
   G4HepEmTrack* aTrack = aGammaTrack.GetTrack();
   for (int i=0; i<numTestCases; ++i) {
-    tsOutMXTot[i] = G4HepEmGammaManager::GetTotalMacXSec (theGammaData, theMatData, tsInImat[i], tsInEkin[i], tsInLogEkin[i], &aGammaTrack); // total mxces
+    aTrack->SetEKin(tsInEkin[i]);
+    aTrack->SetMCIndex(tsInImat[i]); // mat index can be used now as mc index
+    tsOutMXTot[i] = G4HepEmGammaManager::GetTotalMacXSec(hepEmData, &aGammaTrack); // total mxces
     // set all track fields that the sampling below needs
     const double totMFP = (tsOutMXTot[i] > 0) ? 1.0/tsOutMXTot[i] : 1E+20;
     if (tsOutMXTot[i]>0) { // otherwise IMFP would be such that we never call sampling
       aTrack->SetMFP(totMFP, 0);
-      G4HepEmGammaManager::SampleInteraction(theGammaData, &aGammaTrack, tsInEkin[i], tsInLogEkin[i], tsInImat[i], tsInURand[i]); // sample interaction
+      G4HepEmGammaManager::SampleInteraction(hepEmData, &aGammaTrack, tsInURand[i]); // sample interaction
       tsOutProcID[i] = aGammaTrack.GetTrack()->GetWinnerProcessIndex();
     }
   }

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -284,59 +284,40 @@ bool operator==(const G4HepEmGammaData& lhs, const G4HepEmGammaData& rhs)
     return false;
   }
 
-  // conversion data grid
-  if(std::tie(lhs.fConvLogMinEkin, lhs.fConvEILDelta) !=
-     std::tie(rhs.fConvLogMinEkin, rhs.fConvEILDelta))
+  // the 3 energy window related data
+  if(std::tie(lhs.fDataPerMat, lhs.fNumData0, lhs.fNumData1) !=
+     std::tie(rhs.fDataPerMat, rhs.fNumData0, rhs.fNumData1))
   {
     return false;
   }
 
-  if(!compare_arrays(lhs.fConvEnergyGridSize, lhs.fConvEnergyGrid,
-                     rhs.fConvEnergyGridSize, rhs.fConvEnergyGrid))
+  if(std::tie(lhs.fEMin0, lhs.fEMax0, lhs.fLogEMin0, lhs.fEILDelta0) !=
+     std::tie(rhs.fEMin0, rhs.fEMax0, rhs.fLogEMin0, rhs.fEILDelta0))
   {
     return false;
   }
 
-  // compton data grid
-  if(std::tie(lhs.fCompLogMinEkin, lhs.fCompEILDelta) !=
-     std::tie(rhs.fCompLogMinEkin, rhs.fCompEILDelta))
+  if(std::tie(lhs.fEMax1, lhs.fLogEMin1, lhs.fEILDelta1) !=
+     std::tie(rhs.fEMax1, rhs.fLogEMin1, rhs.fEILDelta1))
   {
     return false;
   }
 
-  if(!compare_arrays(lhs.fCompEnergyGridSize, lhs.fCompEnergyGrid,
-                     rhs.fCompEnergyGridSize, rhs.fCompEnergyGrid))
+  if(std::tie(lhs.fEMax2, lhs.fLogEMin2, lhs.fEILDelta2) !=
+     std::tie(rhs.fEMax2, rhs.fLogEMin2, rhs.fEILDelta2))
   {
     return false;
   }
 
-  // gamma-nuclear data grid
-  if(std::tie(lhs.fGNucLogMinEkin, lhs.fGNucEILDelta) !=
-     std::tie(rhs.fGNucLogMinEkin, rhs.fGNucEILDelta))
+  // the cross section related data array
+  const int lhsXsecSize = lhs.fNumMaterials * lhs.fDataPerMat;
+  const int rhsXsecSize = rhs.fNumMaterials * rhs.fDataPerMat;
+  if(!compare_arrays(lhsXsecSize, lhs.fMacXsecData,
+                     rhsXsecSize, rhs.fMacXsecData))
   {
     return false;
   }
 
-  if(!compare_arrays(lhs.fGNucEnergyGridSize, lhs.fGNucEnergyGrid,
-                     rhs.fGNucEnergyGridSize, rhs.fGNucEnergyGrid))
-  {
-    return false;
-  }
-
-
-  // the macroscopic cross sections for all materials and for
-  // [conversion,compton,gamma-nuclear] at each material
-  const int lhsXsecSize =
-    lhs.fNumMaterials * 2 * (lhs.fConvEnergyGridSize + lhs.fCompEnergyGridSize
-                             + lhs.fGNucEnergyGridSize);
-  const int rhsXsecSize =
-    rhs.fNumMaterials * 2 * (rhs.fConvEnergyGridSize + rhs.fCompEnergyGridSize
-                             + rhs.fGNucEnergyGridSize);
-  if(!compare_arrays(lhsXsecSize, lhs.fConvCompGNucMacXsecData, rhsXsecSize,
-                     rhs.fConvCompGNucMacXsecData))
-  {
-    return false;
-  }
 
   if(std::tie(lhs.fElemSelectorConvLogMinEkin, lhs.fElemSelectorConvEILDelta) !=
      std::tie(rhs.fElemSelectorConvLogMinEkin, rhs.fElemSelectorConvEILDelta))


### PR DESCRIPTION
Move to a new representation of the gamma cross sections that support using the total macroscopic cross section. This single value is used now to sample the step length till the next interaction, i.e. a single cross section evaluation but without having information on the type of the interaction. The type of the interaction is determined only when interaction indeed happens at that post step point: by further cross section interpolations. This might have benefits in granular geometries when the gamma steps are often limited by volume boundaries thus no physics interaction happens at the post step point. The benefit is due to the reduced number of cross section evaluations.