### PR TITLE
Rebind `G4Random` engine for every track

### DIFF
--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -326,10 +326,12 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
   G4HepEmElectronTrack* theElTrack = theTLData->GetPrimaryElectronTrack();
   G4HepEmTrack *thePrimaryTrack = theElTrack->GetTrack();
   theElTrack->ReSet();
-  // In principle, we could continue to use the other generated Gaussian
-  // number as long as we are in the same event, but play it safe.
+  // In principle, it would be enough to support switching random engines
+  // between events, but we have no means to reliably detect this in the
+  // tracking manager. This call also always discards the other generated
+  // Gaussian number to play it safe.
+  RebindG4RandomEngine();
   G4HepEmRandomEngine *rnge = theTLData->GetRNGEngine();
-  rnge->DiscardGauss();
 
   // Pull data structures into local variables.
   G4HepEmData *theHepEmData = fRunManager->GetHepEmData();
@@ -876,10 +878,11 @@ bool G4HepEmTrackingManager::TrackGamma(G4Track *aTrack) {
   G4HepEmGammaTrack* theGammaTrack = theTLData->GetPrimaryGammaTrack();
   G4HepEmTrack* thePrimaryTrack = theGammaTrack->GetTrack();
   theGammaTrack->ReSet();
-  // In principle, we could continue to use the other generated Gaussian
-  // number as long as we are in the same event, but play it safe.
-  G4HepEmRandomEngine *rnge = theTLData->GetRNGEngine();
-  rnge->DiscardGauss();
+  // In principle, it would be enough to support switching random engines
+  // between events, but we have no means to reliably detect this in the
+  // tracking manager. This call also always discards the other generated
+  // Gaussian number to play it safe.
+  RebindG4RandomEngine();
 
   // Pull data structures into local variables.
   G4HepEmData *theHepEmData = fRunManager->GetHepEmData();

--- a/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
+++ b/G4HepEm/G4HepEm/src/G4HepEmTrackingManager.cc
@@ -331,7 +331,6 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
   // tracking manager. This call also always discards the other generated
   // Gaussian number to play it safe.
   RebindG4RandomEngine();
-  G4HepEmRandomEngine *rnge = theTLData->GetRNGEngine();
 
   // Pull data structures into local variables.
   G4HepEmData *theHepEmData = fRunManager->GetHepEmData();
@@ -438,7 +437,7 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
     // Sample the `number-of-interaction-left`
     for (int ip=0; ip<4; ++ip) {
       if (thePrimaryTrack->GetNumIALeft(ip)<=0.) {
-        thePrimaryTrack->SetNumIALeft(-G4HepEmLog(rnge->flat()), ip);
+        thePrimaryTrack->SetNumIALeft(-G4HepEmLog(fRandomEngine->flat()), ip);
       }
     }
     // True distance to discrete interaction.
@@ -455,7 +454,8 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
 
     do {
       // Possibly true step limit of MSC, and conversion to geometrical step length.
-      G4HepEmElectronManager::HowFarToMSC(theHepEmData, theHepEmPars, theElTrack, rnge);
+      G4HepEmElectronManager::HowFarToMSC(theHepEmData, theHepEmPars,
+                                          theElTrack, fRandomEngine);
       if (thePrimaryTrack->GetWinnerProcessIndex() != -2) {
         // If MSC did not limit the step, exit the loop after this iteration.
         continueStepping = false;
@@ -527,7 +527,8 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
           }
 
           // === 4. Sample MSC direction change and displacement.
-          G4HepEmElectronManager::SampleMSC(theHepEmData, theHepEmPars, theElTrack, rnge);
+          G4HepEmElectronManager::SampleMSC(theHepEmData, theHepEmPars,
+                                            theElTrack, fRandomEngine);
 
           const double *pdir = thePrimaryTrack->GetDirection();
           postStepPoint.SetMomentumDirection(
@@ -612,7 +613,8 @@ bool G4HepEmTrackingManager::TrackElectron(G4Track *aTrack) {
       // If not already stopped, restore the pre-step energy and sample loss
       // fluctuations.
       theElTrack->SetPreStepEKin(preStepEkin, preStepLogEkin);
-      stopped = G4HepEmElectronManager::SampleLossFluctuations(theHepEmData, theHepEmPars, theElTrack, rnge);
+      stopped = G4HepEmElectronManager::SampleLossFluctuations(
+          theHepEmData, theHepEmPars, theElTrack, fRandomEngine);
     }
 
     // ATLAS XTR RELATED:


### PR DESCRIPTION
This is the most generic solution to the problem that experiment frameworks call `G4Random::setTheEngine` to use a specific engine for an event. In principle, it would be it would be enough to support switching random engines between events, but the tracking manager has no means to reliably detect this. Since rebinding a pointer is a cheap operation (no performance impact measurable with this change in TestEm3), just always do it per track.

FYI @SeverinDiederichs 