### PR TITLE
Woodcock tracking of photons is available now in the HepEm tracking.    

### DIFF
--- a/G4HepEm/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/G4HepEm/CMakeLists.txt
@@ -2,10 +2,12 @@ set(G4HEPEM_headers
   include/G4HepEmNoProcess.hh
   include/G4HepEmProcess.hh
   include/G4HepEmRunManager.hh
+  include/G4HepEmWoodcockHelper.hh
 )
 set(G4HEPEM_sources
   src/G4HepEmProcess.cc
   src/G4HepEmRunManager.cc
+  src/G4HepEmWoodcockHelper.cc
 )
 
 set(G4HEPEM_Geant4_LIBRARIES

--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -13,6 +13,7 @@ class G4Step;
 class G4VProcess;
 class G4VParticleChange;
 class G4Region;
+class G4HepEmWoodcockHelper;
 
 #include <vector>
 
@@ -41,6 +42,10 @@ public:
   // radiator region (only for ATLAS and only if different than init.ed below)
   void SetXTRProcessName(const std::string& name) { fXTRProcessName = name; }
   void SetXTRRegionName(const std::string& name)  { fXTRRegionName  = name; }
+
+  void AddWoodcockTrackingRegion(const std::string& regionName) {
+    fWDTRegionNames.push_back(regionName);
+  }
 
 
 private:
@@ -111,6 +116,10 @@ private:
   // The names that will be used to find the XTR process and detector region.
   std::string fXTRProcessName = {"XTR"};
   std::string fXTRRegionName  = {"TRT_RADIATOR"};
+
+  // A vector of Woodcock tracking region names (set by user if any) and a helper.
+  std::vector<std::string> fWDTRegionNames;
+  G4HepEmWoodcockHelper*   fWDTHelper;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/G4HepEm/G4HepEm/include/G4HepEmWoodcockHelper.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmWoodcockHelper.hh
@@ -1,0 +1,101 @@
+#ifndef G4HepEmWoodcockHelper_h
+#define G4HepEmWoodcockHelper_h 1
+
+#include "G4Navigator.hh"
+#include "globals.hh"
+
+class G4VSolid;
+class G4MaterialCutsCouple;
+class G4Material;
+class G4LogicalVolume;
+class G4VPhysicalVolume;
+class G4Track;
+
+class G4HepEmData;
+class G4HepEmMatCutData;
+class G4HepEmGammaTrack;
+
+#include <map>
+
+class G4HepEmWoodcockHelper {
+public:
+    G4HepEmWoodcockHelper();
+   ~G4HepEmWoodcockHelper();
+
+    // Returns true only if at least one Woodcock tracking region has been found
+    G4bool Initialize(std::vector<std::string>& wdtRegionNames, struct G4HepEmMatCutData* hepEmMatCutData, G4VPhysicalVolume* worldVolume);
+
+
+    void     SetKineticEnergyLimit(G4double val) { fWDTKineticEnergyLimit = val; }
+    G4double GetKineticEnergyLimit() { return fWDTKineticEnergyLimit; }
+
+
+    // Checks if this step will be done in a WDT region with high enough kinetic energy.
+    // Finds the root volume of the region in chich this step will be done and
+    // sets the following fileds: fWDTTransform, fWDTHepEmIMC, fWDTSolid, fWDTCouple
+    // Returns `false` is the step is not in a WDT region or the energy is too low.
+    G4bool  FindWDTVolume(int regionID, const G4Track& aTrack);
+
+    // Keeps "Woodock" tracking inside an envelop, found and set up in `FindWDTVolume`,
+    // till the photon gets close to this volume boundary (returns `true`) or
+    // reaches a point of interaction (returns `false`). The accumulated step length
+    // during the tracking is written to the field of the input G4HepEmTrack while
+    // all relevant pre-step point infomatin is set to thier post-step point value
+    // (as several volume boundaries might have been crossed between the pre- and
+    // post step points and interaction can only happen at the post step point if any).
+    G4bool KeepTracking(const struct G4HepEmData* theHepEmData, G4HepEmGammaTrack* theGammaTrack, G4Track& aTrack);
+
+
+private:
+
+   void ClearData();
+
+   void FindWDTMaterial(G4LogicalVolume* lvol, double& maxDensity, G4Material** maxDensityMat);
+
+
+   // One `WDTDataPerRootLogVol` data is structured for each root logical volume
+   // of a Woodcock tracking reagion: with a pointer to its solid, to the mat.-
+   // cuts couple of the "heaviest" material in this branch, i.e. below the root
+   // logical volume, and its corresponding G4HepEm material-cuts couple index.
+   struct WDTDataPerRootLogVol {
+     WDTDataPerRootLogVol()
+     : fSolid(nullptr), fG4Couple(nullptr), fG4CoupleHepEmIndex(-1) {}
+     WDTDataPerRootLogVol(G4VSolid* solid, G4MaterialCutsCouple* couple, G4int hepEmIMC)
+     : fSolid(solid),   fG4Couple(couple),  fG4CoupleHepEmIndex(hepEmIMC) {}
+     G4VSolid*              fSolid;              // solid of the root logical vol.
+     G4MaterialCutsCouple*  fG4Couple;           // couple with the heaviest material
+     G4int                  fG4CoupleHepEmIndex; // G4HepEm mat-cut index of that
+   };
+
+   // All `WDTDataPerRootLogVol` that belongs to one Woodcock tracking region, i.e.
+   // as many as root logical volume of that region. Indexed by the ID of the
+   // root logical volume (i.e. that's the key).
+   struct WDTDataForARegion {
+     std::map<G4int, WDTDataPerRootLogVol*> fWDTDataRegion;
+   };
+
+   // Woodcock tracking related data for all regions where Woodcock tracking was
+   // requested by giving the name of the regions (and a detector region with that
+   // name has been found). Indexed by the G4Region ID (i.e. that's the key).
+   // All these data are initialised when the `Initialize` method is invoked.
+   std::map<G4int, WDTDataForARegion*> fWDTData;
+
+   // Some data that are used during the Woodcock tracking and their values are
+   // set accoring to the root logical volume inside which the actual tracking is
+   // performed. Most of these values are set based on the `WDTDataPerRootLogVol`,
+   // (stored for all root logical volumes of all Woodcock tracking regions)
+   // inside the `FindRootVolume` method.
+   // NOTE: none of these objects are owned
+   G4VSolid*             fWDTSolid;
+   G4MaterialCutsCouple* fWDTCouple;
+   G4int                 fWDTHepEmIMC;
+   G4AffineTransform     fWDTTransform;  // transformation of the actual phy. vol.
+
+   // A navigator used to locate points (not to mess with the navigator for tarcking)
+   G4Navigator           fWDTNavigator;
+
+   // A kinetic energy limit below which Woodcock tracking is turned off.
+   G4double              fWDTKineticEnergyLimit;
+};
+
+#endif // G4HepEmWoodcockHelper

--- a/G4HepEm/G4HepEm/src/G4HepEmWoodcockHelper.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmWoodcockHelper.cc
@@ -1,0 +1,333 @@
+
+#include "G4HepEmWoodcockHelper.hh"
+
+#include "G4VSolid.hh"
+#include "G4MaterialCutsCouple.hh"
+#include "G4Material.hh"
+#include "G4LogicalVolume.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4RegionStore.hh"
+
+#include "G4Track.hh"
+#include "G4TouchableHistory.hh"
+#include "G4NavigationHistory.hh"
+#include "G4TransportationManager.hh"
+
+#include "Randomize.hh"
+
+#include "G4HepEmData.hh"
+#include "G4HepEmMatCutData.hh"
+#include "G4HepEmGammaTrack.hh"
+
+#include "G4HepEmGammaManager.hh"
+
+G4HepEmWoodcockHelper::G4HepEmWoodcockHelper()
+: fWDTSolid(nullptr),
+  fWDTCouple(nullptr),
+  fWDTHepEmIMC(-1),
+  fWDTKineticEnergyLimit(0.2) // 200 keV
+{ }
+
+
+G4HepEmWoodcockHelper::~G4HepEmWoodcockHelper() {
+  ClearData();
+}
+
+
+G4bool G4HepEmWoodcockHelper::Initialize(std::vector<std::string>& wdtRegionNames, struct G4HepEmMatCutData* hepEmMatCutData, G4VPhysicalVolume* worldVolume) {
+  // make sure that all data are cleared
+  ClearData();
+  // NOTE: I will alway know that a given region is Woodcock region or not by
+  // checking if the region ID is in the `fWDTData` map. And do not need to check
+  // in each step during the tracking: as long as the region stays the same.
+  //
+  G4bool oneHasBeenFound = false;
+  // Try to find the Woodcock tracking regions (one-by-one) in the store by using
+  // their names (given by the user).
+  const int numWDTRegions = wdtRegionNames.size();
+  for (int ir=0; ir<numWDTRegions; ++ir) {
+    const std::string& wdtRegionName = wdtRegionNames[ir];
+    G4Region* wdtRegion = G4RegionStore::GetInstance()->GetRegion(wdtRegionName, false);
+    if (wdtRegion != nullptr) {
+      oneHasBeenFound = true;
+      // Found a region with the given name: set Region ID to index map element
+      // Create a WDT data for this region and store in the `fWDTData` map
+      WDTDataForARegion* wdtDataRegion = new WDTDataForARegion();
+      fWDTData[wdtRegion->GetInstanceID()] = wdtDataRegion;
+      // Iterate the root logical volumes of this region.
+      // Find and store their solid and the heaviest material within each
+      int numRootLVolume = wdtRegion->GetNumberOfRootVolumes();
+      // std::cout << "G4HepEmWoodcockHelper::Initialize() Woodcock region = "
+      //          << wdtRegionName << " was found with "
+      //          << numRootLVolume << " root logical volumes."
+      //          << std::endl;
+      std::vector<G4LogicalVolume*>::const_iterator itrLV = wdtRegion->GetRootLogicalVolumeIterator();
+      for (std::size_t ilv = 0; ilv<numRootLVolume; ++ilv) {
+        G4LogicalVolume* rootLogVol = (*itrLV);
+        // std::cout << " The [ " << ilv << " ]-th root logical volume is "
+        //          << rootLogVol->GetName() << std::endl;
+        G4double maxDensity = -1.0;
+        G4Material*  wdtMat = nullptr;
+        // find the material with maximum density in this root logical volume branch
+        FindWDTMaterial(rootLogVol, maxDensity, &wdtMat);
+        G4MaterialCutsCouple* wdtCouple = wdtRegion->FindCouple(wdtMat);
+        // std::cout << " The heaviest material in this branch is " << wdtMat->GetName()
+        //          << " wdtCouple indx = " << wdtCouple->GetIndex()
+        //          << " wdTMat name = " << wdtMat->GetName()
+        //          << std::endl;
+        // Create a `WDTDataPerRootLogVol`structure for this root logical volume
+        // set all required fields and store in the map indexed(key) by the log. vol. ID
+        const int hepEmIMC = hepEmMatCutData->fG4MCIndexToHepEmMCIndex[wdtCouple->GetIndex()];
+        WDTDataPerRootLogVol* wdtDataRootLogVol = new WDTDataPerRootLogVol(rootLogVol->GetSolid(), wdtCouple, hepEmIMC);
+        wdtDataRegion->fWDTDataRegion[rootLogVol->GetInstanceID()] = wdtDataRootLogVol;
+        ++itrLV;
+      }
+    } else {
+      // std::cout << "G4HepEmWoodcockHelper::Initialize() Woodcock region = "
+      //          << wdtRegionName << " was NOT found!"
+      //          << std::endl;
+    }
+  }
+  //
+  if (oneHasBeenFound) {
+    // Set the world volume of the WDT navigator
+    fWDTNavigator.SetWorldVolume(worldVolume);
+  }
+  return oneHasBeenFound;
+}
+
+
+G4bool G4HepEmWoodcockHelper::FindWDTVolume(int regionID, const G4Track& aTrack) {
+  // Early return if this step is not in a WDT region or kinetic energy is too low
+  if ( fWDTData.find(regionID) == fWDTData.end() || aTrack.GetKineticEnergy() < fWDTKineticEnergyLimit) {
+    return false;
+  }
+  // Obtain the Woodcock tracking data stored for the actual region
+  WDTDataForARegion* wdtDataRegion = fWDTData[regionID];
+  // Find the actual root logical volume within this step is done
+  // NOTE: it doesn't change the state of the touchable so I can keep tracking after
+  const G4NavigationHistory* navHistory = ((G4TouchableHistory*)(aTrack.GetTouchableHandle()()))->GetHistory();
+  int currentDepth = navHistory->GetDepth();
+  std::map<G4int, WDTDataPerRootLogVol*>::iterator itr;
+  while (currentDepth > -1) {
+    itr = wdtDataRegion->fWDTDataRegion.find(navHistory->GetVolume(currentDepth)->GetLogicalVolume()->GetInstanceID());
+    if (itr != wdtDataRegion->fWDTDataRegion.end()) {
+      break;
+    }
+    // moving one level up in the geometry tree
+    --currentDepth;
+  };
+  // Don't do WDT if the volume was not found
+  if (currentDepth < 0) {
+    return false;
+  }
+  // Get the WDT data for the root logical volume in which the actual tracking happens
+  WDTDataPerRootLogVol* wdtDataRootLogVol = itr->second;
+  // Obtain the actual transformation: used to transform the actual point/direction to
+  // volume local before computing the distance to its boundary.
+  fWDTTransform = navHistory->GetTransform(currentDepth);
+  fWDTHepEmIMC  = wdtDataRootLogVol->fG4CoupleHepEmIndex;
+  fWDTSolid     = wdtDataRootLogVol->fSolid;
+  fWDTCouple    = wdtDataRootLogVol->fG4Couple;
+  //
+  // Check if the current pre-step point is indeed inside. If distance to
+  // the root volume boundary is zero (or very small) then just do normal
+  // tracking as we are already (logically) outside (might be due to
+  // boundary crossing in multiple steps)
+  const G4ThreeVector& r0 = aTrack.GetPosition();
+  const G4ThreeVector& v0 = aTrack.GetMomentumDirection();
+  const G4ThreeVector localPoint     = fWDTTransform.TransformPoint(r0);
+  const G4ThreeVector localDirection = fWDTTransform.TransformAxis(v0);
+  G4double distToBoundary = std::max(fWDTSolid->DistanceToOut(localPoint, localDirection)-1.0E-3, 0.0 );
+  return (distToBoundary < 1.0E-6) ? false : true;
+}
+
+
+G4bool G4HepEmWoodcockHelper::KeepTracking(const struct G4HepEmData* theHepEmData, G4HepEmGammaTrack* theGammaTrack, G4Track& aTrack) {
+  // Calculate the distance to boundary and the physics length keep eating up
+  // the distance to boundary till: 1. interaction is reached or close to boundary.
+  // In both cases, locate the point before going further, then either make
+  // a boundary step (case 2.) or let it go to selecting and performing the
+  // physics interaction.
+  G4StepPoint& preStepPoint  = *(aTrack.GetStep()->GetPreStepPoint());
+  G4StepPoint& postStepPoint = *(aTrack.GetStep()->GetPostStepPoint());
+
+  // Compute the distance to the boundary of the actual root volume.
+  // - get direction and start position
+  const G4ThreeVector& r0 = preStepPoint.GetPosition();
+  const G4ThreeVector& v0 = preStepPoint.GetMomentumDirection();
+  const G4ThreeVector localPoint     = fWDTTransform.TransformPoint(r0);
+  const G4ThreeVector localDirection = fWDTTransform.TransformAxis(v0);
+  G4double distToBoundary = std::max( fWDTSolid->DistanceToOut(localPoint, localDirection)-1.0E-3, 0.0 );
+  // When `distToBoundary = 0`, we are within 1.0E-3 to the the boundary.
+  //
+  // Compute the WDT reference mxsec (i.e. maximum total mxsec along this setp).
+  // (need to set only the MC index as ekin has alrady been set above).
+  G4HepEmTrack* thePrimaryTrack = theGammaTrack->GetTrack();
+  thePrimaryTrack->SetMCIndex(fWDTHepEmIMC);
+  const G4double wdtMXsec   = G4HepEmGammaManager::GetTotalMacXSec(theHepEmData, theGammaTrack);
+  const G4double wdtMFP     = wdtMXsec > 0.0 ? 1.0/wdtMXsec : DBL_MAX;
+  const G4double wdtPEmxSec = theGammaTrack->GetPEmxSec();
+  // Init some variables before starting Woodcock tracking of the gamma
+  const G4Material* wdtMaterial = fWDTCouple->GetMaterial();
+  G4double mxsec = 0.0;
+  G4int prevHepEmIMC = -1;
+  G4bool doStop = false;
+
+  // While either interacts or gets close to the boundary of the actual root volume:
+  const G4int* g4MCIndexToHepEmMCIndex = theHepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex;
+  G4double wdtStepLength = 0.0;
+  G4bool isWDTReachedBoundary = false;
+  while (!doStop) {
+    // Compute the step length till the next interaction in the WDT material
+    const G4double pstep = wdtMFP < DBL_MAX ? -G4Log( G4UniformRand() )*wdtMFP : DBL_MAX;
+    // Take the minimum of this and the distance to the WDT root volume boundary
+    // while checking if this step ends up close to the volume boundary
+    if (distToBoundary < pstep) {
+      wdtStepLength += distToBoundary;
+      isWDTReachedBoundary = true;
+      doStop = true;
+    } else {
+      // Particle will be moved by a step length of `pstep` so we reduce the
+      // distance to boundary accordingly.
+      wdtStepLength  += pstep;
+      distToBoundary -= pstep;
+      // Locate the actual post step point in order to get the real material.
+      // NOTE: we might start here from a certain depth (i.e. from the depth of
+      //       the actual root logical volume)
+      const G4VPhysicalVolume* pVol = fWDTNavigator.LocateGlobalPointAndSetup(r0+wdtStepLength*v0, nullptr, true, true);
+      const G4LogicalVolume*   lVol = pVol->GetLogicalVolume();
+      const G4Material* postStepMat = lVol->GetMaterial();
+      // Check if the real material of the post-step point is the WDT one?
+      if (wdtMaterial != postStepMat) {
+        // Post step point is NOT in the WDT material: need to check if interacts.
+        // Compute the total macroscopic cross section for that material.
+        const G4MaterialCutsCouple* couple = lVol->GetMaterialCutsCouple();
+        const int hepEmIMC = g4MCIndexToHepEmMCIndex[couple->GetIndex()];
+        if (hepEmIMC != prevHepEmIMC) {
+          // Recompute the total macroscopic cross section only if the material
+          // has changed compared to the previous computation (energy stays const.)
+          prevHepEmIMC = hepEmIMC;
+          thePrimaryTrack->SetMCIndex(hepEmIMC);
+          mxsec = G4HepEmGammaManager::GetTotalMacXSec(theHepEmData, theGammaTrack);
+        }
+        // Sample if interaction happens at this post step point:
+        // P(interact) = preStepLambda/wdckMXsec note: preStepLambda <= wdckMXsec
+        doStop = (mxsec*wdtMFP > G4UniformRand());
+        if (doStop) {
+          // Interaction happens: set the track fields required later.
+          // Set the total MFP of the track that will be needed when sampling
+          // the type of the interaction. The HepEm MC index is already set
+          // above while the g4 one is also set here.
+          const double mfp = mxsec > 0.0 ? 1.0/mxsec : DBL_MAX;
+          thePrimaryTrack->SetMFP(mfp, 0);
+          // g4IMC = couple->GetIndex();
+          // NOTE: PE mxsec is correct as the last call to `GetTotalMacXSec`
+          // was fone above for this material.
+        }
+      } else {
+        // Post step point is in the WDT material: interacts for sure (prob.=1)
+        // Set the total MFP and MC index of the track that will be needed when
+        // sampling the type of the interaction. The g4 MC index is also set here.
+        doStop = true;
+        thePrimaryTrack->SetMCIndex(fWDTHepEmIMC);
+        thePrimaryTrack->SetMFP(wdtMFP, 0);
+        // g4IMC = fWDTHelper->fWDTCouple->GetIndex();
+        // Reset the PE mxsec: set in `G4HepEmGammaManager::GetTotalMacXSec`
+        // that might have been called for an other material above (without
+        // resulting in interaction). Needed for the interaction type sampling.
+        theGammaTrack->SetPEmxSec(wdtPEmxSec);
+      }
+    }
+
+    if (doStop) {
+      // Reached the end, i.e. either interaction happens at the current post
+      // step point or it is locating close to the WDT volume boundary
+      // (wdtRegionBoundary=true in this case).
+      // Update the track with its final position and locate the track properly.
+      postStepPoint.SetPosition(r0+wdtStepLength*v0);
+      G4TouchableHandle touchableHandle = aTrack.GetTouchableHandle();
+      G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->LocateGlobalPointAndUpdateTouchableHandle(postStepPoint.GetPosition(), postStepPoint.GetMomentumDirection(), touchableHandle, false);
+      aTrack.SetTouchableHandle(touchableHandle);
+      aTrack.SetNextTouchableHandle(touchableHandle);
+      // Set pre/post step point location and touchable to be the same (as we
+      // might have moved the track from a far away volume).
+      // NOTE: as energy deposit happens only at discrete interactions for gamma,
+      // in case of non-zero energy deposit, i.e. when SD codes are invoked,
+      // the track is never on boundary. So all SD code should work fine with
+      // identical pre- and post-step points.
+      postStepPoint.SetTouchableHandle(touchableHandle);
+      preStepPoint.SetTouchableHandle(touchableHandle);
+      preStepPoint.SetPosition(postStepPoint.GetPosition());
+      // NOTE: some (e.g. calibration) SD codes might be called even in case of zero
+      // energy deposit so set the SD pointer in all cases.
+      const G4LogicalVolume* postStepLogVol = touchableHandle->GetVolume()->GetLogicalVolume();
+      preStepPoint.SetSensitiveDetector(postStepLogVol->GetSensitiveDetector());
+
+      // Set all track properteis needed later: all pre-step point information are
+      // actually set to be their post step point values!
+      // lvol = aTrack.GetTouchable()->GetVolume()->GetLogicalVolume();
+      // MCC  = lvol->GetMaterialCutsCouple();
+      preStepPoint.SetMaterial(postStepLogVol->GetMaterial());
+      preStepPoint.SetMaterialCutsCouple(postStepLogVol->GetMaterialCutsCouple());
+
+      postStepPoint.SetMaterial(postStepLogVol->GetMaterial());
+      postStepPoint.SetMaterialCutsCouple(postStepLogVol->GetMaterialCutsCouple());
+
+      // NOTE: the number of interaction length left will be cleared in all
+      // cases when WDT tracking happened (see below).
+    }
+    // If the WDT region boundary has not been reached in this step then delta
+    // interaction happend so just keep moving the post-step point toward the
+    // WDT (root) volume boundary.
+  };  // END OF WHILE ON WDT
+
+  // Update the time based on the accumulated WDT step length
+  // step.SetStepLength(wdtStepLength);
+  // aTrack->SetStepLength(wdtStepLength);
+  const G4double preStepVelocity = preStepPoint.GetVelocity();
+  const G4double deltaTime = preStepVelocity > 0 ? wdtStepLength/preStepVelocity : 0;
+  postStepPoint.AddGlobalTime(deltaTime);
+  postStepPoint.AddLocalTime(deltaTime);
+
+  // Store the total Woodcock tracking step length in the HepEmTrack field and
+  // return with the flag that indicates if boundary has been reached.
+  thePrimaryTrack->SetGStepLength(wdtStepLength);
+
+  return isWDTReachedBoundary;
+}
+
+
+void G4HepEmWoodcockHelper::ClearData() {
+  // iterate over the `fWDTData` map
+  std::map<G4int, WDTDataForARegion*>::iterator itrRegion = fWDTData.begin();
+  for (; itrRegion != fWDTData.end(); itrRegion++) {
+    // iterate over the root logical volume data inside each reagion
+    WDTDataForARegion* dataForARegion = itrRegion->second;
+    std::map<G4int, WDTDataPerRootLogVol*>::iterator itrRootVol
+        = dataForARegion->fWDTDataRegion.begin();
+    for (; itrRootVol != dataForARegion->fWDTDataRegion.end(); itrRootVol++) {
+      // NOTE: we do not own the solid and the material-cuts couple (only store their ptr)
+      delete itrRootVol->second;
+    }
+    dataForARegion->fWDTDataRegion.clear();
+    delete dataForARegion;
+  }
+  fWDTData.clear();
+}
+
+
+void G4HepEmWoodcockHelper::FindWDTMaterial(G4LogicalVolume* lvol, double& maxDensity, G4Material** maxDensityMat) {
+  G4Material*  mat = lvol->GetMaterial();
+  G4double density = mat->GetDensity();
+  if (density > maxDensity) {
+    maxDensity = density;
+    *maxDensityMat = mat;
+  }
+  // recurse
+  int numDaughters = lvol->GetNoDaughters();
+  for (int id=0; id<numDaughters; ++id) {
+      G4LogicalVolume* lv = lvol->GetDaughter(id)->GetLogicalVolume();
+      FindWDTMaterial(lv, maxDensity, maxDensityMat);
+  }
+}

--- a/apps/examples/TestEm3/ATLASbar.mac
+++ b/apps/examples/TestEm3/ATLASbar.mac
@@ -40,7 +40,12 @@
 ## -----------------------------------------------------------------------------
 ## Option to apply cuts also beyond ionisation and bremsstrahlung
 ## -----------------------------------------------------------------------------
-##/process/em/UseGeneralProcess true
+/process/em/applyCuts true
+##
+## -----------------------------------------------------------------------------
+## Option to set the production cut value in the "Woodcock_Region" (calorimeter)
+## -----------------------------------------------------------------------------
+/testem/det/setWDCKRegionCut 0.7 mm
 ##
 ## -----------------------------------------------------------------------------
 ## Set secondary production threshold, init. the run and set primary properties

--- a/apps/examples/TestEm3/include/DetectorConstruction.hh
+++ b/apps/examples/TestEm3/include/DetectorConstruction.hh
@@ -70,6 +70,8 @@ public:
   void SetCalorSizeYZ(G4double);
   void SetNbOfLayers(G4int);
 
+  void SetWDTRegionCutValue(G4double cut) { fWDTRegionCutValue = cut; }
+
   void SetMagField(const G4ThreeVector &fv) { fMagFieldVector = fv; }
 
   void SetPrimaryGenerator(PrimaryGeneratorAction *pg) { fPrimaryGenerator = pg; }
@@ -103,6 +105,9 @@ private:
 
   G4double fCalorSizeYZ;
   G4double fCalorThickness;
+
+  // cut value for the Woodcock tracking region (i.e. for the calorimeter)
+  G4double fWDTRegionCutValue;
 
   G4Material *fDefaultMaterial;
   G4double fWorldSizeYZ;

--- a/apps/examples/TestEm3/include/DetectorMessenger.hh
+++ b/apps/examples/TestEm3/include/DetectorMessenger.hh
@@ -60,17 +60,19 @@ class DetectorMessenger: public G4UImessenger
 
     G4UIdirectory*             fTestemDir;
     G4UIdirectory*             fDetDir;
-    
+
     G4UIcmdWithADoubleAndUnit* fSizeYZCmd;
     G4UIcmdWithAnInteger*      fNbLayersCmd;
     G4UIcmdWithAnInteger*      fNbAbsorCmd;
     G4UIcommand*               fAbsorCmd;
-    //
+
     G4UIcmdWith3VectorAndUnit* fFieldCmd;
+
+    G4UIcmdWithADoubleAndUnit* fWDTRegionCutCmd;
+
 
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #endif
-

--- a/apps/examples/TestEm3/src/DetectorConstruction.cc
+++ b/apps/examples/TestEm3/src/DetectorConstruction.cc
@@ -55,6 +55,8 @@
 #include "G4UniformMagField.hh"
 #include "G4FieldManager.hh"
 
+#include "G4ProductionCuts.hh"
+
 #include "PrimaryGeneratorAction.hh"
 
 #include <iomanip>
@@ -72,6 +74,7 @@ DetectorConstruction::DetectorConstruction()
   fAbsorThickness[2] = 5.7 * mm;
   fNbOfLayers        = 50;
   fCalorSizeYZ       = 40. * cm;
+  fWDTRegionCutValue = 0.7 * mm;
   ComputeCalorParameters();
 
   // materials
@@ -368,6 +371,17 @@ G4VPhysicalVolume *DetectorConstruction::ConstructCalorimeter()
   }
   //
   PrintCalorParameters();
+
+  //
+  // Create a Detector region with the calorimeter inside and name = Woodcock_Region
+  G4Region* regionWDCK = new G4Region("Woodcock_Region");
+  regionWDCK->AddRootLogicalVolume(fLogicCalor);
+  // a UI command, to set the cut value in the WDCK region, has also been added
+  G4ProductionCuts* pcut = new G4ProductionCuts;
+  pcut->SetProductionCut(fWDTRegionCutValue, 0);
+  pcut->SetProductionCut(fWDTRegionCutValue, 1);
+  pcut->SetProductionCut(fWDTRegionCutValue, 2);
+  regionWDCK->SetProductionCuts(pcut);
 
   // always return the fPhysical World
   //

--- a/apps/examples/TestEm3/src/DetectorMessenger.cc
+++ b/apps/examples/TestEm3/src/DetectorMessenger.cc
@@ -54,8 +54,9 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction * Det)
  fNbLayersCmd(0),
  fNbAbsorCmd(0),
  fAbsorCmd(0),
- fFieldCmd(0)
-{ 
+ fFieldCmd(0),
+ fWDTRegionCutCmd(0)
+{
   fTestemDir = new G4UIdirectory("/testem/");
   fTestemDir->SetGuidance("UI commands specific to this example");
   //
@@ -69,14 +70,14 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction * Det)
   fSizeYZCmd->SetUnitCategory("Length");
   fSizeYZCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   fSizeYZCmd->SetToBeBroadcasted(false);
-  //  
+  //
   fNbLayersCmd = new G4UIcmdWithAnInteger("/testem/det/setNbOfLayers",this);
   fNbLayersCmd->SetGuidance("Set number of layers.");
   fNbLayersCmd->SetParameterName("NbLayers",false);
   fNbLayersCmd->SetRange("NbLayers>0");
   fNbLayersCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   fNbLayersCmd->SetToBeBroadcasted(false);
-  // 
+  //
   fNbAbsorCmd = new G4UIcmdWithAnInteger("/testem/det/setNbOfAbsor",this);
   fNbAbsorCmd->SetGuidance("Set number of Absorbers.");
   fNbAbsorCmd->SetParameterName("NbAbsor",false);
@@ -89,12 +90,12 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction * Det)
   fFieldCmd->SetUnitCategory("Magnetic flux density");
   fFieldCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
   fFieldCmd->SetToBeBroadcasted(false);
-  // 
+  //
   fAbsorCmd = new G4UIcommand("/testem/det/setAbsor",this);
   fAbsorCmd->SetGuidance("Set the absor nb, the material, the thickness.");
   fAbsorCmd->SetGuidance("  absor number : from 1 to NbOfAbsor");
   fAbsorCmd->SetGuidance("  material name");
-  fAbsorCmd->SetGuidance("  thickness (with unit) : t>0."); 
+  fAbsorCmd->SetGuidance("  thickness (with unit) : t>0.");
   //
   G4UIparameter* AbsNbPrm = new G4UIparameter("AbsorNb",'i',false);
   AbsNbPrm->SetGuidance("absor number : from 1 to NbOfAbsor");
@@ -104,7 +105,7 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction * Det)
   G4UIparameter* MatPrm = new G4UIparameter("material",'s',false);
   MatPrm->SetGuidance("material name");
   fAbsorCmd->SetParameter(MatPrm);
-  //    
+  //
   G4UIparameter* ThickPrm = new G4UIparameter("thickness",'d',false);
   ThickPrm->SetGuidance("thickness of absorber");
   ThickPrm->SetParameterRange("thickness>0.");
@@ -117,7 +118,16 @@ DetectorMessenger::DetectorMessenger(DetectorConstruction * Det)
   fAbsorCmd->SetParameter(unitPrm);
   //
   fAbsorCmd->AvailableForStates(G4State_PreInit,G4State_Idle);
-  fAbsorCmd->SetToBeBroadcasted(false);  
+  fAbsorCmd->SetToBeBroadcasted(false);
+
+  fWDTRegionCutCmd = new G4UIcmdWithADoubleAndUnit("/testem/det/setWDCKRegionCut",this);
+  fWDTRegionCutCmd->SetGuidance("Set the cut value used in the Woodcock tracking region (which is the calorimeter)");
+  fWDTRegionCutCmd->SetParameterName("Size",false);
+  fWDTRegionCutCmd->SetRange("Size>0.");
+  fWDTRegionCutCmd->SetUnitCategory("Length");
+  fWDTRegionCutCmd->AvailableForStates(G4State_PreInit);
+  fWDTRegionCutCmd->SetToBeBroadcasted(false);
+
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -129,8 +139,9 @@ DetectorMessenger::~DetectorMessenger()
   delete fNbAbsorCmd;
   delete fAbsorCmd;
   delete fFieldCmd;
-  delete fDetDir;  
+  delete fDetDir;
   delete fTestemDir;
+  delete fWDTRegionCutCmd;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -148,7 +159,7 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
 
   if( command == fFieldCmd )
    { fDetector->SetMagField(fFieldCmd->GetNew3VectorValue(newValue));}
-   
+
   if (command == fAbsorCmd)
    {
      G4int num; G4double tick;
@@ -160,6 +171,11 @@ void DetectorMessenger::SetNewValue(G4UIcommand* command,G4String newValue)
      fDetector->SetAbsorMaterial (num,material);
      fDetector->SetAbsorThickness(num,tick);
    }
+
+   if( command == fWDTRegionCutCmd ) {
+     fDetector->SetWDTRegionCutValue(fWDTRegionCutCmd->GetNewDoubleValue(newValue));
+   }
+
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/apps/examples/TestEm3/src/PhysListHepEmTracking.cc
+++ b/apps/examples/TestEm3/src/PhysListHepEmTracking.cc
@@ -31,6 +31,8 @@ void PhysListHepEmTracking::ConstructProcess()
   // Register custom tracking manager for e-/e+ and gammas.
   auto* trackingManager = new G4HepEmTrackingManager;
 
+  trackingManager->AddWoodcockTrackingRegion("Woodcock_Region");
+
   G4Electron::Definition()->SetTrackingManager(trackingManager);
   G4Positron::Definition()->SetTrackingManager(trackingManager);
   G4Gamma::Definition()->SetTrackingManager(trackingManager);


### PR DESCRIPTION
Woodcock tracking of photons is used now in the HepEm tracking manager when tracking photons. It can be activated in a detector region by simply adding the detector region name to the HepEm tracking manager using the provided `AddWoodcockTrackingRegion` method.  This can significantly accelerate the simulation in case of sub-detectors with higher granularity when the volume size if smaller then the mean free path, i.e. when photons steps are more often limited by the volume boundary than physics interaction. 

Woodcock tracking of photons is activated now by default in the `TestEm3` example application.  
 