### PR TITLE
A set of smaller modifications for increasing robustness and verbosity.

### DIFF
--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -80,6 +80,8 @@ private:
   //       no harm outside Athena.
   void InitXTRRelated();
 
+  // Reports the extra physics configuration, i.e. nuclear and fast sim. processes
+  void ReportExtraProcesses(int particleID);
 
 #ifdef G4HepEm_EARLY_TRACKING_EXIT
   // Virtual function to check early tracking exit. This function allows user

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -672,8 +672,8 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
 
       // ATLAS XTR RELATED:
       // Invoke the TRTTransitionRadiation process for e-/e+ fXTRProcess:
-      // But only if the step was done in the Radiator region with energy > 255 MeV (m_EkinMin)
-      if (fXTRProcess != nullptr && fXTRRegion == preStepPoint.GetPhysicalVolume()->GetLogicalVolume()->GetRegion() && thePrimaryTrack->GetEKin() > 255.0) {
+      // But only if the step was done with energy > 255 MeV (m_EkinMin) in the Radiator region (if that region was found)
+      if (fXTRProcess != nullptr && thePrimaryTrack->GetEKin() > 255.0 && (fXTRRegion == nullptr || fXTRRegion == preStepPoint.GetPhysicalVolume()->GetLogicalVolume()->GetRegion())) {
         // the TRTTransitionRadiation process might create photons as secondary
         // and changes the primary e-/e+ energy only but nothing more than that
         // requires: kinetic energy and momentum direction from the track (dynamic part.) and logical volume
@@ -1427,7 +1427,7 @@ void G4HepEmTrackingManager::InitXTRRelated() {
   // NOTE: becomes `nullptr` if there is no detector region with the name ensuring
   //       that everything works fine also outside ATLAS Athena
   // NOTE: after the suggested changes in Athena, the region name should be
-  //       `TRT_RADIATOR` but till that it's `DefaultRegionForTheWorld`
+  //       `TRT_RADIATOR` but till that `nullptr` also works fine (just less effitient)
   fXTRRegion = G4RegionStore::GetInstance()->GetRegion(fXTRRegionName, false);
   // Try to get the pointer to the TRTTransitionRadiation process (same for e-/e+)
   // NOTE: stays `nullptr` if gamma dosen't have process with the name ensuring
@@ -1440,14 +1440,14 @@ void G4HepEmTrackingManager::InitXTRRelated() {
     }
   }
   // Print information if the XTR process was found (enable to check)
-  if (fXTRProcess != nullptr) {
-    std::cout << " G4HepEmTrackingManager: found the ATLAS specific "
-              << fXTRProcess->GetProcessName() << " process";
-    if (fXTRRegion != nullptr) {
-      std::cout << " with the " << fXTRRegion->GetName() << " region.";
-    }
-    std::cout << std::endl;
-  }
+//  if (fXTRProcess != nullptr) {
+//    std::cout << " G4HepEmTrackingManager: found the ATLAS specific "
+//              << fXTRProcess->GetProcessName() << " process";
+//    if (fXTRRegion != nullptr) {
+//      std::cout << " with the " << fXTRRegion->GetName() << " region.";
+//    }
+//    std::cout << std::endl;
+//  }
 }
 
 

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -36,7 +36,9 @@
 
 #include "G4VProcess.hh"
 #include "G4EmProcessSubType.hh"
+#include "G4GammaGeneralProcess.hh"
 #include "G4HadronicProcessType.hh"
+#include "G4HadronicProcess.hh"
 #include "G4ProcessType.hh"
 #include "G4TransportationProcessType.hh"
 
@@ -1364,6 +1366,14 @@ void G4HepEmTrackingManager::InitNuclearProcesses(int particleID) {
   for (std::size_t ip=0; ip<processVector->entries(); ip++) {
     if( (*processVector)[ip]->GetProcessName()==nameNuclearProcess) {
       *proc = (*processVector)[ip];
+      // make sure the process is initialised (element selectors needs to be built)
+      (*proc)->PreparePhysicsTable(*particleDef);
+      (*proc)->BuildPhysicsTable(*particleDef);
+      break;
+    }
+    // gamm ageneral case
+    if( (*processVector)[ip]->GetProcessSubType()==G4EmProcessSubType::fGammaGeneralProcess) {
+      *proc = static_cast<G4GammaGeneralProcess*>((*processVector)[ip])->GetGammaNuclear();
       // make sure the process is initialised (element selectors needs to be built)
       (*proc)->PreparePhysicsTable(*particleDef);
       (*proc)->BuildPhysicsTable(*particleDef);

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -19,6 +19,7 @@
 #include "G4HepEmGammaManager.hh"
 #include "G4HepEmGammaTrack.hh"
 
+#include "G4Version.hh"
 #include "G4MaterialCutsCouple.hh"
 #include "G4Step.hh"
 #include "G4StepPoint.hh"
@@ -35,6 +36,7 @@
 #include "G4ProductionCutsTable.hh"
 
 #include "G4VProcess.hh"
+#include "G4ProcessTable.hh"
 #include "G4EmProcessSubType.hh"
 #include "G4GammaGeneralProcess.hh"
 #include "G4HadronicProcessType.hh"
@@ -1383,13 +1385,20 @@ void G4HepEmTrackingManager::InitNuclearProcesses(int particleID) {
       (*proc)->BuildPhysicsTable(*particleDef);
       break;
     }
-    // gamm ageneral case
+    // gamma ageneral case
     if( (*processVector)[ip]->GetProcessSubType()==G4EmProcessSubType::fGammaGeneralProcess) {
+#if G4VERSION_NUMBER >= 1120
+      // this getter available only in the `G4GammaGeneralProcess` only from g4-11.2.0
       *proc = static_cast<G4GammaGeneralProcess*>((*processVector)[ip])->GetGammaNuclear();
-      // make sure the process is initialised (element selectors needs to be built)
-      (*proc)->PreparePhysicsTable(*particleDef);
-      (*proc)->BuildPhysicsTable(*particleDef);
-      break;
+#else
+      *proc = G4ProcessTable::GetProcessTable()->FindProcess(nameNuclearProcess, G4Gamma::Definition());
+#endif
+      if ((*proc) != nullptr) {
+        // make sure the process is initialised (element selectors needs to be built)
+        (*proc)->PreparePhysicsTable(*particleDef);
+        (*proc)->BuildPhysicsTable(*particleDef);
+        break;
+      }
     }
   }
 }

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -1105,7 +1105,7 @@ bool G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
           step.UpdateTrack();
 
           // Stack secondaries created by the HepEm physics above
-          edep += StackSecondaries(theTLData, aTrack, proc, g4IMC, isApplyCuts);
+          edep += StackSecondaries(theTLData, aTrack, fGammaNoProcessVector[iDProc], g4IMC, isApplyCuts);
 
         } else {
           // Gamma-nuclear: --> use Geant4 for the interaction:

--- a/G4HepEm/G4HepEm/src/G4HepEmWoodcockHelper.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmWoodcockHelper.cc
@@ -328,6 +328,15 @@ void G4HepEmWoodcockHelper::FindWDTMaterial(G4LogicalVolume* lvol, double& maxDe
   int numDaughters = lvol->GetNoDaughters();
   for (int id=0; id<numDaughters; ++id) {
       G4LogicalVolume* lv = lvol->GetDaughter(id)->GetLogicalVolume();
+      // detect sub-region and stop if found: Woodcock tracking can be used only in leaf regions
+      if (lvol->GetRegion() != lv->GetRegion()) {
+        std::cerr << "\n *** G4HepEmWoodcockHelper::FindWDTMaterial \n"
+                  << "     Woodcock tracking cannot be applied in this region: " << lvol->GetRegion()->GetName() << "\n"
+                  << "     A sub-region has been found: " <<  lv->GetRegion()->GetName() << "\n"
+                  << "     Note: Woodcock tracking requires leaf region!\n"
+                  << std::endl;
+        exit(1);
+      }
       FindWDTMaterial(lv, maxDensity, maxDensityMat);
   }
 }


### PR DESCRIPTION
A set of final modifications correcting some issues (e.g. correct setting of the creator process in case of gamma interactions or ensuring to find the gamma-nuclear interaction even if encapsulated inside the gamma-general process), increasing robustness (e.g. detect if Woodcock tracking was required in non-leaf detector region or allowing the ATLAS specific `XTR` process work even if no special region has been set for it). Report on the extra process configuration, i.e. on fast simulation and nuclear interactions, has also been added.  