### PR TITLE
Add early tracking exit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,13 @@
 cmake_minimum_required(VERSION 3.17...3.18 FATAL_ERROR)
 project(G4HepEm VERSION 0.1.0)
 
+#----------------------------------------------------------------------------
+# Option for enabling early exit
+option(G4HepEm_EARLY_TRACKING_EXIT "Enable user-defined early tracking exit" OFF)
+if(G4HepEm_EARLY_TRACKING_EXIT)
+  message(STATUS "User-defined early tracking exit is enabled")
+endif()
+
 # Local and Core Modules
 include(GNUInstallDirs)
 include(CheckLanguage)
@@ -30,6 +37,10 @@ function(g4hepem_add_library _name)
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
       $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}>)
     target_link_libraries(${_name} PUBLIC ${_g4hepem_LINK})
+
+    if(G4HepEm_EARLY_TRACKING_EXIT)
+      target_compile_definitions(${_name} PUBLIC G4HepEm_EARLY_TRACKING_EXIT)
+    endif()
   endif()
 
   # Build static library, if enabled.
@@ -45,6 +56,10 @@ function(g4hepem_add_library _name)
     foreach(_lib ${_g4hepem_LINK})
       target_link_libraries(${_name}-static PUBLIC ${_lib}-static)
     endforeach()
+
+    if(G4HepEm_EARLY_TRACKING_EXIT)
+      target_compile_definitions(${_name}-static PUBLIC G4HepEm_EARLY_TRACKING_EXIT)
+    endif()
 
     # If only the static library, add alias targets for convenience.
     if(NOT BUILD_SHARED_LIBS)

--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -29,7 +29,7 @@ public:
 
   void PreparePhysicsTable(const G4ParticleDefinition &) override;
 
-  virtual void HandOverOneTrack(G4Track *aTrack) override;
+  void HandOverOneTrack(G4Track *aTrack) override;
 
   void SetMultipleSteps(G4bool val) {
     fMultipleSteps = val;

--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -3,7 +3,6 @@
 
 #include "G4EventManager.hh"
 #include "G4VTrackingManager.hh"
-
 #include "globals.hh"
 
 class G4HepEmRunManager;

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -192,7 +192,7 @@ void G4HepEmTrackingManager::PreparePhysicsTable(
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
+bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
   TrackingManagerHelper::ChargedNavigation navigation;
 
   // Prepare for calling the user action.
@@ -307,6 +307,13 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
 
   while(aTrack->GetTrackStatus() == fAlive)
   {
+#ifdef G4HepEm_EARLY_TRACKING_EXIT
+    // check for user-defined early exit
+    if (CheckEarlyTrackingExit(aTrack, evtMgr, userTrackingAction, secondaries)) {
+      return false; 
+    }
+#endif
+
     // Beginning of this step: Prepare data structures.
     aTrack->IncrementCurrentStepNumber();
 
@@ -734,11 +741,12 @@ void G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
   }
 
   evtMgr->StackTracks(&secondaries);
+  return true;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
+bool G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
   TrackingManagerHelper::NeutralNavigation navigation;
 
   // Prepare for calling the user action.
@@ -848,6 +856,12 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
   // === StartTracking ===
 
   while (aTrack->GetTrackStatus() == fAlive) {
+#ifdef G4HepEm_EARLY_TRACKING_EXIT
+    // check for user-defined early exit
+    if (CheckEarlyTrackingExit(aTrack, evtMgr, userTrackingAction, secondaries)) {
+      return false; 
+    }
+#endif
 
     // Beginning of this step: Prepare data structures.
     aTrack->IncrementCurrentStepNumber();
@@ -1144,6 +1158,7 @@ void G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
   }
 
   evtMgr->StackTracks(&secondaries);
+  return true;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......


### PR DESCRIPTION
This PR adds the feature of intercepting the tracking loop of `TrackElectron` and `TrackGamma` in the `G4HepEmTrackingManager`. Via the compile-time flag `G4HepEm_EARLY_TRACKING_EXIT` a new virtual function `CheckEarlyTrackingExit` is introduced. If that function returns true, the tracking loop is exited immediately. It is up to the user in the derived class to handle the proper ending of the track. Therefore few parameters needed to be set to `protected` instead of `private`. 

This feature allows for exiting the tracking loop to, e.g., track particles on GPU, as shown in the derived `G4HepEmTrackingManagerSpecialized` class in [this PR in AdePT ](https://github.com/apt-sim/AdePT/pull/324).