### PR TITLE
enable rebinding to the current G4 engine

### DIFF
--- a/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
+++ b/G4HepEm/G4HepEm/include/G4HepEmTrackingManager.hh
@@ -38,6 +38,10 @@ public:
   // Control verbosity (0/1) (propagated to the G4HepEmRuManager)
   void SetVerbose(G4int verbose);
 
+  // Rebinds the random engine to the currently used engine by the thread
+  // Needed if the random engine was swapped after construction of the HepEm TM
+  void RebindG4RandomEngine();
+
   // Returns the vector of e-/e+ G4HepEmNoProcess pointers used only to set a
   // creator and step limiter G4VProcess of the G4Step with an appropriate
   // name and EM process type.

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -150,6 +150,13 @@ void G4HepEmTrackingManager::SetVerbose(G4int verbose) {
 
 //....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
 
+void G4HepEmTrackingManager::RebindG4RandomEngine() {
+  fRandomEngine->SetObject(G4Random::getTheEngine());
+  fRandomEngine->DiscardGauss();
+}
+
+//....oooOO0OOooo........oooOO0OOooo........oooOO0OOooo........oooOO0OOooo......
+
 void G4HepEmTrackingManager::BuildPhysicsTable(const G4ParticleDefinition &part) {
   if (&part == G4Electron::Definition()) {
     int particleID = 0;

--- a/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
+++ b/G4HepEm/G4HepEmRun/include/G4HepEmRandomEngine.hh
@@ -33,6 +33,9 @@ public:
   G4HepEmRandomEngine(void *object)
     : fObject(object), fIsGauss(false), fGauss(0.) { }
 
+  G4HepEmHostDevice
+  void SetObject(void* p) { fObject = p; }
+
   /** Return a random number uniformly distributed between 0 and 1.
    */
   G4HepEmHostDevice


### PR DESCRIPTION
In Gaussino, the rng engine is [reset for every single event](https://gitlab.cern.ch/Gaussino/Gaussino/-/blob/master/Sim/GiGaMTCore/src/Lib/GiGaWorkerPilot.cpp#L171-L173).

This lead to reproducibility issues with G4HepEm, as the thread order of initializing (when the G4HepEm `fRandomEngine` is set in the constructor) is not the same when the events are run. This led to different events seeing a different rng between runs. To fix the issue, this PR proposes to add a function in the `G4HepEmTrackingManager` that re-binds the `fRandomEngine` to the current G4 random engine. As Gaussino requires a custom derived `G4HepEmTrackingManager` due to custom cuts anyway, I can add a derived `HandOverOneTrack` call, which also calls the `RebindG4RandomEngine()` as soon as the event id between tracks changes.

@mnovak42 @hahnjo This is just a suggestion how to fix this issue, if you see a better solution or a different implementation, feel free to close the PR or adjust it.