### PR TITLE
Link against `Geant4::G4physicslists`

### DIFF
--- a/G4HepEm/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/G4HepEm/CMakeLists.txt
@@ -28,6 +28,7 @@ if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
 
   set(G4HEPEM_Geant4_LIBRARIES ${G4HEPEM_Geant4_LIBRARIES}
     Geant4::G4event
+    Geant4::G4physicslists
     Geant4::G4tracking
   )
 endif()


### PR DESCRIPTION
`G4HepEmTrackingManager.cc` now includes `G4GammaGeneralProcess.hh`, which is part of the `G4physicslists` library. This fixes the compilation with a build directory of Geant4 (non-installed).