### PR TITLE
Check for G4VTrackingManager support via compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,19 @@ if(G4HepEm_GEANT4_BUILD)
   endif()
 
   set(CMAKE_CXX_STANDARD ${Geant4_CXX_STANDARD}) # use value from Geant4Config.cmake
+
+  # Check if Geant4 is supports G4VTrackingManager
+  # Always available from v11.0, but experiments may backport it to earlier versions
+  # so we do a compile check.
+  include(CheckCXXSourceCompiles)
+  set(CMAKE_REQUIRED_LIBRARIES ${Geant4_LIBRARIES})
+  check_cxx_source_compiles("
+    #include \"G4VTrackingManager.hh\"
+    class testtm_ : public G4VTrackingManager {
+    public:
+      void HandOverOneTrack(G4Track*) {}
+    };
+    int main() { testtm_ model; return 0; }" G4HepEm_HAS_G4VTRACKINGMANAGER)
 else()
   # Need workaround for G4VERSION_NUM G4HepEmRun...
   # ... done in that component for now.

--- a/G4HepEm/G4HepEm/CMakeLists.txt
+++ b/G4HepEm/G4HepEm/CMakeLists.txt
@@ -14,7 +14,7 @@ set(G4HEPEM_Geant4_LIBRARIES
   Geant4::G4track
 )
 
-if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
+if(G4HepEm_HAS_G4VTRACKINGMANAGER)
   set(G4HEPEM_headers ${G4HEPEM_headers}
     include/G4EmTrackingManager.hh
     include/G4HepEmConfig.hh

--- a/apps/examples/TestEm3/CMakeLists.txt
+++ b/apps/examples/TestEm3/CMakeLists.txt
@@ -44,7 +44,7 @@ set(sources
   src/SteppingVerbose.cc
   src/TrackingAction.cc
 )
-if(Geant4_VERSION VERSION_GREATER_EQUAL 11.0)
+if(G4HepEm_HAS_G4VTRACKINGMANAGER)
   set(sources ${sources}
     src/PhysListG4EmTracking.cc
     src/PhysListHepEmTracking.cc
@@ -55,4 +55,5 @@ endif()
 # Add the executable, and link it to the Geant4 libraries
 #
 add_executable(TestEm3 ${PROJECT_SOURCE_DIR}/TestEm3.cc ${sources})
+target_compile_definitions(TestEm3 PRIVATE $<$<BOOL:${G4HepEm_HAS_G4VTRACKINGMANAGER}>:G4HepEm_HAS_G4VTRACKINGMANAGER>)
 target_link_libraries(TestEm3 ${Geant4_LIBRARIES} ${G4HepEm_LIBRARIES})

--- a/apps/examples/TestEm3/src/PhysicsList.cc
+++ b/apps/examples/TestEm3/src/PhysicsList.cc
@@ -86,8 +86,8 @@ PhysicsList::PhysicsList() : G4VModularPhysicsList(),
   fMessenger = new PhysicsListMessenger(this);
   verboseLevel = 0;
 
-#if G4VERSION_NUMBER >= 1100
-  // make the `G4HepEmTrackingManager` the default whenever it's available (g4>=11.0)
+#if G4HepEm_HAS_G4VTRACKINGMANAGER
+  // make the `G4HepEmTrackingManager` the default whenever it's available
   fEmName = G4String("HepEmTracking");
   fEmPhysicsList = new PhysListHepEmTracking(fEmName);
 #else

--- a/cmake/G4HepEmConfig.cmake.in
+++ b/cmake/G4HepEmConfig.cmake.in
@@ -7,6 +7,10 @@
 # - Project properties
 set_and_check(G4HepEm_INCLUDE_DIR "@PACKAGE_G4HEPEM_EXPORTED_INCLUDE_DIR@")
 
+# Record whether we support G4VTrackingManager.
+# Note that this implies the re-found Geant4 below is the exact same as we
+# were built with, especially if G4VTrackingManager has been backported to < 11.0
+set(G4HepEm_trackingmanager_FOUND @G4HepEm_HAS_G4VTRACKINGMANAGER@)
 
 # - Project dependencies
 include(CMakeFindDependencyMacro)


### PR DESCRIPTION
G4HepEm currently uses the Geant4 version to determine availability of the `G4VTrackingManager` interface/capability. This is always available from Geant4 v11.0 onwards, but experiments may backport the capability to earlier versions (here, request from LHCb).

Use a CMake-time compile check to determine if `G4VTrackingManager` is available in the found Geant4 irrespective of its version. Output result to CMake variable and use this to determine whether to add G4HepEm tracking manager support. Add a "FOUND" variable to installed CMake config file to indicate if G4HepEm provides tracking manager capability.

Tested locally with raw 10.7 and 11.3 installs which result in same behaviour as before. Would need more testing with LHCb's patched Geant4 to confirm it works in that case.