### PR TITLE
Adding configuration options, allowing some to be set per detector region.

### DIFF
--- a/G4HepEm/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/G4HepEm/CMakeLists.txt
@@ -19,10 +19,12 @@ set(G4HEPEM_Geant4_LIBRARIES
 if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
   set(G4HEPEM_headers ${G4HEPEM_headers}
     include/G4EmTrackingManager.hh
+    include/G4HepEmConfig.hh
     include/G4HepEmTrackingManager.hh
   )
   set(G4HEPEM_sources ${G4HEPEM_sources}
     src/G4EmTrackingManager.cc
+    src/G4HepEmConfig.cc
     src/G4HepEmTrackingManager.cc
   )
 

--- a/G4HepEm/G4HepEm/include/G4HepEmConfig.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmConfig.hh
@@ -91,6 +91,11 @@ public:
   G4bool GetMultipleStepsInMSCWithTransportation(const G4String& nameRegion);
   G4bool GetMultipleStepsInMSCWithTransportation(int indxRegion);
 
+  // Activating/deactivating applying cuts on other processes beyond ioni. and brem.
+  void   SetApplyCuts(G4bool val, const G4String& nameRegion);
+  void   SetApplyCuts(G4bool val);
+  G4bool GetApplyCuts(const G4String& nameRegion);
+  G4bool GetApplyCuts(int indxRegion);
 
 
   // NOTE: to see if we set its memebr Parameters or it will have its own

--- a/G4HepEm/G4HepEm/include/G4HepEmConfig.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmConfig.hh
@@ -51,6 +51,11 @@ public:
     return fWDTRegionNames;
   }
 
+  // Set/get the kinetic energy limit below which Woodcock tracking should be turned off.*/
+  void     SetWDTEnergyLimit(G4double ekin) { fWDTEnergyLimit = ekin; }
+  G4double GetWDTEnergyLimit() { return fWDTEnergyLimit; }
+
+
 
   // Set the `fDRoverRange` and `fFinalRange` parameters of the continuous energy
   // loss step limit function (everywhere or in a given detector region)
@@ -117,6 +122,8 @@ private:
 
   // The list of detector regions that the user requested Woodock-tracking in.
   std::vector<std::string> fWDTRegionNames;
+  // Kinetic energy below which Woodcock tracking is turned off.*/
+  G4double                 fWDTEnergyLimit;
 
 };
 

--- a/G4HepEm/G4HepEm/include/G4HepEmConfig.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmConfig.hh
@@ -1,0 +1,118 @@
+
+#ifndef G4HepEmConfig_h
+#define G4HepEmConfig_h 1
+
+#include "globals.hh"
+
+#include <vector>
+#include <string>
+
+
+class G4HepEmParameters;
+
+/**
+ * @file    G4HepEmConfig.hh
+ * @class   G4HepEmConfig
+ * @author  M. Novak
+ * @date    2025
+ *
+ * Stores the configuration of the HepEm simulation.
+ *
+ * The `G4HepEmTrackingManager` stores an object from this class that allows its
+ * configuration.
+ *
+ * Most of the configurations/parameters are those stored in the
+ * `G4HepEmParameters` member of this configuration class. These values are red
+ * at run time so they can be set anytime before the `beamON`. Many of these
+ * parameters can be configured in G4HepEm per detector regions!
+ *
+ * Other parameters/configurations are already needed at the initialisation,
+ * e.g. list of Woodcock tracking regions. However, the `G4HepEmTrackingManager`
+ * is constructed only during the initialisation itself (in the physics list
+ * `ConstructProcess` interface). Therefore, these parameters/configurations
+ * need to be set in the code right after the `G4HepEmTrackingManager` is
+ * constructed and assigned to the particles (i.e. in `ConstructProcess`).
+ */
+
+
+// Class to hold parameters that can be set by the user.
+class G4HepEmConfig {
+public:
+  G4HepEmConfig();
+ ~G4HepEmConfig();
+
+  void Dump();
+
+  // Activate/deactivate Woodcock-tracking of photons in a given detector region
+  // NOTE: this must be done before the initialissation of the run, i.e. right
+  //       after the construction of the `G4HepEmTrackinManager` !!!
+  void SetWoodcockTrackingRegion(const std::string& regionName, G4bool val=true);
+  std::vector<std::string>& GetWoodcockTrackingRegionNames() {
+    return fWDTRegionNames;
+  }
+
+
+  // Set the `fDRoverRange` and `fFinalRange` parameters of the continuous energy
+  // loss step limit function (everywhere or in a given detector region)
+  void     SetEnergyLossStepLimitFunctionParameters(G4double drRange, G4double finRange, const G4String& nameRegion);
+  void     SetEnergyLossStepLimitFunctionParameters(G4double drRange, G4double finRange);
+  G4double GetEnergyLossStepLimitFunctionParameters(const G4String& nameRegion, G4bool isDRover=true);
+  G4double GetEnergyLossStepLimitFunctionParameters(int indxRegion, G4bool isDRover=true);
+
+  // Set the 'rangeFactor' parameter of the MSC step (everywhere or in a given detector region)
+  void     SetMSCRangeFactor(G4double val, const G4String& nameRegion);
+  void     SetMSCRangeFactor(G4double val);
+  G4double GetMSCRangeFactor(const G4String& nameRegion);
+  G4double GetMSCRangeFactor(int indxRegion);
+  // Set the 'safetyFactor' parameter of the MSC step (everywhere or in a given detector region)
+  void     SetMSCSafetyFactor(G4double val, const G4String& nameRegion);
+  void     SetMSCSafetyFactor(G4double val);
+  G4double GetMSCSafetyFactor(const G4String& nameRegion);
+  G4double GetMSCSafetyFactor(int indxRegion);
+
+  // Activating/deactivating energy loss fluctuation everywhere or in a given
+  // detector region (default: true --> active)
+  void   SetEnergyLossFluctuation(G4bool val, const G4String& nameRegion);
+  void   SetEnergyLossFluctuation(G4bool val);
+  G4bool GetEnergyLossFluctuation(const G4String& nameRegion);
+  G4bool GetEnergyLossFluctuation(int indxRegion);
+
+  // Activating/deactivating using the `minimal` MSC step limit everywhere or in
+  // a given detector region (the default i.e. `fUseSafety` is used otherwise)
+  void   SetMinimalMSCStepLimit(G4bool val, const G4String& nameRegion);
+  void   SetMinimalMSCStepLimit(G4bool val);
+  G4bool GetMinimalMSCStepLimit(const G4String& nameRegion);
+  G4bool GetMinimalMSCStepLimit(int indxRegion);
+
+  // Activating/deactivating using the combined MSC + Transportation e-/e+ tracking/stepping
+  // through multiple steps (default: true --> active)
+  void   SetMultipleStepsInMSCWithTransportation(G4bool val, const G4String& nameRegion);
+  void   SetMultipleStepsInMSCWithTransportation(G4bool val);
+  G4bool GetMultipleStepsInMSCWithTransportation(const G4String& nameRegion);
+  G4bool GetMultipleStepsInMSCWithTransportation(int indxRegion);
+
+
+
+  // NOTE: to see if we set its memebr Parameters or it will have its own
+  void SetG4HepEmParameters(G4HepEmParameters* hepEmPars) {
+    fG4HepEmParameters = hepEmPars;
+  }
+  G4HepEmParameters* GetG4HepEmParameters() { return fG4HepEmParameters; }
+
+private:
+  G4int GetRegionIndex(const G4String& nameRegion);
+  void  CheckRegionIndex(G4int indxRegion);
+
+private:
+
+  // The G4HepEmParameters of the configuration. Default values are taken from Geant4
+  // (mainly from G4EmParameters) but further configurations possible through this
+  // G4HepEmConfig (even per detector regions).
+  G4HepEmParameters*      fG4HepEmParameters;
+
+  // The list of detector regions that the user requested Woodock-tracking in.
+  std::vector<std::string> fWDTRegionNames;
+
+};
+
+#endif // G4HepEmConfig

--- a/G4HepEm/G4HepEm/include/G4HepEmRunManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmRunManager.hh
@@ -53,7 +53,7 @@ public:
   G4HepEmRunManager (bool ismaster);
  ~G4HepEmRunManager ();
 
-  static G4HepEmRunManager* GetMasterRunManager (); 
+  static G4HepEmRunManager* GetMasterRunManager ();
 
   /**
    * Builds or sets (data) members of run-manager.
@@ -73,7 +73,7 @@ public:
    *   its random engine pointer to the corresponding geant4, thread local random
    *   engine pointer.
    */
-  void Initialize (G4HepEmRandomEngine* theRNGEngine, int hepEmParticleIndx);
+  void Initialize (G4HepEmRandomEngine* theRNGEngine, int hepEmParticleIndx, G4HepEmParameters* hepEmPars=nullptr);
 
 
   /**
@@ -92,6 +92,8 @@ public:
   struct G4HepEmParameters* GetHepEmParameters()   const  { return fTheG4HepEmParameters; }
   G4HepEmTLData*            GetTheTLData()         const  { return fTheG4HepEmTLData; }
 
+  void SetVerbose(int verbose) { fVerbose = verbose; }
+
 private:
 
   /**
@@ -103,7 +105,7 @@ private:
    * other words, these are the `global` data structures.
    * This should be invoked by the master thread and only once!
    */
-  void InitializeGlobal ();
+  void InitializeGlobal (G4HepEmParameters* hepEmPars=nullptr);
 
 
 
@@ -121,6 +123,7 @@ private:
    * Collection of configuration parameters used at initialization and run time.
    */
   struct G4HepEmParameters*      fTheG4HepEmParameters;
+  bool   fExternalParameters;
   /*
    * The top level data structure that stores all the data used by all processes
    * (e.g. material or material cuts couple related data, etc.)
@@ -140,6 +143,8 @@ private:
 
   G4HepEmTLData*                 fTheG4HepEmTLData;
 
+  // Verbosity level (only 0/1 at the moment)
+  int fVerbose;
 
 };
 

--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -15,6 +15,7 @@ class G4VProcess;
 class G4VParticleChange;
 class G4Region;
 class G4HepEmWoodcockHelper;
+class G4HepEmConfig;
 
 #include <vector>
 
@@ -22,7 +23,7 @@ class G4HepEmWoodcockHelper;
 
 class G4HepEmTrackingManager : public G4VTrackingManager {
 public:
-  G4HepEmTrackingManager();
+  G4HepEmTrackingManager(G4int verbose=1);
   virtual ~G4HepEmTrackingManager();
 
   void BuildPhysicsTable(const G4ParticleDefinition &) override;
@@ -38,15 +39,17 @@ public:
     return fMultipleSteps;
   }
 
+  // Allows to set configuration/parameters (even some per region)
+  G4HepEmConfig* GetConfig() { return fConfig; }
+
+  // Control verbosity (0/1) (propagated to the G4HepEmRuManager)
+  void SetVerbose(G4int verbose);
+
   // ATLAS XTR RELATED:
   // Set the names of the ATLAS specific transition radiation process and
   // radiator region (only for ATLAS and only if different than init.ed below)
   void SetXTRProcessName(const std::string& name) { fXTRProcessName = name; }
   void SetXTRRegionName(const std::string& name)  { fXTRRegionName  = name; }
-
-  void AddWoodcockTrackingRegion(const std::string& regionName) {
-    fWDTRegionNames.push_back(regionName);
-  }
 
 protected:
   bool TrackElectron(G4Track *aTrack);
@@ -81,6 +84,7 @@ private:
   // NOTE: the fields stays nullptr if no such process/region are found causing
   //       no harm outside Athena.
   void InitXTRRelated();
+
 
 #ifdef G4HepEm_EARLY_TRACKING_EXIT
   // Virtual function to check early tracking exit. This function allows user
@@ -130,8 +134,13 @@ private:
   std::string fXTRRegionName  = {"TRT_RADIATOR"};
 
   // A vector of Woodcock tracking region names (set by user if any) and a helper.
-  std::vector<std::string> fWDTRegionNames;
   G4HepEmWoodcockHelper*   fWDTHelper;
+
+  // Configuration parameters (allows different parameters/configuration per region.
+  G4HepEmConfig* fConfig;
+
+  // Vebosity level (only 0/1 at the moment)
+  G4int  fVerbose;
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......

--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -32,13 +32,6 @@ public:
 
   void HandOverOneTrack(G4Track *aTrack) override;
 
-  void SetMultipleSteps(G4bool val) {
-    fMultipleSteps = val;
-  }
-  G4bool MultipleSteps() const {
-    return fMultipleSteps;
-  }
-
   // Allows to set configuration/parameters (even some per region)
   G4HepEmConfig* GetConfig() { return fConfig; }
 
@@ -63,13 +56,15 @@ private:
   // Stacks secondaries created by HepEm physics (if any) and returns with the
   // energy deposit while stacking due to applying secondary production cuts
   double StackSecondaries(G4HepEmTLData* aTLData, G4Track* aG4PrimaryTrack,
-                          const G4VProcess* aG4CreatorProcess, int aG4IMC);
+                          const G4VProcess* aG4CreatorProcess, int aG4IMC,
+                          bool isApplyCuts);
 
   // Stacks secondaries created by Geant4 physics (if any) and returns with the
   // energy deposit while stacking due to applying secondary production cuts
   double StackG4Secondaries(G4VParticleChange* particleChange,
                             G4Track* aG4PrimaryTrack,
-                            const G4VProcess* aG4CreatorProcess, int aG4IMC);
+                            const G4VProcess* aG4CreatorProcess, int aG4IMC,
+                            bool isApplyCuts);
 
   void InitNuclearProcesses(int particleID);
 
@@ -107,8 +102,6 @@ private:
   const std::vector<G4double> *theCutsGamma = nullptr;
   const std::vector<G4double> *theCutsElectron = nullptr;
   const std::vector<G4double> *theCutsPositron = nullptr;
-  G4bool applyCuts = false;
-  G4bool fMultipleSteps = true;
 
   // A set of empty processes with the correct names and types just to be able
   // to set them as process limiting the step and creating secondaries as some

--- a/G4HepEm/G4HepEm/include/G4HepEmWoodcockHelper.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmWoodcockHelper.hh
@@ -17,6 +17,16 @@ class G4HepEmGammaTrack;
 
 #include <map>
 
+/**
+ * @file    G4HepEmWoodcockHelper.hh
+ * @class   G4HepEmWoodcockHelper
+ * @author  M. Novak
+ * @date    2024
+ *
+ * A helper class to perform Woodcock-tracking of photons in some Geant4 detector
+ * regions (utilised in the G4HepEmTrackinManager).
+ */
+
 class G4HepEmWoodcockHelper {
 public:
     G4HepEmWoodcockHelper();

--- a/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
@@ -208,17 +208,20 @@ void G4HepEmConfig::Dump() {
            << std::setw(5) << std::right
            << fG4HepEmParameters->fElectronTrackingCut/CLHEP::keV
            << " [keV] " << std::endl;
- std::cout << std::left << std::setw(30) << " Min loss table energies " << " : "
+ std::cout << std::left << std::setw(30) << " Min loss table energy " << " : "
            << std::setw(5) << std::right
            << fG4HepEmParameters->fMinLossTableEnergy/CLHEP::keV
            << " [keV] " << std::endl;
- std::cout << std::left << std::setw(30) << " Max loss table energies " << " : "
+ std::cout << std::left << std::setw(30) << " Max loss table energy " << " : "
            << std::setw(5) << std::right
            << fG4HepEmParameters->fMaxLossTableEnergy/CLHEP::TeV
            << " [TeV] " << std::endl;
  std::cout << std::left << std::setw(30) << " Number of loss table bins " << " : "
            << std::setw(5) << std::right
            << fG4HepEmParameters->fNumLossTableBins << std::endl;
+ std::cout << std::left << std::setw(30) << " Positron corr. in MSC theta0 " << " : "
+           << std::setw(5) << std::right
+           << fG4HepEmParameters->fIsMSCPositronCor << std::endl;
  std::cout << std::left << std::setw(30) << " Linear loss limit " << " : "
            << std::setw(5) << std::right
            << fG4HepEmParameters->fParametersPerRegion[0].fLinELossLimit*100

--- a/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
@@ -10,6 +10,7 @@
 
 G4HepEmConfig::G4HepEmConfig() {
   fG4HepEmParameters = new G4HepEmParameters;
+  fWDTEnergyLimit    = 0.2; // 200 keV by default
   InitHepEmParameters(fG4HepEmParameters);
 }
 
@@ -201,90 +202,96 @@ void  G4HepEmConfig::CheckRegionIndex(G4int indxRegion) {
 
 
 void G4HepEmConfig::Dump() {
- std::cout << "\n ==================== G4HepEmConfig ==================== " << std::endl;
- std::cout << " GLOBAL Parameters: " << std::endl;
- std::cout << " --------------------------------------------------------  " << std::endl;
- std::cout << std::left <<std::setw(30) << " Electron tracking cut " << " : "
-           << std::setw(5) << std::right
-           << fG4HepEmParameters->fElectronTrackingCut/CLHEP::keV
-           << " [keV] " << std::endl;
- std::cout << std::left << std::setw(30) << " Min loss table energy " << " : "
-           << std::setw(5) << std::right
-           << fG4HepEmParameters->fMinLossTableEnergy/CLHEP::keV
-           << " [keV] " << std::endl;
- std::cout << std::left << std::setw(30) << " Max loss table energy " << " : "
-           << std::setw(5) << std::right
-           << fG4HepEmParameters->fMaxLossTableEnergy/CLHEP::TeV
-           << " [TeV] " << std::endl;
- std::cout << std::left << std::setw(30) << " Number of loss table bins " << " : "
-           << std::setw(5) << std::right
-           << fG4HepEmParameters->fNumLossTableBins << std::endl;
- std::cout << std::left << std::setw(30) << " Positron corr. in MSC theta0 " << " : "
-           << std::setw(5) << std::right
-           << fG4HepEmParameters->fIsMSCPositronCor << std::endl;
- std::cout << std::left << std::setw(30) << " Linear loss limit " << " : "
-           << std::setw(5) << std::right
-           << fG4HepEmParameters->fParametersPerRegion[0].fLinELossLimit*100
-           << " [%] " << std::endl << std::endl;
- std::cout << " REGION BASED Parameters: " << std::endl;
- std::cout << " --------------------------------------------------------  " << std::endl;
- std::cout << std::left << std::setw(30) << " Parameter for region " << " : ";
- const int numRegions = fG4HepEmParameters->fNumRegions;
- std::vector<int> lengthNameRegions;
- for (int ir=0; ir<numRegions; ++ir) {
-   const G4String& nameRegion = (*G4RegionStore::GetInstance())[ir]->GetName();
-   int len = nameRegion.length();
-   std::cout << std::setw(len) << (*G4RegionStore::GetInstance())[ir]->GetName() << " | ";
-   lengthNameRegions.push_back(len);
- }
- std::cout << std::endl;
+  const int width = 34;
+  std::cout << "\n ======================== G4HepEmConfig ======================= " << std::endl;
+  std::cout << " GLOBAL Parameters: " << std::endl;
+  std::cout << " --------------------------------------------------------------  " << std::endl;
+  std::cout << std::left << std::setw(width) << " Electron tracking cut " << " : "
+            << std::setw(5) << std::right
+            << fG4HepEmParameters->fElectronTrackingCut/CLHEP::keV
+            << " [keV] " << std::endl;
+  std::cout << std::left << std::setw(width) << " Min loss table energy " << " : "
+            << std::setw(5) << std::right
+            << fG4HepEmParameters->fMinLossTableEnergy/CLHEP::keV
+            << " [keV] " << std::endl;
+  std::cout << std::left << std::setw(width) << " Max loss table energy " << " : "
+            << std::setw(5) << std::right
+            << fG4HepEmParameters->fMaxLossTableEnergy/CLHEP::TeV
+            << " [TeV] " << std::endl;
+  std::cout << std::left << std::setw(width) << " Number of loss table bins " << " : "
+            << std::setw(5) << std::right
+            << fG4HepEmParameters->fNumLossTableBins << std::endl;
+  std::cout << std::left << std::setw(width) << " Is positron corr. in MSC theta0 " << " : "
+            << std::setw(5) << std::right
+            << fG4HepEmParameters->fIsMSCPositronCor
+            << " (true/false) "<< std::endl;
+  std::cout << std::left << std::setw(width) << " Woodcock tracking energy limit " << " : "
+            << std::setw(5) << std::right
+            << fWDTEnergyLimit/CLHEP::keV
+            << " [keV] " << std::endl;
+  std::cout << std::left << std::setw(width) << " Linear loss limit " << " : "
+            << std::setw(5) << std::right
+            << fG4HepEmParameters->fParametersPerRegion[0].fLinELossLimit*100
+            << " [%] " << std::endl << std::endl;
+  std::cout << " REGION BASED Parameters: " << std::endl;
+  std::cout << " --------------------------------------------------------------  " << std::endl;
+  std::cout << std::left << std::setw(width) << " Parameter for region " << " : ";
+  const int numRegions = fG4HepEmParameters->fNumRegions;
+  std::vector<int> lengthNameRegions;
+  for (int ir=0; ir<numRegions; ++ir) {
+    const G4String& nameRegion = (*G4RegionStore::GetInstance())[ir]->GetName();
+    int len = nameRegion.length();
+    std::cout << std::setw(len) << (*G4RegionStore::GetInstance())[ir]->GetName() << " | ";
+    lengthNameRegions.push_back(len);
+  }
+  std::cout << std::endl;
 
- std::vector<G4String> names = {" FinalRange (mm)", " DRoverRange", " Energy loss fluctuation",
+  std::vector<G4String> names = {" FinalRange (mm)", " DRoverRange", " Energy loss fluctuation",
         " MSC Range factor",  " MSC Safety factor", " MSC minimal step limit",
         " Multiple steps in MSC+Trans.", " Woodcock-tracking", " Apply cuts"};
- const int numParams  = names.size();
+  const int numParams  = names.size();
 
- for (int ip=0; ip<numParams; ++ip) {
-   for (int ir=0; ir<numRegions; ++ir) {
-     if (ir==0) {
-       std::cout << std::left << std::setw(30) << names[ip] << " : ";
-     }
-     std::cout << std::right << std::setw(lengthNameRegions[ir]);
+  for (int ip=0; ip<numParams; ++ip) {
+    for (int ir=0; ir<numRegions; ++ir) {
+      if (ir==0) {
+        std::cout << std::left << std::setw(width) << names[ip] << " : ";
+      }
+      std::cout << std::right << std::setw(lengthNameRegions[ir]);
 
-     bool isWDT = false;
-     const G4String& regionName =  (*G4RegionStore::GetInstance())[ir]->GetName();
-     if (ip==7) {
-       for (std::vector<std::string>::iterator it=fWDTRegionNames.begin(); it != fWDTRegionNames.end(); ++it) {
-         if (*it==regionName) {
-           isWDT = true;
-           break;
-         }
-       }
-     }
+      bool isWDT = false;
+      const G4String& regionName =  (*G4RegionStore::GetInstance())[ir]->GetName();
+      if (ip==7) {
+        for (std::vector<std::string>::iterator it=fWDTRegionNames.begin(); it != fWDTRegionNames.end(); ++it) {
+          if (*it==regionName) {
+            isWDT = true;
+            break;
+          }
+        }
+      }
 
-     switch (ip) {
-       case 0: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fFinalRange/CLHEP::mm << " | ";
-              break;
-       case 1: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fDRoverRange << " | ";
-              break;
-       case 2: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsELossFluctuation << " | ";
-              break;
-       case 3: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fMSCRangeFactor << " | ";
-              break;
-       case 4: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fMSCSafetyFactor << " | ";
-              break;
-       case 5: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsMSCMinimalStepLimit << " | ";
-              break;
-       case 6: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsMultipleStepsInMSCTrans << " | ";
-              break;
-       case 7: std::cout << isWDT << " | ";
-              break;
-       case 8: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsApplyCuts << " | ";
-              break;
+      switch (ip) {
+        case 0: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fFinalRange/CLHEP::mm << " | ";
+                break;
+        case 1: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fDRoverRange << " | ";
+                break;
+        case 2: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsELossFluctuation << " | ";
+                break;
+        case 3: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fMSCRangeFactor << " | ";
+                break;
+        case 4: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fMSCSafetyFactor << " | ";
+                break;
+        case 5: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsMSCMinimalStepLimit << " | ";
+                break;
+        case 6: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsMultipleStepsInMSCTrans << " | ";
+                break;
+        case 7: std::cout << isWDT << " | ";
+                break;
+        case 8: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsApplyCuts << " | ";
+                break;
 
-     }
-   }
-   std::cout << std::endl;
- }
- std::cout << " ========================================================= " << std::endl << std::endl;
+      }
+    }
+    std::cout << std::endl;
+  }
+  std::cout << " ============================================================== "<< std::endl << std::endl;
 }

--- a/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
@@ -158,6 +158,26 @@ G4bool G4HepEmConfig::GetMultipleStepsInMSCWithTransportation(G4int indxRegion) 
 
 
 
+void G4HepEmConfig::SetApplyCuts(G4bool val, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetApplyCuts(val);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fIsApplyCuts = val;
+  }
+}
+void G4HepEmConfig::SetApplyCuts(G4bool val) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i)
+    fG4HepEmParameters->fParametersPerRegion[i].fIsApplyCuts = val;
+}
+G4bool G4HepEmConfig::GetApplyCuts(const G4String& nameRegion) {
+  return GetApplyCuts(GetRegionIndex(nameRegion));
+}
+G4bool G4HepEmConfig::GetApplyCuts(G4int indxRegion) {
+  CheckRegionIndex(indxRegion);
+  return fG4HepEmParameters->fParametersPerRegion[indxRegion].fIsApplyCuts;
+}
+
+
 G4int G4HepEmConfig::GetRegionIndex(const G4String& nameRegion) {
   G4Region* region = G4RegionStore::GetInstance()->GetRegion(nameRegion, false);
   if (region == nullptr) {
@@ -218,7 +238,7 @@ void G4HepEmConfig::Dump() {
 
  std::vector<G4String> names = {" FinalRange (mm)", " DRoverRange", " Energy loss fluctuation",
         " MSC Range factor",  " MSC Safety factor", " MSC minimal step limit",
-        " Multiple steps in MSC+Trans.", " Woodcock-tracking"};
+        " Multiple steps in MSC+Trans.", " Woodcock-tracking", " Apply cuts"};
  const int numParams  = names.size();
 
  for (int ip=0; ip<numParams; ++ip) {
@@ -256,6 +276,9 @@ void G4HepEmConfig::Dump() {
               break;
        case 7: std::cout << isWDT << " | ";
               break;
+       case 8: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsApplyCuts << " | ";
+              break;
+
      }
    }
    std::cout << std::endl;

--- a/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmConfig.cc
@@ -1,0 +1,264 @@
+
+#include "G4HepEmConfig.hh"
+
+#include "G4HepEmParameters.hh"
+#include "G4HepEmParametersInit.hh"
+
+#include "G4RegionStore.hh"
+#include "G4Region.hh"
+#include "G4SystemOfUnits.hh"
+
+G4HepEmConfig::G4HepEmConfig() {
+  fG4HepEmParameters = new G4HepEmParameters;
+  InitHepEmParameters(fG4HepEmParameters);
+}
+
+
+G4HepEmConfig::~G4HepEmConfig() {
+  FreeG4HepEmParameters(fG4HepEmParameters);
+  delete fG4HepEmParameters;
+}
+
+
+void G4HepEmConfig::SetWoodcockTrackingRegion(const std::string& regionName, G4bool val) {
+  // check if the region name has already been added in order to avoid duplications
+  // - remove if it was requested (i.e. `val=false`)
+  for (std::vector<std::string>::iterator it=fWDTRegionNames.begin(); it != fWDTRegionNames.end(); ++it) {
+    if (*it==regionName) {
+      if (!val) { fWDTRegionNames.erase(it); }
+      return;
+    }
+  }
+  // add to the list if it was not be there
+  if (val) { fWDTRegionNames.push_back(regionName); }
+}
+
+
+void G4HepEmConfig::SetEnergyLossStepLimitFunctionParameters(G4double drRange, G4double finRange, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetEnergyLossStepLimitFunctionParameters(drRange, finRange);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fDRoverRange = drRange;
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fFinalRange  = finRange;
+  }
+}
+void G4HepEmConfig::SetEnergyLossStepLimitFunctionParameters(G4double drRange, G4double finRange) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i) {
+    fG4HepEmParameters->fParametersPerRegion[i].fDRoverRange = drRange;
+    fG4HepEmParameters->fParametersPerRegion[i].fFinalRange  = finRange;
+  }
+}
+G4double G4HepEmConfig::GetEnergyLossStepLimitFunctionParameters(const G4String& nameRegion, G4bool isDRover) {
+  return GetEnergyLossStepLimitFunctionParameters(GetRegionIndex(nameRegion), isDRover);
+}
+G4double G4HepEmConfig::GetEnergyLossStepLimitFunctionParameters(G4int indxRegion, G4bool isDRover) {
+  CheckRegionIndex(indxRegion);
+  return isDRover ? fG4HepEmParameters->fParametersPerRegion[indxRegion].fDRoverRange
+                  : fG4HepEmParameters->fParametersPerRegion[indxRegion].fFinalRange;
+}
+
+
+void G4HepEmConfig::SetMSCRangeFactor(G4double val, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetMSCRangeFactor(val);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fMSCRangeFactor = val;
+  }
+}
+void G4HepEmConfig::SetMSCRangeFactor(G4double val) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i)
+    fG4HepEmParameters->fParametersPerRegion[i].fMSCRangeFactor = val;
+}
+G4double G4HepEmConfig::GetMSCRangeFactor(const G4String& nameRegion) {
+  return GetMSCRangeFactor(GetRegionIndex(nameRegion));
+}
+G4double G4HepEmConfig::GetMSCRangeFactor(G4int indxRegion) {
+  CheckRegionIndex(indxRegion);
+  return fG4HepEmParameters->fParametersPerRegion[indxRegion].fMSCRangeFactor;
+}
+
+void G4HepEmConfig::SetMSCSafetyFactor(G4double val, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetMSCSafetyFactor(val);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fMSCSafetyFactor = val;
+  }
+}
+void G4HepEmConfig::SetMSCSafetyFactor(G4double val) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i)
+    fG4HepEmParameters->fParametersPerRegion[i].fMSCSafetyFactor = val;
+}
+G4double G4HepEmConfig::GetMSCSafetyFactor(const G4String& nameRegion) {
+  return GetMSCSafetyFactor(GetRegionIndex(nameRegion));
+}
+G4double G4HepEmConfig::GetMSCSafetyFactor(G4int indxRegion) {
+  CheckRegionIndex(indxRegion);
+  return fG4HepEmParameters->fParametersPerRegion[indxRegion].fMSCSafetyFactor;
+}
+
+
+void G4HepEmConfig::SetEnergyLossFluctuation(G4bool val, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetEnergyLossFluctuation(val);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fIsELossFluctuation = val;
+  }
+}
+void G4HepEmConfig::SetEnergyLossFluctuation(G4bool val) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i)
+    fG4HepEmParameters->fParametersPerRegion[i].fIsELossFluctuation = val;
+}
+G4bool G4HepEmConfig::GetEnergyLossFluctuation(const G4String& nameRegion) {
+  return GetEnergyLossFluctuation(GetRegionIndex(nameRegion));
+}
+G4bool G4HepEmConfig::GetEnergyLossFluctuation(G4int indxRegion) {
+  CheckRegionIndex(indxRegion);
+  return fG4HepEmParameters->fParametersPerRegion[indxRegion].fIsELossFluctuation;
+}
+
+
+void G4HepEmConfig::SetMinimalMSCStepLimit(G4bool val, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetMinimalMSCStepLimit(val);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fIsMSCMinimalStepLimit = val;
+  }
+}
+void G4HepEmConfig::SetMinimalMSCStepLimit(G4bool val) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i)
+    fG4HepEmParameters->fParametersPerRegion[i].fIsMSCMinimalStepLimit = val;
+}
+G4bool G4HepEmConfig::GetMinimalMSCStepLimit(const G4String& nameRegion) {
+  return GetMinimalMSCStepLimit(GetRegionIndex(nameRegion));
+}
+G4bool G4HepEmConfig::GetMinimalMSCStepLimit(G4int indxRegion) {
+  CheckRegionIndex(indxRegion);
+  return fG4HepEmParameters->fParametersPerRegion[indxRegion].fIsMSCMinimalStepLimit;
+}
+
+
+void G4HepEmConfig::SetMultipleStepsInMSCWithTransportation(G4bool val, const G4String& nameRegion) {
+  if (nameRegion == "all") {
+    SetMultipleStepsInMSCWithTransportation(val);
+  } else {
+    fG4HepEmParameters->fParametersPerRegion[GetRegionIndex(nameRegion)].fIsMultipleStepsInMSCTrans = val;
+  }
+}
+void G4HepEmConfig::SetMultipleStepsInMSCWithTransportation(G4bool val) {
+  for (int i=0; i<fG4HepEmParameters->fNumRegions; ++i)
+    fG4HepEmParameters->fParametersPerRegion[i].fIsMultipleStepsInMSCTrans = val;
+}
+G4bool G4HepEmConfig::GetMultipleStepsInMSCWithTransportation(const G4String& nameRegion) {
+  return GetMultipleStepsInMSCWithTransportation(GetRegionIndex(nameRegion));
+}
+G4bool G4HepEmConfig::GetMultipleStepsInMSCWithTransportation(G4int indxRegion) {
+  CheckRegionIndex(indxRegion);
+  return fG4HepEmParameters->fParametersPerRegion[indxRegion].fIsMultipleStepsInMSCTrans;
+}
+
+
+
+G4int G4HepEmConfig::GetRegionIndex(const G4String& nameRegion) {
+  G4Region* region = G4RegionStore::GetInstance()->GetRegion(nameRegion, false);
+  if (region == nullptr) {
+    std::cerr << "*** ERROR in G4HepEmConfig::GetRegionIndex :\n"
+              << "    Unknown detector region with name = "
+              << nameRegion
+              << std::endl;
+    exit(-1);
+  }
+  return region->GetInstanceID();
+}
+
+void  G4HepEmConfig::CheckRegionIndex(G4int indxRegion) {
+  if (indxRegion >= fG4HepEmParameters->fNumRegions) {
+    std::cerr << "*** ERROR in G4HepEmConfig::CheckRegionIndex :\n"
+              << "    Region index ( = " << indxRegion << " ) out of bounds! "
+              << std::endl;
+    exit(-1);
+  }
+}
+
+
+void G4HepEmConfig::Dump() {
+ std::cout << "\n ==================== G4HepEmConfig ==================== " << std::endl;
+ std::cout << " GLOBAL Parameters: " << std::endl;
+ std::cout << " --------------------------------------------------------  " << std::endl;
+ std::cout << std::left <<std::setw(30) << " Electron tracking cut " << " : "
+           << std::setw(5) << std::right
+           << fG4HepEmParameters->fElectronTrackingCut/CLHEP::keV
+           << " [keV] " << std::endl;
+ std::cout << std::left << std::setw(30) << " Min loss table energies " << " : "
+           << std::setw(5) << std::right
+           << fG4HepEmParameters->fMinLossTableEnergy/CLHEP::keV
+           << " [keV] " << std::endl;
+ std::cout << std::left << std::setw(30) << " Max loss table energies " << " : "
+           << std::setw(5) << std::right
+           << fG4HepEmParameters->fMaxLossTableEnergy/CLHEP::TeV
+           << " [TeV] " << std::endl;
+ std::cout << std::left << std::setw(30) << " Number of loss table bins " << " : "
+           << std::setw(5) << std::right
+           << fG4HepEmParameters->fNumLossTableBins << std::endl;
+ std::cout << std::left << std::setw(30) << " Linear loss limit " << " : "
+           << std::setw(5) << std::right
+           << fG4HepEmParameters->fParametersPerRegion[0].fLinELossLimit*100
+           << " [%] " << std::endl << std::endl;
+ std::cout << " REGION BASED Parameters: " << std::endl;
+ std::cout << " --------------------------------------------------------  " << std::endl;
+ std::cout << std::left << std::setw(30) << " Parameter for region " << " : ";
+ const int numRegions = fG4HepEmParameters->fNumRegions;
+ std::vector<int> lengthNameRegions;
+ for (int ir=0; ir<numRegions; ++ir) {
+   const G4String& nameRegion = (*G4RegionStore::GetInstance())[ir]->GetName();
+   int len = nameRegion.length();
+   std::cout << std::setw(len) << (*G4RegionStore::GetInstance())[ir]->GetName() << " | ";
+   lengthNameRegions.push_back(len);
+ }
+ std::cout << std::endl;
+
+ std::vector<G4String> names = {" FinalRange (mm)", " DRoverRange", " Energy loss fluctuation",
+        " MSC Range factor",  " MSC Safety factor", " MSC minimal step limit",
+        " Multiple steps in MSC+Trans.", " Woodcock-tracking"};
+ const int numParams  = names.size();
+
+ for (int ip=0; ip<numParams; ++ip) {
+   for (int ir=0; ir<numRegions; ++ir) {
+     if (ir==0) {
+       std::cout << std::left << std::setw(30) << names[ip] << " : ";
+     }
+     std::cout << std::right << std::setw(lengthNameRegions[ir]);
+
+     bool isWDT = false;
+     const G4String& regionName =  (*G4RegionStore::GetInstance())[ir]->GetName();
+     if (ip==7) {
+       for (std::vector<std::string>::iterator it=fWDTRegionNames.begin(); it != fWDTRegionNames.end(); ++it) {
+         if (*it==regionName) {
+           isWDT = true;
+           break;
+         }
+       }
+     }
+
+     switch (ip) {
+       case 0: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fFinalRange/CLHEP::mm << " | ";
+              break;
+       case 1: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fDRoverRange << " | ";
+              break;
+       case 2: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsELossFluctuation << " | ";
+              break;
+       case 3: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fMSCRangeFactor << " | ";
+              break;
+       case 4: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fMSCSafetyFactor << " | ";
+              break;
+       case 5: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsMSCMinimalStepLimit << " | ";
+              break;
+       case 6: std::cout << fG4HepEmParameters->fParametersPerRegion[ir].fIsMultipleStepsInMSCTrans << " | ";
+              break;
+       case 7: std::cout << isWDT << " | ";
+              break;
+     }
+   }
+   std::cout << std::endl;
+ }
+ std::cout << " ========================================================= " << std::endl << std::endl;
+}

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -178,6 +178,7 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
         delete fWDTHelper;
       }
       fWDTHelper = new G4HepEmWoodcockHelper;
+      fWDTHelper->SetKineticEnergyLimit(fConfig->GetWDTEnergyLimit());
       G4VPhysicalVolume* worldVolume = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
       G4bool hasBeenFound = fWDTHelper->Initialize(wdtRegionNames, fRunManager->GetHepEmData()->fTheMatCutData, worldVolume);
       if (!hasBeenFound) {

--- a/G4HepEm/G4HepEmData/CMakeLists.txt
+++ b/G4HepEm/G4HepEmData/CMakeLists.txt
@@ -17,6 +17,7 @@ set(G4HEPEMDATA_CXX_sources
   src/G4HepEmGammaData.cc
   src/G4HepEmMatCutData.cc
   src/G4HepEmMaterialData.cc
+  src/G4HepEmParameters.cc
   src/G4HepEmSBTableData.cc
 )
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmMatCutData.hh
@@ -51,6 +51,8 @@ struct G4HepEmMCCData {
   int     fHepEmMatIndex = -1;
   /** Index of the corresponding G4MaterialCutsCouple object.*/
   int     fG4MatCutIndex = -1;
+  /** Index of the Geant4 detector region to which this material-cut belongs to. */
+  int     fG4RegionIndex = -1;
 };
 
 // Data for all matrial cuts couple that are used by G4HepEm.

--- a/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
@@ -43,6 +43,9 @@ struct G4HepEmRegionParmeters {
 
   /** Flag to indicate if the combined MSC + Transportation process is allowed for multiple steps. */
   bool   fIsMultipleStepsInMSCTrans = true;
+
+  /** Apply secondary production threshold on all interactions (beyond ioni. and brem.) */
+  bool   fIsApplyCuts = true;
 };
 
 

--- a/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
@@ -76,23 +76,6 @@ struct G4HepEmParameters {
   G4HepEmRegionParmeters* fParametersPerRegion_gpu = nullptr; //[fNumRegions]
 #endif  // G4HepEm_CUDA_BUILD
 
-
-
-
-  /** The *final range* parameter of the sub-threshold energy loss related step limit function.*/
-  double fFinalRange = 1.0;
-  /** The *rover range* parameter of the sub-threshold energy loss related step limit function.*/
-  double fDRoverRange = 0.2;
-  /** Maximum allowed *linear* energy loss along step due to sub-threshold (continuous) energy losses
-    * given as fraction of the intial kinetic energy. Proper integral is used to compute the mean energy loss
-    * when the energy loss, according to linear approximation, is over this threshold.*/
-  double fLinELossLimit = 0.01;
-
-  // MSC range and safety factor parameters
-  double fMSCRangeFactor  = 0.04;
-  double fMSCSafetyFactor = 0.6;
-
-
 };
 
 /** Function that ...*/

--- a/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
@@ -17,43 +17,100 @@
  * G4HepEmRunManager when its InitializeGlobal() method is invoked by calling
  * the InitHepEmParameters() function declared in the G4HepEmParamatersInit
  * header file. This method extracts information (mainly) from the G4EmParameters
- * singletone object.
+ * singletone object. Therefore, the default values given here will be updated
+ * during the initialisation.
  */
+
+/** Parameters per detector region. */
+struct G4HepEmRegionParmeters {
+  /** The *final range* parameter of the sub-threshold energy loss related step limit function.*/
+  double fFinalRange = 1.0;
+  /** The *rover range* parameter of the sub-threshold energy loss related step limit function.*/
+  double fDRoverRange = 0.2;
+  /** Maximum allowed *linear* energy loss along step due to sub-threshold (continuous) energy losses
+    * given as fraction of the intial kinetic energy. Proper integral is used to compute the mean energy loss
+    * when the energy loss, according to linear approximation, is over this threshold.*/
+  double fLinELossLimit = 0.01;
+
+  /** MSC range and safety factor parameters */
+  double fMSCRangeFactor  = 0.04;
+  double fMSCSafetyFactor = 0.6;
+  /** Flag to indicate if the non-default, simplified `fMinimal` MSC step limit should be used.*/
+  bool   fIsMSCMinimalStepLimit = false;
+
+  /** Flag to indicate if energy loss fluctuation should be used.*/
+  bool   fIsELossFluctuation = true;
+
+  /** Flag to indicate if the combined MSC + Transportation process is allowed for multiple steps. */
+  bool   fIsMultipleStepsInMSCTrans = true;
+};
+
 
 struct G4HepEmParameters {
   /** \f$e^-/e^+\f$ tracking (kinetic) energy cut in Geant4 internal energy units:
     * \f$e^-/e^+\f$ tracks are stopped when their energy drops below this threshold,
     * their kinetic energy is deposited and annihilation to two \f$\gamma\f$-s interaction
     * is invoked for in case of \f$e^+\f$.*/
-  double fElectronTrackingCut;
+  double fElectronTrackingCut = 0.001;
 
   // The configuration of the kinetic energy grid of the energy loss related tables:
   /** Minimum of the kinetic energy grid used to build the sub-(secondary-production)threshold
     * related energy loss quantity tables such as the *restricted stopping power*, *range* and
     * *inverse range* tables. */
-  double fMinLossTableEnergy;
+  double fMinLossTableEnergy = 0.0001; // 100 eV
   /** Maximum of the kinetic energy grid for loss tables.*/
-  double fMaxLossTableEnergy;
+  double fMaxLossTableEnergy = 1.0E+08; // 100 TeV
   /** Number of bins (equally spaced on log scale) of the loss table kinetic energy grid. */
-  int    fNumLossTableBins;
-
-  /** The *final range* parameter of the sub-threshold energy loss related step limit function.*/
-  double fFinalRange;
-  /** The *rover range* parameter of the sub-threshold energy loss related step limit function.*/
-  double fDRoverRange;
-  /** Maximum allowed *linear* energy loss along step due to sub-threshold (continuous) energy losses
-    * given as fraction of the intial kinetic energy. Proper integral is used to compute the mean energy loss
-    * when the energy loss, according to linear approximation, is over this threshold.*/
-  double fLinELossLimit;
+  int    fNumLossTableBins   = 84;
 
   /** Kinetic energy limit between the two (Seltzer-Berger and Relativistic) models for bremsstrahlung photon emission
     * in case of \f$e^-/e^+\f$ primary particles.*/
-  double fElectronBremModelLim;
+  double fElectronBremModelLim = 1000; // 1 GeV
+
+  /** Number of detector regions */
+  int fNumRegions = 0;
+  /** A `G4HepEmRegionParmeters` array for the individual detector regions. */
+  G4HepEmRegionParmeters* fParametersPerRegion = nullptr; //[fNumRegions]
+
+#ifdef G4HepEm_CUDA_BUILD
+  G4HepEmRegionParmeters* fParametersPerRegion_gpu = nullptr; //[fNumRegions]
+#endif  // G4HepEm_CUDA_BUILD
+
+
+
+
+  /** The *final range* parameter of the sub-threshold energy loss related step limit function.*/
+  double fFinalRange = 1.0;
+  /** The *rover range* parameter of the sub-threshold energy loss related step limit function.*/
+  double fDRoverRange = 0.2;
+  /** Maximum allowed *linear* energy loss along step due to sub-threshold (continuous) energy losses
+    * given as fraction of the intial kinetic energy. Proper integral is used to compute the mean energy loss
+    * when the energy loss, according to linear approximation, is over this threshold.*/
+  double fLinELossLimit = 0.01;
 
   // MSC range and safety factor parameters
-  double fMSCRangeFactor;
-  double fMSCSafetyFactor;
+  double fMSCRangeFactor  = 0.04;
+  double fMSCSafetyFactor = 0.6;
+
 
 };
+
+/** Function that ...*/
+void InitG4HepEmParameters (struct G4HepEmParameters* theHepEmParams);
+
+/** Function that ...*/
+void FreeG4HepEmParameters (struct G4HepEmParameters* theHepEmParams);
+
+
+#ifdef G4HepEm_CUDA_BUILD
+  /** Function that makes the `G4HepEmRegionParmeters` array member of `G4HepEmParameters`
+    * available on the device (the host side `_gpu` pointer will refer to the device side array).*/
+  void CopyG4HepEmParametersToGPU(struct G4HepEmParameters* onCPU);
+
+  /** Function that ...*/
+  void FreeG4HepEmParametersOnGPU(struct G4HepEmParameters* onCPU);
+#endif  // G4HepEm_CUDA_BUILD
+
+
 
 #endif // G4HepEmParameters_HH

--- a/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
+++ b/G4HepEm/G4HepEmData/include/G4HepEmParameters.hh
@@ -70,6 +70,9 @@ struct G4HepEmParameters {
     * in case of \f$e^-/e^+\f$ primary particles.*/
   double fElectronBremModelLim = 1000; // 1 GeV
 
+  /** Flag to indicate if the e+ correction should be used in the MSC \theta_0 angle. */
+  bool   fIsMSCPositronCor = true;
+
   /** Number of detector regions */
   int fNumRegions = 0;
   /** A `G4HepEmRegionParmeters` array for the individual detector regions. */

--- a/G4HepEm/G4HepEmData/src/G4HepEmParameters.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmParameters.cc
@@ -1,0 +1,44 @@
+
+#include "G4HepEmParameters.hh"
+
+void InitG4HepEmParameters (struct G4HepEmParameters* theHepEmParams) {
+  FreeG4HepEmParameters(theHepEmParams);
+}
+
+
+void FreeG4HepEmParameters (struct G4HepEmParameters* theHepEmParams) {
+  if (theHepEmParams == nullptr) {
+    return;
+  }
+  if (theHepEmParams->fParametersPerRegion != nullptr) {
+    delete[] theHepEmParams->fParametersPerRegion;
+    theHepEmParams->fParametersPerRegion = nullptr;
+  }
+
+#ifdef G4HepEm_CUDA_BUILD
+  FreeG4HepEmParametersOnGPU(theHepEmParams);
+#endif // G4HepEm_CUDA_BUILD
+}
+
+
+#ifdef G4HepEm_CUDA_BUILD
+#include <cuda_runtime.h>
+#include "G4HepEmCuUtils.hh"
+
+void CopyG4HepEmParametersToGPU(struct G4HepEmParameters* onCPU) {
+  if (onCPU == nullptr) return;
+  // clean away previous (if any)
+  FreeG4HepEmParametersOnGPU (onCPU);
+  // allocate memory on device for the G4HepEmRegionParmeters array
+  gpuErrchk ( cudaMalloc ( &(onCPU-fParametersPerRegion_gpu), sizeof( struct G4HepEmRegionParmeters )*onCPU->fNumRegions ) );
+  // copy the `fParametersPerRegion` G4HepEmRegionParmeters array from host to device
+  gpuErrchk ( cudaMemcpy ( onCPU->fParametersPerRegion_gpu, onCPU->fParametersPerRegion, sizeof( struct G4HepEmRegionParmeters )*onCPU->fNumRegions, cudaMemcpyHostToDevice ) );
+}
+
+void FreeG4HepEmParametersOnGPU(struct G4HepEmParameters* onHost) {
+  if (onHost != nullptr && onHost->fParametersPerRegion_gpu != nullptr) {
+    cudaFree (onHost->fParametersPerRegion_gpu);
+    theHepEmParams->fParametersPerRegion_gpu = nullptr;
+  }
+}
+#endif // G4HepEm_CUDA_BUILD

--- a/G4HepEm/G4HepEmData/src/G4HepEmParameters.cc
+++ b/G4HepEm/G4HepEmData/src/G4HepEmParameters.cc
@@ -30,7 +30,7 @@ void CopyG4HepEmParametersToGPU(struct G4HepEmParameters* onCPU) {
   // clean away previous (if any)
   FreeG4HepEmParametersOnGPU (onCPU);
   // allocate memory on device for the G4HepEmRegionParmeters array
-  gpuErrchk ( cudaMalloc ( &(onCPU-fParametersPerRegion_gpu), sizeof( struct G4HepEmRegionParmeters )*onCPU->fNumRegions ) );
+  gpuErrchk ( cudaMalloc ( &(onCPU->fParametersPerRegion_gpu), sizeof( struct G4HepEmRegionParmeters )*onCPU->fNumRegions ) );
   // copy the `fParametersPerRegion` G4HepEmRegionParmeters array from host to device
   gpuErrchk ( cudaMemcpy ( onCPU->fParametersPerRegion_gpu, onCPU->fParametersPerRegion, sizeof( struct G4HepEmRegionParmeters )*onCPU->fNumRegions, cudaMemcpyHostToDevice ) );
 }
@@ -38,7 +38,7 @@ void CopyG4HepEmParametersToGPU(struct G4HepEmParameters* onCPU) {
 void FreeG4HepEmParametersOnGPU(struct G4HepEmParameters* onHost) {
   if (onHost != nullptr && onHost->fParametersPerRegion_gpu != nullptr) {
     cudaFree (onHost->fParametersPerRegion_gpu);
-    theHepEmParams->fParametersPerRegion_gpu = nullptr;
+    onHost->fParametersPerRegion_gpu = nullptr;
   }
 }
 #endif // G4HepEm_CUDA_BUILD

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -136,6 +136,7 @@ namespace nlohmann
       j["fIsMSCMinimalStepLimit"]     = d.fIsMSCMinimalStepLimit;
       j["fIsELossFluctuation"]        = d.fIsELossFluctuation;
       j["fIsMultipleStepsInMSCTrans"] = d.fIsMultipleStepsInMSCTrans;
+      j["fIsApplyCuts"]               = d.fIsApplyCuts;
     }
 
     static G4HepEmRegionParmeters from_json(const json& j)
@@ -152,6 +153,7 @@ namespace nlohmann
       j.at("fIsMSCMinimalStepLimit").get_to(d.fIsMSCMinimalStepLimit);
       j.at("fIsELossFluctuation").get_to(d.fIsELossFluctuation);
       j.at("fIsMultipleStepsInMSCTrans").get_to(d.fIsMultipleStepsInMSCTrans);
+      j.at("fIsApplyCuts").get_to(d.fIsApplyCuts);
 
       return d;
     }

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -120,6 +120,43 @@ namespace nlohmann
 // --- G4HepEmParameters
 namespace nlohmann
 {
+
+  template <>
+  struct adl_serializer<G4HepEmRegionParmeters>
+  {
+    static void to_json(json& j, const G4HepEmRegionParmeters& d)
+    {
+      j["fFinalRange"]    = d.fFinalRange;
+      j["fDRoverRange"]   = d.fDRoverRange;
+      j["fLinELossLimit"] = d.fLinELossLimit;
+
+      j["fMSCRangeFactor"]  = d.fMSCRangeFactor;
+      j["fMSCSafetyFactor"] = d.fMSCSafetyFactor;
+
+      j["fIsMSCMinimalStepLimit"]     = d.fIsMSCMinimalStepLimit;
+      j["fIsELossFluctuation"]        = d.fIsELossFluctuation;
+      j["fIsMultipleStepsInMSCTrans"] = d.fIsMultipleStepsInMSCTrans;
+    }
+
+    static G4HepEmRegionParmeters from_json(const json& j)
+    {
+      G4HepEmRegionParmeters d;
+
+      j.at("fFinalRange").get_to(d.fFinalRange);
+      j.at("fDRoverRange").get_to(d.fDRoverRange);
+      j.at("fLinELossLimit").get_to(d.fLinELossLimit);
+
+      j.at("fMSCRangeFactor").get_to(d.fMSCRangeFactor);
+      j.at("fMSCSafetyFactor").get_to(d.fMSCSafetyFactor);
+
+      j.at("fIsMSCMinimalStepLimit").get_to(d.fIsMSCMinimalStepLimit);
+      j.at("fIsELossFluctuation").get_to(d.fIsELossFluctuation);
+      j.at("fIsMultipleStepsInMSCTrans").get_to(d.fIsMultipleStepsInMSCTrans);
+
+      return d;
+    }
+  };
+
   // We *can* have direct to/from_json functions for G4HepEmParameters
   // as it is simple. Use of adl_serializer is *purely* for consistency
   // with other structures!
@@ -139,12 +176,10 @@ namespace nlohmann
         j["fMinLossTableEnergy"]   = d->fMinLossTableEnergy;
         j["fMaxLossTableEnergy"]   = d->fMaxLossTableEnergy;
         j["fNumLossTableBins"]     = d->fNumLossTableBins;
-        j["fFinalRange"]           = d->fFinalRange;
-        j["fDRoverRange"]          = d->fDRoverRange;
-        j["fLinELossLimit"]        = d->fLinELossLimit;
         j["fElectronBremModelLim"] = d->fElectronBremModelLim;
-        j["fMSCRangeFactor"]       = d->fMSCRangeFactor;
-        j["fMSCSafetyFactor"]      = d->fMSCSafetyFactor;
+        j["fNumRegions"]           = d->fNumRegions;
+        j["fParametersPerRegion"]  =
+          make_span(d->fNumRegions, d->fParametersPerRegion);
       }
     }
 
@@ -162,12 +197,13 @@ namespace nlohmann
         d->fMinLossTableEnergy   = j.at("fMinLossTableEnergy").get<double>();
         d->fMaxLossTableEnergy   = j.at("fMaxLossTableEnergy").get<double>();
         d->fNumLossTableBins     = j.at("fNumLossTableBins").get<int>();
-        d->fFinalRange           = j.at("fFinalRange").get<double>();
-        d->fDRoverRange          = j.at("fDRoverRange").get<double>();
-        d->fLinELossLimit        = j.at("fLinELossLimit").get<double>();
         d->fElectronBremModelLim = j.at("fElectronBremModelLim").get<double>();
-        d->fMSCRangeFactor       = j.at("fMSCRangeFactor").get<double>();
-        d->fMSCSafetyFactor      = j.at("fMSCSafetyFactor").get<double>();
+        d->fNumRegions           = j.at("fNumRegions").get<int>();
+
+        d->fParametersPerRegion  = new G4HepEmRegionParmeters[d->fNumRegions];
+        auto tmpParPerRegion = j.at("fParametersPerRegion");
+        std::copy(tmpParPerRegion.begin(), tmpParPerRegion.end(), d->fParametersPerRegion);
+
         return d;
       }
     }

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -179,6 +179,7 @@ namespace nlohmann
         j["fMaxLossTableEnergy"]   = d->fMaxLossTableEnergy;
         j["fNumLossTableBins"]     = d->fNumLossTableBins;
         j["fElectronBremModelLim"] = d->fElectronBremModelLim;
+        j["fIsMSCPositronCor"]     = d->fIsMSCPositronCor;
         j["fNumRegions"]           = d->fNumRegions;
         j["fParametersPerRegion"]  =
           make_span(d->fNumRegions, d->fParametersPerRegion);
@@ -200,6 +201,7 @@ namespace nlohmann
         d->fMaxLossTableEnergy   = j.at("fMaxLossTableEnergy").get<double>();
         d->fNumLossTableBins     = j.at("fNumLossTableBins").get<int>();
         d->fElectronBremModelLim = j.at("fElectronBremModelLim").get<double>();
+        d->fIsMSCPositronCor     = j.at("fIsMSCPositronCor").get<bool>();
         d->fNumRegions           = j.at("fNumRegions").get<int>();
 
         d->fParametersPerRegion  = new G4HepEmRegionParmeters[d->fNumRegions];

--- a/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
+++ b/G4HepEm/G4HepEmDataJsonIO/src/G4HepEmDataJsonIOImpl.hh
@@ -434,6 +434,7 @@ namespace nlohmann
       j["fLogSecGamCutE"]  = d.fLogSecGamCutE;
       j["fHepEmMatIndex"]  = d.fHepEmMatIndex;
       j["fG4MatCutIndex"]  = d.fG4MatCutIndex;
+      j["fG4RegionIndex"]  = d.fG4RegionIndex;
     }
 
     static G4HepEmMCCData from_json(const json& j)
@@ -446,6 +447,7 @@ namespace nlohmann
       j.at("fLogSecGamCutE").get_to(d.fLogSecGamCutE);
       j.at("fHepEmMatIndex").get_to(d.fHepEmMatIndex);
       j.at("fG4MatCutIndex").get_to(d.fG4MatCutIndex);
+      j.at("fG4RegionIndex").get_to(d.fG4RegionIndex);
 
       return d;
     }

--- a/G4HepEm/G4HepEmInit/include/G4HepEmElectronInit.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmElectronInit.hh
@@ -1,5 +1,5 @@
 
-// Initialisation of all e-/e+ related data (e-loss tables, macroscopic cross 
+// Initialisation of all e-/e+ related data (e-loss tables, macroscopic cross
 // sections and target element selectors for each model) and interaction models.
 
 #ifndef G4HepEmElementInit_HH
@@ -8,7 +8,7 @@
 struct G4HepEmData;
 struct G4HepEmParameters;
 
-void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, bool iselectron);
+void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, bool iselectron, int verbose=0);
 
 
 

--- a/G4HepEm/G4HepEmInit/include/G4HepEmGammaInit.hh
+++ b/G4HepEm/G4HepEmInit/include/G4HepEmGammaInit.hh
@@ -10,7 +10,7 @@
 struct G4HepEmData;
 struct G4HepEmParameters;
 
-void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars);
+void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars, int verbose=0);
 
 
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmElectronInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmElectronInit.cc
@@ -34,7 +34,7 @@
 
 
 void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* hepEmPars,
-                      bool iselectron) {
+                      bool iselectron, int verbose) {
   // clean previous G4HepEmElectronData (if any)
   //
   // create G4Models for e- or for e+
@@ -42,7 +42,7 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
   if (iselectron) {
     g4PartDef = G4Electron::Electron();
   }
-  std::cout << "     ---  InitElectronData ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  InitElectronData ... " << std::endl;
   // Min/Max energies of the EM model (same as for the loss-tables)
   G4double emModelEMin = G4EmParameters::Instance()->MinKinEnergy();
   G4double emModelEMax = G4EmParameters::Instance()->MaxKinEnergy();
@@ -108,18 +108,18 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
     AllocateElectronData(&(hepEmData->fThePositronData));
   }
   // build energy loss data
-  std::cout << "     ---  BuildELossTables ..." << std::endl;
+  if (verbose > 1) std::cout << "     ---  BuildELossTables ..." << std::endl;
   BuildELossTables(modelMB, modelSB, modelRB, hepEmData, hepEmPars, iselectron);
   // build macroscopic cross section data (mat-cut dependent ioni and brem)
-  std::cout << "     ---  BuildLambdaTables ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  BuildLambdaTables ... " << std::endl;
   BuildLambdaTables(modelMB, modelSB, modelRB, hepEmData, hepEmPars, iselectron);
   // build macroscopic cross section data (mat dependent electron -, positron - nuclear)
   BuildNuclearLambdaTables(&hadENucXSDataStore, hepEmData, hepEmPars, iselectron);
   // build macroscopic first transport cross section data (used by Urban msc)
-  std::cout << "     ---  BuildTransportXSectionTables ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  BuildTransportXSectionTables ... " << std::endl;
   BuildTransportXSectionTables(modelUMSC, hepEmData, hepEmPars, iselectron);
   // build element selectors
-  std::cout << "     ---  BuildElementSelectorTables ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  BuildElementSelectorTables ... " << std::endl;
   BuildElementSelectorTables(modelMB, modelSB, modelRB, hepEmData, hepEmPars, iselectron);
   //
   // === Initialize the interaction description part of all models
@@ -130,7 +130,7 @@ void InitElectronData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* h
   //       the G4HepEmSBTables data structure (SB-table are the same fo -e and e+
   //       so we should build them only once)
   if (!hepEmData->fTheSBTableData) {
-    std::cout << "     ---  BuildSBBremTables ... " << std::endl;
+    if (verbose > 1) std::cout << "     ---  BuildSBBremTables ... " << std::endl;
     BuildSBBremSTables(hepEmData, hepEmPars, modelSB);
   }
 

--- a/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmGammaInit.cc
@@ -34,12 +34,12 @@
 
 #include <iostream>
 
-void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/) {
+void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*hepEmPars*/, int verbose) {
   // clean previous G4HepEmElectronData (if any)
   //
   // create G4Models for gamma
   G4ParticleDefinition* g4PartDef = G4Gamma::Gamma();
-  std::cout << "     ---  InitGammaData ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  InitGammaData ... " << std::endl;
   // Min/Max energies of the EM model (same as for the loss-tables)
   G4double emModelEMin = G4EmParameters::Instance()->MinKinEnergy();
   G4double emModelEMax = G4EmParameters::Instance()->MaxKinEnergy();
@@ -86,10 +86,10 @@ void InitGammaData(struct G4HepEmData* hepEmData, struct G4HepEmParameters* /*he
   // the allocation) but cleans the memory of the hepEmData->fTheGammaData
   AllocateGammaData(&(hepEmData->fTheGammaData));
   // build macroscopic cross section data for Conversion and Compton
-  std::cout << "     ---  BuildLambdaTables ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  BuildLambdaTables ... " << std::endl;
   BuildLambdaTables(modelPP, modelKN, &hadGNucXSDataStore, hepEmData);
   // build element selectors
-  std::cout << "     ---  BuildElementSelectorTables ... " << std::endl;
+  if (verbose > 1) std::cout << "     ---  BuildElementSelectorTables ... " << std::endl;
   BuildElementSelectorTables(modelPP, hepEmData);
   //
   // delete all g4 models

--- a/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
@@ -49,13 +49,4 @@ void InitHepEmParameters(struct G4HepEmParameters* hepEmPars) {
 
     rDat.fIsMultipleStepsInMSCTrans = true;
   }
-
-  hepEmPars->fFinalRange           = 1.0*CLHEP::mm;
-  hepEmPars->fDRoverRange          = 0.2;
-  hepEmPars->fLinELossLimit        = G4EmParameters::Instance()->LinearLossLimit();
-
-  // range factor parameter of the MSC stepping
-  hepEmPars->fMSCRangeFactor       = G4EmParameters::Instance()->MscRangeFactor();
-  hepEmPars->fMSCSafetyFactor      = G4EmParameters::Instance()->MscSafetyFactor();
-
 }

--- a/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
@@ -4,6 +4,7 @@
 #include "G4HepEmParameters.hh"
 
 // g4 include
+#include "G4Version.hh"
 #include "G4EmParameters.hh"
 #include "G4RegionStore.hh"
 #include "G4MscStepLimitType.hh"
@@ -24,6 +25,14 @@ void InitHepEmParameters(struct G4HepEmParameters* hepEmPars) {
   // e-/e+ related auxilary parameters:
   // energy limit between the 2 models (Seltzer-Berger and RelBrem) used for e-/e+
   hepEmPars->fElectronBremModelLim = 1.0*CLHEP::GeV;
+
+  // flag to indicate if the e+ correction to the MSC theta0 angle should be used
+  // note: em parameter for this available only in Geant4 version >= 11.1
+#if G4VERSION_NUMBER >= 1110
+  hepEmPars->fIsMSCPositronCor = G4EmParameters::Instance()->MscPositronCorrection();
+#else
+  hepEmPars->fIsMSCPositronCor = true;
+#endif
 
   // get the number of detector regions and allocate the per-region data array
   int numRegions = G4RegionStore::GetInstance()->size();

--- a/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
@@ -5,10 +5,15 @@
 
 // g4 include
 #include "G4EmParameters.hh"
+#include "G4RegionStore.hh"
+#include "G4MscStepLimitType.hh"
 #include "G4SystemOfUnits.hh"
 
+// NOTE: here we set all parameters according to their Geant4 values then
+//       later, in the `G4HepEmRunManager` from where this method is invoked from,
+//       we apply possible per-region configurations on the top of this.
 void InitHepEmParameters(struct G4HepEmParameters* hepEmPars) {
-  // e-/e+ tracking cut in kinetic energy
+  // tracking cut for e- in internal Geant4 energy units
   hepEmPars->fElectronTrackingCut = G4EmParameters::Instance()->LowestElectronEnergy();
 
   // energy loss table (i.e. dE/dx) related paramaters
@@ -16,15 +21,41 @@ void InitHepEmParameters(struct G4HepEmParameters* hepEmPars) {
   hepEmPars->fMaxLossTableEnergy   = G4EmParameters::Instance()->MaxKinEnergy();
   hepEmPars->fNumLossTableBins     = G4EmParameters::Instance()->NumberOfBins();
 
-  hepEmPars->fFinalRange           = 1.0*CLHEP::mm;
-  hepEmPars->fDRoverRange          = 0.2;
-  hepEmPars->fLinELossLimit        = G4EmParameters::Instance()->LinearLossLimit();
-
   // e-/e+ related auxilary parameters:
   // energy limit between the 2 models (Seltzer-Berger and RelBrem) used for e-/e+
   hepEmPars->fElectronBremModelLim = 1.0*CLHEP::GeV;
 
+  // get the number of detector regions and allocate the per-region data array
+  int numRegions = G4RegionStore::GetInstance()->size();
+  hepEmPars->fNumRegions = numRegions;
+  hepEmPars->fParametersPerRegion = new G4HepEmRegionParmeters[numRegions];
+
+  // set default values for all regions (might be changed after this init)
+  for (int i=0; i<G4RegionStore::GetInstance()->size(); ++i) {
+    G4HepEmRegionParmeters& rDat = hepEmPars->fParametersPerRegion[i];
+    // std::cout << " [" << i << "] Regin name = " << (*G4RegionStore::GetInstance())[i]->GetName() << std::endl;
+
+    // NOTE: these values are hidden inside G4EmParameters::G4EmExtraParameters!!!
+    rDat.fFinalRange    = 1.0*CLHEP::mm;
+    rDat.fDRoverRange   = 0.2;
+    rDat.fLinELossLimit = G4EmParameters::Instance()->LinearLossLimit();
+
+    rDat.fMSCRangeFactor  = G4EmParameters::Instance()->MscRangeFactor();
+    rDat.fMSCSafetyFactor = G4EmParameters::Instance()->MscSafetyFactor();
+
+    rDat.fIsMSCMinimalStepLimit = (G4MscStepLimitType::fMinimal == G4EmParameters::Instance()->MscStepLimitType());
+
+    rDat.fIsELossFluctuation = G4EmParameters::Instance()->LossFluctuation();
+
+    rDat.fIsMultipleStepsInMSCTrans = true;
+  }
+
+  hepEmPars->fFinalRange           = 1.0*CLHEP::mm;
+  hepEmPars->fDRoverRange          = 0.2;
+  hepEmPars->fLinELossLimit        = G4EmParameters::Instance()->LinearLossLimit();
+
   // range factor parameter of the MSC stepping
   hepEmPars->fMSCRangeFactor       = G4EmParameters::Instance()->MscRangeFactor();
   hepEmPars->fMSCSafetyFactor      = G4EmParameters::Instance()->MscSafetyFactor();
+
 }

--- a/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
+++ b/G4HepEm/G4HepEmInit/src/G4HepEmParametersInit.cc
@@ -48,5 +48,7 @@ void InitHepEmParameters(struct G4HepEmParameters* hepEmPars) {
     rDat.fIsELossFluctuation = G4EmParameters::Instance()->LossFluctuation();
 
     rDat.fIsMultipleStepsInMSCTrans = true;
+
+    rDat.fIsApplyCuts = G4EmParameters::Instance()->ApplyCuts();
   }
 }

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.hh
@@ -27,7 +27,7 @@ public:
 
   G4HepEmHostDevice
   static void StepLimit(G4HepEmData* hepEmData, G4HepEmParameters* hepEmPars, G4HepEmMSCTrackData* mscData,
-                        double ekin, int imat, double range, double presafety,
+                        double ekin, int imat, int iregion, double range, double presafety,
                         bool onBoundary, bool iselectron, G4HepEmRandomEngine* rnge);
 
   G4HepEmHostDevice

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.hh
@@ -33,7 +33,7 @@ public:
   G4HepEmHostDevice
   static void SampleScattering(G4HepEmData* hepEmData, G4HepEmMSCTrackData* mscData, double pStepLength,
                                double preStepEkin, double preStepTr1mfp, double postStepEkin, double postStepTr1mfp,
-                               int imat, bool isElectron, G4HepEmRandomEngine* rnge);
+                               int imat, bool isElectron, bool isPosCor, G4HepEmRandomEngine* rnge);
 
 
 
@@ -43,7 +43,7 @@ public:
   static double SampleCosineTheta(double pStepLengt, double preStepEkin, double preStepTr1mfp,
                                   double postStepEkin, double postStepTr1mfp, double umscTlimitMin,
                                   double radLength, double zeff, const double* umscTailCoeff, const double* umscThetaCoeff,
-                                  bool isElectron, G4HepEmRandomEngine* rnge);
+                                  bool isElectron, bool isPosCor, G4HepEmRandomEngine* rnge);
 
   // auxilary method for sampling cos(theta) in a simplified way: using an arbitrary pdf with correct mean and stdev
   // (used in the above `SampleCosineTheta`)
@@ -53,7 +53,7 @@ public:
   // auxilary method for computing theta0 (used in the above `SampleCosineTheta`)
   G4HepEmHostDevice
   static double ComputeTheta0(double stepInRadLength, double postStepEkin, double preStepEkin,
-                              double zeff, const double* umscThetaCoeff, bool isElectron);
+                              double zeff, const double* umscThetaCoeff, bool isElectron, bool isPosCor);
 
   // auxilary method for computing the e+ correction to theta0 (used in the above `ComputeTheta0` but only in case of e+)
   G4HepEmHostDevice

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
@@ -17,7 +17,7 @@
 // Note, that in all cases, the final physical step length will need to be coverted to geometrical
 // one that is done in the G4HepEmElectronManager.
 void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmParameters* hepEmPars,
-    G4HepEmMSCTrackData* mscData, double ekin, int imat, double range, double presafety,
+    G4HepEmMSCTrackData* mscData, double ekin, int imat, int iregion, double range, double presafety,
     bool onBoundary, bool iselectron, G4HepEmRandomEngine* rnge) {
   // Initial values:
   //  - lengths are already initialised to the current minimum physics step  which is the true, minimum
@@ -25,6 +25,9 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
   //  - the first transport mean free path value, i.e. `mscData.fLambtr1` is also assumed to be up to date
   mscData->fIsNoScatteringInMSC = false;
   mscData->fIsDisplace          = true;
+
+  const double mscRangeFactor  = hepEmPars->fParametersPerRegion[iregion].fMSCRangeFactor;
+  const double mscSafetyFactor = hepEmPars->fParametersPerRegion[iregion].fMSCSafetyFactor;
 
   // stop in case of:
   // - very small steps
@@ -45,8 +48,8 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
     // note: the below is true only because `lambdaLimit = 1.0 [mm]`
     //const double kILambdaLimit   = 1.0; // 1/(kLambdaLimit = 1.0 [mm])
     mscData->fDynamicRangeFactor = lambdaTr1 > 1.0
-                                   ? hepEmPars->fMSCRangeFactor*(0.75 + 0.25*lambdaTr1)
-                                   : hepEmPars->fMSCRangeFactor;
+                                   ? mscRangeFactor*(0.75 + 0.25*lambdaTr1)
+                                   : mscRangeFactor;
     // note: `ekin` below is the kinetic energy in MeV;
     const double stepMin = lambdaTr1*1.0E-3/(2.0E-3 + ekin*(matData.fUMSCStepMinPars[0] + ekin*matData.fUMSCStepMinPars[1]));
 
@@ -72,7 +75,7 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
   // the true step limit
   const double tlimitmin = mscData->fTlimitMin;
   const double tlimit    = range > presafety
-                  ? G4HepEmMax(G4HepEmMax(mscData->fInitialRange*mscData->fDynamicRangeFactor, hepEmPars->fMSCSafetyFactor*presafety), tlimitmin)
+                  ? G4HepEmMax(G4HepEmMax(mscData->fInitialRange*mscData->fDynamicRangeFactor, mscSafetyFactor*presafety), tlimitmin)
                   : G4HepEmMax(range, tlimitmin);
   // randomise the true step limit but only if the step was determined by msc
   if (tlimit < mscData->fTrueStepLength) { // keep mscData->fTrueStepLength otherwise as teh current step-limit --> not msc limited this step

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
@@ -128,10 +128,10 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
 
 void G4HepEmElectronInteractionUMSC::SampleScattering(G4HepEmData* hepEmData, G4HepEmMSCTrackData* mscData,
      double pStepLength, double preStepEkin, double preStepTr1mfp, double postStepEkin, double postStepTr1mfp,
-     int imat, bool isElectron, G4HepEmRandomEngine* rnge) {
+     int imat, bool isElectron, bool isPosCor, G4HepEmRandomEngine* rnge) {
   const struct G4HepEmMatData& matData = hepEmData->fTheMaterialData->fMaterialData[imat];
   const double cost  = SampleCosineTheta(pStepLength, preStepEkin, preStepTr1mfp, postStepEkin, postStepTr1mfp, mscData->fTlimitMin,
-                         matData.fRadiationLength, matData.fZeff, matData.fUMSCTailCoeff, matData.fUMSCThetaCoeff, isElectron, rnge);
+                         matData.fRadiationLength, matData.fZeff, matData.fUMSCTailCoeff, matData.fUMSCThetaCoeff, isElectron, isPosCor, rnge);
   // no scattering so no dispacement in case cost = 1.0
   if (std::abs(cost) >= 1.0) {
     mscData->fIsNoScatteringInMSC = true;
@@ -150,7 +150,7 @@ void G4HepEmElectronInteractionUMSC::SampleScattering(G4HepEmData* hepEmData, G4
 
 double G4HepEmElectronInteractionUMSC::SampleCosineTheta(double pStepLength, double preStepEkin, double preStepTr1mfp,
        double postStepEkin, double postStepTr1mfp, double umscTlimitMin, double radLength, double zeff,
-       const double* umscTailCoeff, const double* umscThetaCoeff, bool isElectron, G4HepEmRandomEngine* rnge) {
+       const double* umscTailCoeff, const double* umscThetaCoeff, bool isElectron, bool isPosCor, G4HepEmRandomEngine* rnge) {
   // NOTE: since I already know the finalEnergy in the electron Manager and that is already set to the track,
   //       I could get the logFinalEnergy from the updated track which could save up one log call
   // compute the 1rst transport mfp at the post-step point energy
@@ -199,8 +199,8 @@ double G4HepEmElectronInteractionUMSC::SampleCosineTheta(double pStepLength, dou
   const double   tsmall    = G4HepEmMin(umscTlimitMin, 1.0);
   const bool stpNotExSmall = pStepLength > tsmall;
   const double theta0      = stpNotExSmall
-                            ? ComputeTheta0(pStepLength/radLength, postStepEkin, preStepEkin, zeff, umscThetaCoeff, isElectron)
-                            : ComputeTheta0(tsmall/radLength,      postStepEkin, preStepEkin, zeff, umscThetaCoeff, isElectron)*std::sqrt(pStepLength/tsmall);
+                            ? ComputeTheta0(pStepLength/radLength, postStepEkin, preStepEkin, zeff, umscThetaCoeff, isElectron, isPosCor)
+                            : ComputeTheta0(tsmall/radLength,      postStepEkin, preStepEkin, zeff, umscThetaCoeff, isElectron, isPosCor)*std::sqrt(pStepLength/tsmall);
   //
   if (theta0 > kPi*0.166666) {
     return SimpleScattering(xmeanth, x2meanth, rnge);
@@ -293,14 +293,15 @@ double G4HepEmElectronInteractionUMSC::SimpleScattering(double xmeanth, double x
 
 
 // totry: all these could probably computed in `float`
-double G4HepEmElectronInteractionUMSC::ComputeTheta0(double stepInRadLength, double postStepEkin, double preStepEkin, double zeff, const double* umscThetaCoeff, bool isElectron) {
+double G4HepEmElectronInteractionUMSC::ComputeTheta0(double stepInRadLength, double postStepEkin, double preStepEkin, double zeff,
+       const double* umscThetaCoeff, bool isElectron, bool isPosCor) {
   // ( Highland formula: Particle Physics Booklet, July 2002, eq. 26.10)
   const double     kHighland = 13.6; // note:: assumed to be in MeV
   const double postInvBetaPc = (postStepEkin + kElectronMassC2)/(postStepEkin*(postStepEkin + 2.*kElectronMassC2));
   const double invBetaPc     = preStepEkin != postStepEkin
                                ? std::sqrt(postInvBetaPc*(preStepEkin + kElectronMassC2)/(preStepEkin*(preStepEkin + 2.*kElectronMassC2)))
                                : postInvBetaPc;
-  const double y = isElectron
+  const double y = (isElectron || !isPosCor)
                    ? stepInRadLength
                    : stepInRadLength * Theta0PositronCorrection(preStepEkin*postStepEkin, zeff);
   return kHighland*std::sqrt(y)*invBetaPc*(umscThetaCoeff[0] + umscThetaCoeff[1]*G4HepEmLog(y));

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronInteractionUMSC.icc
@@ -26,9 +26,6 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
   mscData->fIsNoScatteringInMSC = false;
   mscData->fIsDisplace          = true;
 
-  const double mscRangeFactor  = hepEmPars->fParametersPerRegion[iregion].fMSCRangeFactor;
-  const double mscSafetyFactor = hepEmPars->fParametersPerRegion[iregion].fMSCSafetyFactor;
-
   // stop in case of:
   // - very small steps
   // - will never leave the current volume boundary (the correction on range accounts fluctuation)
@@ -39,44 +36,79 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
     mscData->fIsDisplace = false;
     return;
   }
-  // set the initial range, dynamic range factor, minimal step and true step values
-  // if just enetring to a new volume or performing the very first step with this
-  // particle (or more exactly, reaching this point first time)
-  if (mscData->fIsFirstStep || onBoundary) {
-    const double lambdaTr1 = mscData->fLambtr1;
-    mscData->fInitialRange = G4HepEmMax(range, lambdaTr1);
-    // note: the below is true only because `lambdaLimit = 1.0 [mm]`
-    //const double kILambdaLimit   = 1.0; // 1/(kLambdaLimit = 1.0 [mm])
-    mscData->fDynamicRangeFactor = lambdaTr1 > 1.0
-                                   ? mscRangeFactor*(0.75 + 0.25*lambdaTr1)
-                                   : mscRangeFactor;
-    // note: `ekin` below is the kinetic energy in MeV;
-    const double stepMin = lambdaTr1*1.0E-3/(2.0E-3 + ekin*(matData.fUMSCStepMinPars[0] + ekin*matData.fUMSCStepMinPars[1]));
+  const double mscRangeFactor  =  hepEmPars->fParametersPerRegion[iregion].fMSCRangeFactor;
+  const double mscSafetyFactor =  hepEmPars->fParametersPerRegion[iregion].fMSCSafetyFactor;
+  const bool   mscIsUseSafety  = !hepEmPars->fParametersPerRegion[iregion].fIsMSCMinimalStepLimit;
 
-    // there is some difference in the algorithm from G4.11.0 that (together with
-    // the differences in the fUMSCPar, fUMSCStepMinPars[0,1] parameter values) gives
-    // 2-3 % lower number of HITS (e.g. lower number of steps) in ATLAS when using
-    // G4.11.0 compred to older G4 versions such as G4.10.6.p03.
-    // We include this to ease validation though this is an improvment of G4 11.0
+  double tlimit = 0.0;
+  if (mscIsUseSafety) {
+      // The `fUseSafety` Urban MSC step limit (i.e. sdandard EM):
+      // ---------------------------------------------------------
+      // set the initial range, dynamic range factor, minimal step and true step values
+      // if just enetring to a new volume or performing the very first step with this
+      // particle (or more exactly, reaching this point first time)
+      if (mscData->fIsFirstStep || onBoundary) {
+        const double lambdaTr1 = mscData->fLambtr1;
+        mscData->fInitialRange = G4HepEmMax(range, lambdaTr1);
+        // note: the below is true only because `lambdaLimit = 1.0 [mm]`
+        //const double kILambdaLimit   = 1.0; // 1/(kLambdaLimit = 1.0 [mm])
+        mscData->fDynamicRangeFactor = lambdaTr1 > 1.0
+                                       ? mscRangeFactor*(0.75 + 0.25*lambdaTr1)
+                                       : mscRangeFactor;
+        // note: `ekin` below is the kinetic energy in MeV;
+        const double stepMin = lambdaTr1*1.0E-3/(2.0E-3 + ekin*(matData.fUMSCStepMinPars[0] + ekin*matData.fUMSCStepMinPars[1]));
+
+        // there is some difference in the algorithm from G4.11.0 that (together with
+        // the differences in the fUMSCPar, fUMSCStepMinPars[0,1] parameter values) gives
+        // 2-3 % lower number of HITS (e.g. lower number of steps) in ATLAS when using
+        // G4.11.0 compred to older G4 versions such as G4.10.6.p03.
+        // We include this to ease validation though this is an improvment of G4 11.0
 #if G4VERSION_NUM < 1070
-    // G4 version before 10.7
-    mscData->fTlimitMin  = G4HepEmMax(0.70*matData.fZeffSqrt*stepMin, kTLimitMinfix);
+        // G4 version before 10.7
+        mscData->fTlimitMin  = G4HepEmMax(0.70*matData.fZeffSqrt*stepMin, kTLimitMinfix);
 #else
-    // this is like in Geant4.11.0
-    const double dum0    = iselectron ? 0.87*matData.fZeff23 : 0.70*matData.fZeffSqrt;
-    // note `tlow` = 5 [keV] ==> 5.0E-3 [MeV] ==> 1/tlow = 200 [1/MeV]
-    const double dum1    = ekin > 5.0E-3 ? dum0*stepMin : dum0*stepMin*0.5*(1.0 + ekin*200.0);
-    mscData->fTlimitMin  = G4HepEmMax(dum1, kTLimitMinfix);
+        // this is like in Geant4.11.0
+        const double dum0    = iselectron ? 0.87*matData.fZeff23 : 0.70*matData.fZeffSqrt;
+        // note `tlow` = 5 [keV] ==> 5.0E-3 [MeV] ==> 1/tlow = 200 [1/MeV]
+        const double dum1    = ekin > 5.0E-3 ? dum0*stepMin : dum0*stepMin*0.5*(1.0 + ekin*200.0);
+        mscData->fTlimitMin  = G4HepEmMax(dum1, kTLimitMinfix);
 #endif
 
-    // reset first step flag (if any)
-    mscData->fIsFirstStep = false;
-  }
-  // the true step limit
-  const double tlimitmin = mscData->fTlimitMin;
-  const double tlimit    = range > presafety
+        // reset first step flag (if any)
+        mscData->fIsFirstStep = false;
+      }
+      // the true step limit
+      const double tlimitmin = mscData->fTlimitMin;
+      tlimit    = range > presafety
                   ? G4HepEmMax(G4HepEmMax(mscData->fInitialRange*mscData->fDynamicRangeFactor, mscSafetyFactor*presafety), tlimitmin)
                   : G4HepEmMax(range, tlimitmin);
+  } else {
+      // The `fMinimal` Urban MSC step limit (i.e. sdandard EM):
+      // ---------------------------------------------------------
+      // NOTE: `tlimit` is updated only when moving to a new volume (see below).
+      //  Its value is stored in `mscData->fInitialRange` instead of introducing a
+      //  new memebr as `fInitialRange` is not used when the step limit is `fMinimal`
+      //
+      // NOTE: `tlimit` stays its initial value till the first boundary which is
+      //  very large (1E+21 mm in our case while 1E+50 in G4UrbanMscModel) so
+      //  no MSC step limit till the very first boundary for sure.
+      if (onBoundary) {
+        const double lambdaTr1 = mscData->fLambtr1;
+        const double tmpTlimit = range > lambdaTr1
+                                 ? mscRangeFactor*range
+                                 : mscRangeFactor*lambdaTr1;
+        // store `tlimit` in `mscData->fInitialRange` instead of introducing
+        // a new member as `fInitialRange` is not used when the step limit is
+        // `fMinimal`; note: tlimitmin = 10*kTLimitMinfix
+        mscData->fInitialRange = G4HepEmMax(tmpTlimit,  10*kTLimitMinfix);
+      }
+      tlimit = mscData->fInitialRange; // initialised to 1E+21 mm at start tracking
+  }
+
+  // NOTE: on `tlimit` and `tlimitmin`
+  // `fUseSafety`: `tlimit` is updated in each step while `tlimitmin` only at first of entering to a new volume
+  // `fMinimal`  : `tlimit` is updated only when enetring to a new volume while `tlimitmin` is constant (10x kTLimitMinfix)
+  const double tlimitmin = mscData->fTlimitMin;
   // randomise the true step limit but only if the step was determined by msc
   if (tlimit < mscData->fTrueStepLength) { // keep mscData->fTrueStepLength otherwise as teh current step-limit --> not msc limited this step
     const double dum0 = tlimit > tlimitmin
@@ -84,6 +116,7 @@ void G4HepEmElectronInteractionUMSC::StepLimit(G4HepEmData* hepEmData, G4HepEmPa
                         : tlimitmin;
     mscData->fTrueStepLength = G4HepEmMin(dum0, mscData->fTrueStepLength);
   }
+
   // msc step limit is done!
   //
   // convert the true (physics) step length to geometrical one (i.e. the pojection of the transport vector

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -61,8 +61,9 @@ void G4HepEmElectronManager::HowFarToDiscreteInteraction(struct G4HepEmData* hep
   //
   const double range  = GetRestRange(theElectronData, theIMC, theEkin, theLEkin);
   theElTrack->SetRange(range);
-  const double frange = hepEmPars->fFinalRange;
-  const double drange = hepEmPars->fDRoverRange;
+  const int indxRegion = hepEmData->fTheMatCutData->fMatCutData[theIMC].fG4RegionIndex;
+  const double frange  = hepEmPars->fParametersPerRegion[indxRegion].fFinalRange;
+  const double drange  = hepEmPars->fParametersPerRegion[indxRegion].fDRoverRange;
   pStepLength = (range > frange)
                 ? range*drange + frange*(1.0-drange)*(2.0-frange/range)
                 : range;
@@ -124,8 +125,9 @@ void G4HepEmElectronManager::HowFarToMSC(struct G4HepEmData* hepEmData, struct G
                                                ? hepEmData->fTheElectronData
                                                : hepEmData->fThePositronData;
 
-  const int theImat = (hepEmData->fTheMatCutData->fMatCutData[theIMC]).fHepEmMatIndex;
-
+  const G4HepEmMCCData& theMatCutData = hepEmData->fTheMatCutData->fMatCutData[theIMC];
+  const int theImat = theMatCutData.fHepEmMatIndex;
+  const int theIreg = theMatCutData.fG4RegionIndex;
   G4HepEmMSCTrackData* mscData = theElTrack->GetMSCTrackData();
   // init some mscData for the case if we skipp calling msc due to very small step
   mscData->fTrueStepLength      = pStepLength;
@@ -139,7 +141,7 @@ void G4HepEmElectronManager::HowFarToMSC(struct G4HepEmData* hepEmData, struct G
     mscData->fIsActive = true;
     // compute the fist transport mean free path
     mscData->fLambtr1  = GetTransportMFP(theElectronData, theImat, theEkin, theLEkin);
-    G4HepEmElectronInteractionUMSC::StepLimit(hepEmData, hepEmPars, mscData, theEkin, theImat, range,
+    G4HepEmElectronInteractionUMSC::StepLimit(hepEmData, hepEmPars, mscData, theEkin, theImat, theIreg, range,
                                               theTrack->GetSafety(), theTrack->GetOnBoundary(), isElectron, rnge);
     // If msc limited the true step length, then the G4HepEmMSCTrackData::fTrueStepLength member of
     // the input electron track is < pStepLengt. Otherwise its = pStepLengt.
@@ -236,7 +238,9 @@ bool G4HepEmElectronManager::ApplyMeanEnergyLoss(struct G4HepEmData* hepEmData, 
   const double theLEkin = theTrack->GetLogEKin();
   double eloss = pStepLength*GetRestDEDX(elData, theIMC, theEkin, theLEkin);
   // 2. use integral if linear energy loss is over the limit fraction
-  if (eloss > theEkin*hepEmPars->fLinELossLimit) {
+  const int indxRegion = hepEmData->fTheMatCutData->fMatCutData[theIMC].fG4RegionIndex;
+  const double parLinELossLimit = hepEmPars->fParametersPerRegion[indxRegion].fLinELossLimit;
+  if (eloss > theEkin*parLinELossLimit) {
     const double postStepRange = theRange - pStepLength;
     eloss = theEkin - GetInvRange(elData, theIMC, postStepRange);
   }
@@ -329,8 +333,10 @@ bool G4HepEmElectronManager::SampleLossFluctuations(struct G4HepEmData* hepEmDat
   double eloss     = theTrack->GetEnergyDeposit();
   // sample energy loss fluctuations
 #ifndef NOFLUCTUATION
+  const int iregion = hepEmData->fTheMatCutData->fMatCutData[theIMC].fG4RegionIndex;;
+  const int isFluctuation = hepEmPars->fParametersPerRegion[iregion].fIsELossFluctuation;
   const double kFluctParMinEnergy  = 1.E-5; // 10 eV
-  if (eloss > kFluctParMinEnergy) {
+  if (isFluctuation && eloss > kFluctParMinEnergy) {
     const G4HepEmMCCData& theMatCutData = hepEmData->fTheMatCutData->fMatCutData[theIMC];
     const double elCut   = theMatCutData.fSecElProdCutE;
     const int    theImat = theMatCutData.fHepEmMatIndex;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmElectronManager.icc
@@ -301,8 +301,9 @@ void G4HepEmElectronManager::SampleMSC(struct G4HepEmData* hepEmData, struct G4H
     const double postStepTr1mfp = GetTransportMFP(elData, theImat, postStepEkin, postStepLEkin);
     // - sample scattering: including net angular deflection and lateral dispacement that will be
     //                      written into mscData::fDirection and mscData::fDisplacement
+    const bool isPosCor = hepEmPars->fIsMSCPositronCor;
     G4HepEmElectronInteractionUMSC::SampleScattering(hepEmData, mscData, pStepLength, preStepEkin, mscData->fLambtr1, postStepEkin, postStepTr1mfp,
-                                    theImat, isElectron, rnge);
+                                    theImat, isElectron, isPosCor, rnge);
     // NOTE: displacement will be applied in the caller where we have access to the required Geant4 functionality
     //       (and if its length is longer than a small minimal length and we are not ended up on boundary)
     //

--- a/apps/examples/TestEm3/src/PhysListHepEmTracking.cc
+++ b/apps/examples/TestEm3/src/PhysListHepEmTracking.cc
@@ -1,5 +1,7 @@
 #include "PhysListHepEmTracking.hh"
+
 #include "G4HepEmTrackingManager.hh"
+#include "G4HepEmConfig.hh"
 
 #include "G4EmParameters.hh"
 
@@ -30,8 +32,14 @@ void PhysListHepEmTracking::ConstructProcess()
 {
   // Register custom tracking manager for e-/e+ and gammas.
   auto* trackingManager = new G4HepEmTrackingManager;
-
-  trackingManager->AddWoodcockTrackingRegion("Woodcock_Region");
+  // Configuration of G4HepEm
+  // Several paramaters can be configured per detector region. These are:
+  //  MSC parameters, continuous energy loss step limit function parameters,
+  //  MSC minimal/default step limit, Woodcock tracking of photons, energy loss
+  //  fluctuation, multiple steps in the combined MSC with Transportation
+  // Here we activate only one: Woodcock tracking in the calorimeter region (Woodcock_Region)
+  G4HepEmConfig* config = trackingManager->GetConfig();
+  config->SetWoodcockTrackingRegion("Woodcock_Region");
 
   G4Electron::Definition()->SetTrackingManager(trackingManager);
   G4Positron::Definition()->SetTrackingManager(trackingManager);

--- a/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
+++ b/testing/G4HepEmDataInterfaces/TestG4HepEmDataInterfaces.cc
@@ -162,6 +162,7 @@ void G4HepEmMatCutDataTester(G4HepEmMatCutData* d, int expectedG4Cuts, int expec
     // Each G4HepEmMCCData element must be default constructed
     EXPECT_EQ((d->fMatCutData[i]).fHepEmMatIndex, -1);
     EXPECT_EQ((d->fMatCutData[i]).fG4MatCutIndex, -1);
+    EXPECT_EQ((d->fMatCutData[i]).fG4RegionIndex, -1);
   }
 }
 

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -48,11 +48,11 @@ bool operator==(const G4HepEmRegionParmeters& lhs, const G4HepEmRegionParmeters&
   return std::tie(lhs.fFinalRange, lhs.fDRoverRange, lhs.fLinELossLimit,
               lhs.fMSCRangeFactor, lhs.fMSCSafetyFactor,
               lhs.fIsMSCMinimalStepLimit, lhs.fIsELossFluctuation,
-              lhs.fIsMultipleStepsInMSCTrans) ==
+              lhs.fIsMultipleStepsInMSCTrans, lhs.fIsApplyCuts) ==
      std::tie(rhs.fFinalRange, rhs.fDRoverRange, rhs.fLinELossLimit,
               rhs.fMSCRangeFactor, rhs.fMSCSafetyFactor,
               rhs.fIsMSCMinimalStepLimit, rhs.fIsELossFluctuation,
-              rhs.fIsMultipleStepsInMSCTrans);
+              rhs.fIsMultipleStepsInMSCTrans, rhs.fIsApplyCuts);
 }
 
 bool operator!=(const G4HepEmRegionParmeters& lhs, const G4HepEmRegionParmeters& rhs)

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -114,9 +114,11 @@ bool operator!=(const G4HepEmElementData& lhs, const G4HepEmElementData& rhs)
 bool operator==(const G4HepEmMCCData& lhs, const G4HepEmMCCData& rhs)
 {
   return std::tie(lhs.fSecElProdCutE, lhs.fSecPosProdCutE, lhs.fSecGamProdCutE,
-                  lhs.fLogSecGamCutE, lhs.fHepEmMatIndex, lhs.fG4MatCutIndex) ==
+                  lhs.fLogSecGamCutE, lhs.fHepEmMatIndex, lhs.fG4MatCutIndex,
+                  lhs.fG4RegionIndex) ==
          std::tie(rhs.fSecElProdCutE, rhs.fSecPosProdCutE, rhs.fSecGamProdCutE,
-                  rhs.fLogSecGamCutE, rhs.fHepEmMatIndex, rhs.fG4MatCutIndex);
+                  rhs.fLogSecGamCutE, rhs.fHepEmMatIndex, rhs.fG4MatCutIndex,
+                  rhs.fG4RegionIndex);
 }
 
 bool operator!=(const G4HepEmMCCData& lhs, const G4HepEmMCCData& rhs)

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -43,16 +43,39 @@ bool compare_arrays(int lhsSize, const T* lhsData, int rhsSize,
 }
 
 // --- G4HepEmParameters
+bool operator==(const G4HepEmRegionParmeters& lhs, const G4HepEmRegionParmeters& rhs)
+{
+  return std::tie(lhs.fFinalRange, lhs.fDRoverRange, lhs.fLinELossLimit,
+              lhs.fMSCRangeFactor, lhs.fMSCSafetyFactor,
+              lhs.fIsMSCMinimalStepLimit, lhs.fIsELossFluctuation,
+              lhs.fIsMultipleStepsInMSCTrans) ==
+     std::tie(rhs.fFinalRange, rhs.fDRoverRange, rhs.fLinELossLimit,
+              rhs.fMSCRangeFactor, rhs.fMSCSafetyFactor,
+              rhs.fIsMSCMinimalStepLimit, rhs.fIsELossFluctuation,
+              rhs.fIsMultipleStepsInMSCTrans);
+}
+
+bool operator!=(const G4HepEmRegionParmeters& lhs, const G4HepEmRegionParmeters& rhs)
+{
+  return !(lhs == rhs);
+}
+
+
 bool operator==(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)
 {
+
+  if(!compare_arrays(lhs.fNumRegions, lhs.fParametersPerRegion,
+                     rhs.fNumRegions, rhs.fParametersPerRegion))
+  {
+    return false;
+  }
+
   return std::tie(lhs.fElectronTrackingCut, lhs.fMinLossTableEnergy,
                   lhs.fMaxLossTableEnergy, lhs.fNumLossTableBins,
-                  lhs.fFinalRange, lhs.fDRoverRange, lhs.fLinELossLimit,
-                  lhs.fElectronBremModelLim) ==
+                  lhs.fElectronBremModelLim, lhs.fNumRegions) ==
          std::tie(rhs.fElectronTrackingCut, rhs.fMinLossTableEnergy,
                   rhs.fMaxLossTableEnergy, rhs.fNumLossTableBins,
-                  rhs.fFinalRange, rhs.fDRoverRange, rhs.fLinELossLimit,
-                  rhs.fElectronBremModelLim);
+                  rhs.fElectronBremModelLim, rhs.fNumRegions);
 }
 
 bool operator!=(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)

--- a/testing/TestUtils/G4HepEmDataComparison.hh
+++ b/testing/TestUtils/G4HepEmDataComparison.hh
@@ -72,10 +72,12 @@ bool operator==(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)
 
   return std::tie(lhs.fElectronTrackingCut, lhs.fMinLossTableEnergy,
                   lhs.fMaxLossTableEnergy, lhs.fNumLossTableBins,
-                  lhs.fElectronBremModelLim, lhs.fNumRegions) ==
+                  lhs.fElectronBremModelLim, lhs.fIsMSCPositronCor,
+                  lhs.fNumRegions) ==
          std::tie(rhs.fElectronTrackingCut, rhs.fMinLossTableEnergy,
                   rhs.fMaxLossTableEnergy, rhs.fNumLossTableBins,
-                  rhs.fElectronBremModelLim, rhs.fNumRegions);
+                  rhs.fElectronBremModelLim, rhs.fNumRegions,
+                  rhs.fIsMSCPositronCor);
 }
 
 bool operator!=(const G4HepEmParameters& lhs, const G4HepEmParameters& rhs)


### PR DESCRIPTION
A `G4HepEmConfig` object has been added to the `G4HepEmTrackingManager` that allows to set and store configuration options and parameters. Most of the parameters are stored in its `G4HepEmParameters` member that has been extended to hold some of its parameters per detector region.

The `G4HepEmConfig` member of the `G4HepEmTrackingManager` can be obtained after its construction and its parameters can be set before the initialisation of the run. 

Different values of the following parameters can be set per detector region using the `G4HepEmConfig` setters:
 - Woodcock tracking of photons and its kinetic energy limit (below which it's turned OFF)
   (default: Woodcock tracking is OFF; its minimal energy is `200 keV`) 
 - parameters of the continuous energy loss step limit function 
   (default: `finalRange = 1 mm`; `dRoverRange = 0.2`)
 - the `range` and `safety` factor parameters of the multiple scattering model 
   (default values are taken from `G4HepEmParameters` with default `rangeF= 0.04`, `safetyF = 2.5` values there)
 - step limit type of the multiple scattering: the simplified `G4MscStepLimitType::fMinimal` step limit algorithm is also available now beyond the default (`G4MscStepLimitType::fUseSafety`)
   (default: using the minimal step limit if OFF in all regions)
 - activating/deactivating energy loss fluctuation 
   (default values are taken from `G4HepEmParameters` with default ON there)
 - activating/deactivating applying cuts on secondaries from all processes (i.e. not only those from ionisation and bremsstrahlung)     
   (default values are taken from `G4HepEmParameters` with default OFF there) 
 - activating/deactivating allowing the combined multiple scattering and transportation through multiple steps 
   (default: ON)

The following parameters has a single global value (and can be set directly in the `G4HepEmParameters` member of the `G4HepEmConfig` object):
 - `fElectronTrackingCut`: tracking cut on e-/e+ 
   (default values are taken from `G4HepEmParameters` with a default of `1 keV` there in case of standard EM opt0)
 - `fIsMSCPositronCor`: indicates if the e+ correction, to the mean scattering angle in the MSC model, should be applied      
   (default: ON)
