### PR TITLE
Storing and making available the secondary e+ production energy threshold values also on the device now.

### DIFF
--- a/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
@@ -41,6 +41,8 @@
 struct G4HepEmMCCData {
   /** Secondary \f$e^-\f$ production threshold energy [MeV]. */
   double  fSecElProdCutE = 0.0;
+  /** Secondary \f$e^+\f$ production threshold energy [MeV]. */
+  double  fSecPosProdCutE = 0.0;
   /** Secondary \f$\gamma\f$ production threshold energy [MeV]. */
   double  fSecGamProdCutE = 0.0;
   /** Logarithm of the above secondary \f$\gamma\f$ production threshold. */

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -429,6 +429,7 @@ namespace nlohmann
     static void to_json(json& j, const G4HepEmMCCData& d)
     {
       j["fSecElProdCutE"]  = d.fSecElProdCutE;
+      j["fSecPosProdCutE"] = d.fSecPosProdCutE;
       j["fSecGamProdCutE"] = d.fSecGamProdCutE;
       j["fLogSecGamCutE"]  = d.fLogSecGamCutE;
       j["fHepEmMatIndex"]  = d.fHepEmMatIndex;
@@ -440,6 +441,7 @@ namespace nlohmann
       G4HepEmMCCData d;
 
       j.at("fSecElProdCutE").get_to(d.fSecElProdCutE);
+      j.at("fSecPosProdCutE").get_to(d.fSecPosProdCutE);
       j.at("fSecGamProdCutE").get_to(d.fSecGamProdCutE);
       j.at("fLogSecGamCutE").get_to(d.fLogSecGamCutE);
       j.at("fHepEmMatIndex").get_to(d.fHepEmMatIndex);

--- a/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmMaterialInit.cc
@@ -82,6 +82,7 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
     G4int mcIndx          = matCut->GetIndex();
     G4double gammaCutE    = (*(theCoupleTable->GetEnergyCutsVector(0)))[mcIndx];
     G4double electronCutE = (*(theCoupleTable->GetEnergyCutsVector(1)))[mcIndx];
+    G4double positronCutE = (*(theCoupleTable->GetEnergyCutsVector(2)))[mcIndx];
     const G4Material* mat = matCut->GetMaterial();
     G4int matIndx         = mat->GetIndex();
 
@@ -91,6 +92,7 @@ void InitMaterialAndCoupleData(struct G4HepEmData* hepEmData, struct G4HepEmPara
     // NOTE: mccData.fHepEmMatIndex will be set below when it becomes known
     mccData.fG4MatCutIndex  = mcIndx;
     mccData.fSecElProdCutE  = std::max(electronCutE, hepEmPars->fElectronTrackingCut);
+    mccData.fSecPosProdCutE = positronCutE;
     mccData.fSecGamProdCutE = gammaCutE;
     mccData.fLogSecGamCutE  = std::log(gammaCutE);
     ++numUsedG4MatCuts;

--- a/testing/MaterialAndRelated/src/Implementation.cc
+++ b/testing/MaterialAndRelated/src/Implementation.cc
@@ -147,11 +147,17 @@ bool TestMatCutData ( const struct G4HepEmData* hepEmData ) {
     const int                hepEmMCIndex = hepEmData->fTheMatCutData->fG4MCIndexToHepEmMCIndex[g4MatCut->GetIndex()];
     const struct G4HepEmMCCData& heMatCut = hepEmData->fTheMatCutData->fMatCutData[hepEmMCIndex];
     // compare the stored properties:
-    double  g4ElCutE = (*(theCoupleTable->GetEnergyCutsVector(1)))[g4MatCut->GetIndex()];
-    double g4GamCutE = (*(theCoupleTable->GetEnergyCutsVector(0)))[g4MatCut->GetIndex()];
+    double  g4ElCutE  = (*(theCoupleTable->GetEnergyCutsVector(1)))[g4MatCut->GetIndex()];
+    double  g4PosCutE = (*(theCoupleTable->GetEnergyCutsVector(2)))[g4MatCut->GetIndex()];
+    double g4GamCutE  = (*(theCoupleTable->GetEnergyCutsVector(0)))[g4MatCut->GetIndex()];
     if ( heMatCut.fSecElProdCutE != std::max ( elTrackingCutE, g4ElCutE ) ) {
       isPassed = false;
-      std::cerr << "\n*** ERROR:\nMatCutData: G4HepEm-Geant4 mismatch: fSecElProdCutE != "         << heMatCut.fSecElProdCutE        << " != "  << g4ElCutE        << std::endl;
+      std::cerr << "\n*** ERROR:\nMatCutData: G4HepEm-Geant4 mismatch: fSecElProdCutE != "         << heMatCut.fSecElProdCutE        << " != "  << std::max ( elTrackingCutE, g4ElCutE )  << std::endl;
+      continue;
+    }
+    if ( heMatCut.fSecPosProdCutE != g4PosCutE ) {
+      isPassed = false;
+      std::cerr << "\n*** ERROR:\nMatCutData: G4HepEm-Geant4 mismatch: fSecPosProdCutE != "         << heMatCut.fSecPosProdCutE        << " != "  << g4PosCutE        << std::endl;
       continue;
     }
     if ( heMatCut.fSecGamProdCutE != g4GamCutE ) {

--- a/testing/MaterialAndRelated/src/MatCutData.cu
+++ b/testing/MaterialAndRelated/src/MatCutData.cu
@@ -21,7 +21,7 @@
 // device side main memory
 //
 __global__
-void TestMatCutDataKernel (struct G4HepEmMatCutData* mcData_d, int* mcIndices_d, double* resSecElCut_d
+void TestMatCutDataKernel (struct G4HepEmMatCutData* mcData_d, int* mcIndices_d, double* resSecElCut_d,
                            double* resSecPosCut_d, double* resSecGamCut_d, int* resMatIndx_d, int numTestCases) {
     int tid = blockIdx.x * blockDim.x + threadIdx.x;
     if (tid < numTestCases) {

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -113,10 +113,10 @@ bool operator!=(const G4HepEmElementData& lhs, const G4HepEmElementData& rhs)
 // --- G4HepEmMatCutData
 bool operator==(const G4HepEmMCCData& lhs, const G4HepEmMCCData& rhs)
 {
-  return std::tie(lhs.fSecElProdCutE, lhs.fSecGamProdCutE, lhs.fLogSecGamCutE,
-                  lhs.fHepEmMatIndex, lhs.fG4MatCutIndex) ==
-         std::tie(rhs.fSecElProdCutE, rhs.fSecGamProdCutE, rhs.fLogSecGamCutE,
-                  rhs.fHepEmMatIndex, rhs.fG4MatCutIndex);
+  return std::tie(lhs.fSecElProdCutE, lhs.fSecPosProdCutE, lhs.fSecGamProdCutE,
+                  lhs.fLogSecGamCutE, lhs.fHepEmMatIndex, lhs.fG4MatCutIndex) ==
+         std::tie(rhs.fSecElProdCutE, rhs.fSecPosProdCutE, rhs.fSecGamProdCutE,
+                  rhs.fLogSecGamCutE, rhs.fHepEmMatIndex, rhs.fG4MatCutIndex);
 }
 
 bool operator!=(const G4HepEmMCCData& lhs, const G4HepEmMCCData& rhs)


### PR DESCRIPTION
Secondary positron production values are not used at the moment in the run time part of `G4HepEm` (`G4HepEmRun`) but we added now them to the material cut data to make them available on the device. This can be used now to implement `applyCut` also on the device (similarly as done in the `G4HepEmTrackingManager` based directly on the `Geant4` values).     