### PR TITLE
Miscellaneous modifications on the example application. 

### DIFF
--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -175,6 +175,10 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
     if (G4Threading::IsMasterThread() && fVerbose > 0) {
       ReportExtraProcesses(particleID);
     }
+    // Report the configuration (as e+ is the last among the 3 particles in a normal g4 flow)
+    if (G4Threading::IsMasterThread() && fVerbose > 0) {
+      fConfig->Dump();
+    }
   } else if (&part == G4Gamma::Definition()) {
     int particleID = 2;
     fRunManager->Initialize(fRandomEngine, particleID, fConfig->GetG4HepEmParameters());
@@ -201,10 +205,6 @@ void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part)
     // Report extra process configuration
     if (G4Threading::IsMasterThread() && fVerbose > 0) {
       ReportExtraProcesses(particleID);
-    }
-    // Report the configuration
-    if (G4Threading::IsMasterThread() && fVerbose > 0) {
-      fConfig->Dump();
     }
   } else {
     std::cerr

--- a/apps/examples/TestEm3/ATLASbar.mac
+++ b/apps/examples/TestEm3/ATLASbar.mac
@@ -24,13 +24,36 @@
 ##/testem/det/setField 0 0 2.0 tesla
 ##
 ## -----------------------------------------------------------------------------
-## Set the physics list (more exactly, the EM physics constructor):
-##   = 'HepEm'           : the G4HepEm EM physics c.t.r.
-##   =  'G4Em'           : the G4 EM physics c.t.r. that corresponds to G4HepEm
-##   = 'emstandard_opt0' : the original, G4 EM-Opt0 physics c.t.r.
+## Set the physics list (more exactly, the EM physics constructor e-/e+, gamma):
+##
+## NOTE: the full-fledged G4HepEm physics with its special tracking, i.e.
+##   `HepEmTracking` below, is the recommended usage of G4HepEm through its
+##   `G4HepEmTrackingManager`. This provides correct and complete physics
+##    (i.e. including nuclear interactions as well if attached to the particles)
+##    combined with maximal computing performance benefits, it requires at least
+##    Geant4-11.0. The other option is `HepEm`, i.e. connecting only the G4HepEm
+##    physics (through the `G4VProcess` interface), is incomplete (e.g. nuclear
+##    interactions aren't incorporated properly) and not efficient as it doesn't
+##    contain the special tracking component).
+##
+##  1. 'HepEmTracking' : full-fleged `G4HepEmTrackingManager`(G4HepEm physics with its special tracking)
+##  2. 'G4Em'          : native G4 EM physics that corresponds to the G4HepEm physics
+##  3. 'G4 EM-opt0'    : the native G4 EM standard opt0 physics constructor
+##  4. 'HepEm'         : G4HepEm physics using the `G4VProcess` interface (only for )
+##
+## NOTE: nuclear interactions are also added to e-/e+ and gamma through the
+##       `G4EmExtraPhysics` constructor (see the `PhysicsList`).
 ## -----------------------------------------------------------------------------
-/testem/phys/addPhysics   HepEmTracking
-##/testem/phys/addPhysics   G4Em
+/testem/phys/addPhysics HepEmTracking
+##/testem/phys/addPhysics G4Em
+##/testem/phys/addPhysics emstandard_opt0
+## NOTE: `HepEm` is only for development!
+##/testem/phys/addPhysics HepEm
+##
+## -----------------------------------------------------------------------------
+## Set the verbosity of the physics list (parameters, setting, configuration)
+## -----------------------------------------------------------------------------
+/testem/phys/verbose 1
 ##
 ## -----------------------------------------------------------------------------
 ## Use the gamma-general process in Geant4 (similarly to HepEmTracking)

--- a/apps/examples/TestEm3/include/PhysicsListMessenger.hh
+++ b/apps/examples/TestEm3/include/PhysicsListMessenger.hh
@@ -41,28 +41,29 @@ class PhysicsList;
 class G4UIdirectory;
 class G4UIcmdWithADoubleAndUnit;
 class G4UIcmdWithAString;
+class G4UIcmdWithAnInteger;
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 class PhysicsListMessenger: public G4UImessenger
 {
   public:
-  
+
     PhysicsListMessenger(PhysicsList* );
    ~PhysicsListMessenger();
-    
+
     virtual void SetNewValue(G4UIcommand*, G4String);
-    
+
   private:
-  
+
     PhysicsList*               fPhysicsList;
-    
-    G4UIdirectory*             fPhysDir;    
+
+    G4UIdirectory*             fPhysDir;
     G4UIcmdWithAString*        fListCmd;
-    
+    G4UIcmdWithAnInteger*      fVerboseCmd;
+
 };
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 #endif
-

--- a/apps/examples/TestEm3/src/G4HepEmProcess.cc
+++ b/apps/examples/TestEm3/src/G4HepEmProcess.cc
@@ -71,8 +71,10 @@ G4HepEmProcess::~G4HepEmProcess() {
 
 
 void G4HepEmProcess::BuildPhysicsTable(const G4ParticleDefinition& partDef) {
-  G4cout << " G4HepEmProcess::BuildPhysicsTable for Particle = " << partDef.GetParticleName() << G4endl;
-  StreamInfo(G4cout, partDef);
+  if (G4Threading::IsMasterThread() && verboseLevel > 1) {
+    G4cout << " G4HepEmProcess::BuildPhysicsTable for Particle = " << partDef.GetParticleName() << G4endl;
+    StreamInfo(G4cout, partDef);
+  }
 
   // The ptr-s to global data structures created and filled in InitializeGlobal()
   // will be copied to the workers and the TL-data structure will be created.

--- a/apps/examples/TestEm3/src/G4HepEmProcess.cc
+++ b/apps/examples/TestEm3/src/G4HepEmProcess.cc
@@ -18,6 +18,7 @@
 
 #include "G4ProcessType.hh"
 #include "G4EmProcessSubType.hh"
+#include "G4HadronicProcessType.hh"
 
 #include "G4Threading.hh"
 #include "G4Track.hh"
@@ -59,6 +60,8 @@ G4HepEmProcess::G4HepEmProcess()
   fGammaNoProcessVector.push_back(new G4HepEmNoProcess("conv",   G4ProcessType::fElectromagnetic, G4EmProcessSubType::fGammaConversion));
   fGammaNoProcessVector.push_back(new G4HepEmNoProcess("compt",  G4ProcessType::fElectromagnetic, G4EmProcessSubType::fComptonScattering));
   fGammaNoProcessVector.push_back(new G4HepEmNoProcess("phot",   G4ProcessType::fElectromagnetic, G4EmProcessSubType::fPhotoElectricEffect));
+  fGammaNoProcessVector.push_back(new G4HepEmNoProcess("photonNuclear", G4ProcessType::fHadronic, G4HadronicProcessType::fHadronInelastic));
+
 }
 
 G4HepEmProcess::~G4HepEmProcess() {
@@ -174,6 +177,7 @@ G4VParticleChange* G4HepEmProcess::PostStepDoIt( const G4Track& track, const G4S
   // invoke the physics interactions (all i.e. all along- and post-step as well as possible at rest)
   double pStepLength = track.GetStepLength();
   if (isGamma) {
+    G4HepEmGammaManager::SelectInteraction(fTheG4HepEmRunManager->GetHepEmData(), theTLData);
     G4HepEmGammaManager::Perform(fTheG4HepEmRunManager->GetHepEmData(), fTheG4HepEmRunManager->GetHepEmParameters(), theTLData);
     //
     // set dummy G4VProcess pointers to provide (name) information regarding processes limited the step
@@ -183,6 +187,8 @@ G4VParticleChange* G4HepEmProcess::PostStepDoIt( const G4Track& track, const G4S
       case 1: theG4PostStepPoint->SetProcessDefinedStep(fGammaNoProcessVector[1]);
               break;
       case 2: theG4PostStepPoint->SetProcessDefinedStep(fGammaNoProcessVector[2]);
+              break;
+      case 3: theG4PostStepPoint->SetProcessDefinedStep(fGammaNoProcessVector[3]);
               break;
     }
   } else {

--- a/apps/examples/TestEm3/src/PhysListHepEm.cc
+++ b/apps/examples/TestEm3/src/PhysListHepEm.cc
@@ -31,6 +31,7 @@ void PhysListHepEm::ConstructProcess() {
 
   // creae the only one G4HepEm process that will be assigned to e-/e+ and gamma
   G4HepEmProcess* hepEmProcess = new G4HepEmProcess();
+  hepEmProcess->SetVerboseLevel(verboseLevel);
 
   // Add standard EM Processes
   //
@@ -58,4 +59,9 @@ void PhysListHepEm::ConstructProcess() {
 
     }
   }
+
+  if (G4Threading::IsMasterThread() && verboseLevel > 0) {
+    G4EmParameters::Instance()->Dump();
+  }
+
 }

--- a/apps/examples/TestEm3/src/PhysListHepEmTracking.cc
+++ b/apps/examples/TestEm3/src/PhysListHepEmTracking.cc
@@ -31,7 +31,7 @@ PhysListHepEmTracking::~PhysListHepEmTracking()
 void PhysListHepEmTracking::ConstructProcess()
 {
   // Register custom tracking manager for e-/e+ and gammas.
-  auto* trackingManager = new G4HepEmTrackingManager;
+  auto* trackingManager = new G4HepEmTrackingManager(verboseLevel);
   // Configuration of G4HepEm
   // Several paramaters can be configured per detector region. These are:
   //  MSC parameters, continuous energy loss step limit function parameters,
@@ -44,4 +44,8 @@ void PhysListHepEmTracking::ConstructProcess()
   G4Electron::Definition()->SetTrackingManager(trackingManager);
   G4Positron::Definition()->SetTrackingManager(trackingManager);
   G4Gamma::Definition()->SetTrackingManager(trackingManager);
+
+  if (G4Threading::IsMasterThread() && verboseLevel > 0) {
+    G4EmParameters::Instance()->Dump();
+  }
 }

--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -50,6 +50,10 @@
 
 #include "G4EmExtraPhysics.hh"
 #include "G4HadronicProcessStore.hh"
+#if G4VERSION_NUMBER >= 1100
+#include "G4HadronicParameters.hh"
+#endif
+
 #include "G4HadronicParameters.hh"
 
 #include "G4LossTableManager.hh"
@@ -96,7 +100,9 @@ PhysicsList::PhysicsList() : G4VModularPhysicsList(),
   G4EmParameters::Instance()->SetVerbose(verboseLevel);
 
   // Hardonic verbose needs to be set before construction
+#if G4VERSION_NUMBER >= 1100
   G4HadronicParameters::Instance()->SetVerboseLevel(verboseLevel);
+#endif
   G4HadronicProcessStore::Instance()->SetVerbose(verboseLevel);
 
   // Create the G4EmExtraPhysics to add gamma and lepton nuclear interactions
@@ -151,9 +157,6 @@ void PhysicsList::ConstructProcess()
 {
   // Transportation
   AddTransportation();
-
-  G4HadronicParameters::Instance()->SetVerboseLevel(verboseLevel);
-  G4HadronicProcessStore::Instance()->SetVerbose(verboseLevel);
 
   // Electromagnetic Physics List
   fEmPhysicsList->SetVerboseLevel(verboseLevel);

--- a/apps/examples/TestEm3/src/PhysicsListMessenger.cc
+++ b/apps/examples/TestEm3/src/PhysicsListMessenger.cc
@@ -37,13 +37,15 @@
 #include "G4UIdirectory.hh"
 #include "G4UIcmdWithADoubleAndUnit.hh"
 #include "G4UIcmdWithAString.hh"
+#include "G4UIcmdWithAnInteger.hh"
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
 PhysicsListMessenger::PhysicsListMessenger(PhysicsList* pPhys)
 :G4UImessenger(),fPhysicsList(pPhys),
  fPhysDir(0),
- fListCmd(0)
+ fListCmd(0),
+ fVerboseCmd(0)
 {
   fPhysDir = new G4UIdirectory("/testem/phys/");
   fPhysDir->SetGuidance("physics list commands");
@@ -52,6 +54,15 @@ PhysicsListMessenger::PhysicsListMessenger(PhysicsList* pPhys)
   fListCmd->SetGuidance("Add modular physics list.");
   fListCmd->SetParameterName("PList",false);
   fListCmd->AvailableForStates(G4State_PreInit);
+
+  fVerboseCmd = new G4UIcmdWithAnInteger("/testem/phys/verbose", this);
+  fVerboseCmd->SetGuidance("Set the Verbose level of the PhysicsList");
+  fVerboseCmd->SetGuidance(" 0 : Silent");
+  fVerboseCmd->SetGuidance(" 1 : Config info (default)");
+  fVerboseCmd->SetGuidance(" 2 : Everything");
+  fVerboseCmd->SetParameterName("level", true);
+  fVerboseCmd->SetDefaultValue(0);
+  fVerboseCmd->SetRange("level >=0 && level <=3");
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
@@ -59,16 +70,18 @@ PhysicsListMessenger::PhysicsListMessenger(PhysicsList* pPhys)
 PhysicsListMessenger::~PhysicsListMessenger()
 {
   delete fListCmd;
+  delete fVerboseCmd;
   delete fPhysDir;
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
-void PhysicsListMessenger::SetNewValue(G4UIcommand* command,
-                                          G4String newValue)
-{
-  if( command == fListCmd )
-   { fPhysicsList->AddPhysicsList(newValue);}
+void PhysicsListMessenger::SetNewValue(G4UIcommand* command, G4String newValue) {
+  if( command == fListCmd ) {
+    fPhysicsList->AddPhysicsList(newValue);
+  } else if( command == fVerboseCmd ) {
+    fPhysicsList->SetVerboseLevel(fVerboseCmd->GetNewIntValue(newValue));
+  }
 }
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......


### PR DESCRIPTION
Most of the modifications are related to the verbosity level of the physics (list) configuration/parameter report and its setting. This can now be controlled by a UI command. An additional, unrelated modification is that the `G4HepEmProcess`, i.e. connecting only the `G4HepEm` physics to `Geant4` through its `G4VProcess` interface, has been recovered and works again as expected (after the recent changes in the gamma cross sections). However, `G4HepEm` should be connected to `Geant4` and used only through its `G4HepEmTrackingManager` as this is the only complete and efficient way of its utilisation (the process interface was used only during the physics development).